### PR TITLE
include to_json_string

### DIFF
--- a/mamba_ssm/models/config_mamba.py
+++ b/mamba_ssm/models/config_mamba.py
@@ -1,5 +1,5 @@
-from dataclasses import dataclass, field
-
+from dataclasses import dataclass, field, asdict
+import json
 
 @dataclass
 class MambaConfig:
@@ -12,3 +12,7 @@ class MambaConfig:
     residual_in_fp32: bool = True
     fused_add_norm: bool = True
     pad_vocab_size_multiple: int = 8
+
+    def to_json_string(self):
+        """Serializes this instance to a JSON string."""
+        return json.dumps(asdict(self), indent=2)


### PR DESCRIPTION
To fix :
```
    trainer.train()
  File "/home/julio/anaconda3/envs/mamba/lib/python3.10/site-packages/transformers/trainer.py", line 1555, in train
    return inner_training_loop(
  File "/home/julio/anaconda3/envs/mamba/lib/python3.10/site-packages/transformers/trainer.py", line 1789, in _inner_training_loop
    self.control = self.callback_handler.on_train_begin(args, self.state, self.control)
  File "/home/julio/anaconda3/envs/mamba/lib/python3.10/site-packages/transformers/trainer_callback.py", line 363, in on_train_begin
    return self.call_event("on_train_begin", args, state, control)
  File "/home/julio/anaconda3/envs/mamba/lib/python3.10/site-packages/transformers/trainer_callback.py", line 407, in call_event
    result = getattr(callback, event)(
  File "/home/julio/anaconda3/envs/mamba/lib/python3.10/site-packages/transformers/integrations/integration_utils.py", line 631, in on_train_begin
    model_config_json = model.config.to_json_string()
AttributeError: 'MambaConfig' object has no attribute 'to_json_string'

```
when training with hugging face and saving the model. 