### PR TITLE
Fix directory creating for saving with multiprocessing

### DIFF
--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -251,8 +251,7 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         Save the model and its configuration file to a directory.
         """
         # Ensure save_directory exists
-        if not os.path.exists(save_directory):
-            os.makedirs(save_directory)
+        os.makedirs(save_directory, exist_ok=True)
 
         # Save the model's state_dict
         model_path = os.path.join(save_directory, 'pytorch_model.bin')


### PR DESCRIPTION
The save_pretrained() method can and often will fail when training with multi-processes because the save directory can be created by another process after the check of its existence which will result in an exception from os.makedirs().