### PR TITLE
Fix: remove is_rms_norm parameter in forward method of RMSNorm class

### DIFF
--- a/mamba_ssm/ops/triton/layernorm.py
+++ b/mamba_ssm/ops/triton/layernorm.py
@@ -499,7 +499,6 @@ class RMSNorm(torch.nn.Module):
             eps=self.eps,
             prenorm=prenorm,
             residual_in_fp32=residual_in_fp32,
-            is_rms_norm=True,
         )
 
 


### PR DESCRIPTION
This fixes https://github.com/state-spaces/mamba/issues/44.
Please refer to the issue to get more information about the bug.