### PR TITLE
Error due to missing to_json_string method in MambaConfig class

### DIFF
--- a/mamba_ssm/models/config_mamba.py
+++ b/mamba_ssm/models/config_mamba.py
@@ -1,8 +1,9 @@
 from dataclasses import dataclass, field
+from transformers import PretrainedConfig
 
 
 @dataclass
-class MambaConfig:
+class MambaConfig(PretrainedConfig):
 
     d_model: int = 2560
     n_layer: int = 64


### PR DESCRIPTION
**Reproduce:**
Clone `https://github.com/havenhq/mamba-chat` and run training example in README with current version of `mamba_ssm`.

**Solution:**
Derive MambdaConfig from PretrainedConfig base class