### PR TITLE
Minor edit to `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ import ast
 from pathlib import Path
 from packaging.version import parse, Version
 import platform
+import shutil
 
 from setuptools import setup, find_packages
 import subprocess
@@ -223,7 +224,7 @@ class CachedWheelsCommand(_bdist_wheel):
 
             wheel_path = os.path.join(self.dist_dir, archive_basename + ".whl")
             print("Raw wheel path", wheel_path)
-            os.rename(wheel_filename, wheel_path)
+            shutil.move(wheel_filename, wheel_path)
         except urllib.error.HTTPError:
             print("Precompiled wheel not found. Building from source...")
             # If the wheel could not be downloaded, build from source


### PR DESCRIPTION
**Issue:** Using `pip install .` was failing with the following error:
```
Building wheels for collected packages: mamba-ssm                                                                                                                                                                                                                               
  Building wheel for mamba-ssm (setup.py) ... error                                                                                                                                                                                                                             
  error: subprocess-exited-with-error                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                
  × python setup.py bdist_wheel did not run successfully.                                                                                                                                                                                                                       
  │ exit code: 1                                                                                                                                                                                                                                                                
  ╰─> [9 lines of output]                                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                                                
                                                                                                                                                                                                                                                                                
      torch.__version__  = 2.1.1                                                                                                                                                                                                                                                
      
      
      running bdist_wheel
      Guessing wheel URL:  https://github.com/state-spaces/mamba/releases/download/v1.0.1/mamba_ssm-1.0.1+cu118torch2.1cxx11abiFALSE-cp310-cp310-linux_x86_64.whl
      Raw wheel path /tmp/pip-wheel-ksro0zqu/mamba_ssm-1.0.1-cp310-cp310-linux_x86_64.whl
      error: [Errno 18] Invalid cross-device link: 'mamba_ssm-1.0.1+cu118torch2.1cxx11abiFALSE-cp310-cp310-linux_x86_64.whl' -> '/tmp/pip-wheel-ksro0zqu/mamba_ssm-1.0.1-cp310-cp310-linux_x86_64.whl'
      [end of output]
   
  note: This error originates from a subprocess, and is likely not a problem with pip.
  ERROR: Failed building wheel for mamba-ssm
  Running setup.py clean for mamba-ssm
Failed to build mamba-ssm
ERROR: Could not build wheels for mamba-ssm, which is required to install pyproject.toml-based projects
```

As per this [thread](https://stackoverflow.com/a/43967659), the issue was potentially caused by the source and destination files passed to `os.rename` not being on the same filesystem (I was installing on a shared cluster and so the repo and the tmp might be different nfs). 

**Fix:** Changing `os.rename` to `shutil.move` fixed this issue.