### PR TITLE
Add inputs_embeds as alternative for input_ids

### DIFF
--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -148,8 +148,10 @@ class MixerModel(nn.Module):
             for i, layer in enumerate(self.layers)
         }
 
-    def forward(self, input_ids, inference_params=None):
-        hidden_states = self.embedding(input_ids)
+    def forward(self, input_ids, inference_params=None, inputs_embeds=None):
+        if input_ids is not None and inputs_embeds is not None:
+            raise ValueError("You cannot specify both input_ids and inputs_embeds at the same time")
+        hidden_states = self.embedding(input_ids) if inputs_embeds is None else inputs_embeds
         residual = None
         for layer in self.layers:
             hidden_states, residual = layer(
@@ -225,12 +227,12 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
     def allocate_inference_cache(self, batch_size, max_seqlen, dtype=None, **kwargs):
         return self.backbone.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype, **kwargs)
 
-    def forward(self, input_ids, position_ids=None, inference_params=None, num_last_tokens=0):
+    def forward(self, input_ids, position_ids=None, inference_params=None, num_last_tokens=0, inputs_embeds=None):
         """
         "position_ids" is just to be compatible with Transformer generation. We don't use it.
         num_last_tokens: if > 0, only return the logits for the last n tokens
         """
-        hidden_states = self.backbone(input_ids, inference_params=inference_params)
+        hidden_states = self.backbone(input_ids, inference_params=inference_params, inputs_embeds=inputs_embeds)
         if num_last_tokens > 0:
             hidden_states = hidden_states[:, -num_last_tokens:]
         lm_logits = self.lm_head(hidden_states)


### PR DESCRIPTION
Adding to the model inputs_embeds (same name as HF models use) to token embedding directly rather than token ids

Main use case is training soft prompts without adding N tokens to tokenizer that never get outputted(and then jumping through hoops to train them only without touching existing tokens)