### PR TITLE
Don't hardcode tied embed+unembed

### DIFF
--- a/mamba_ssm/models/config_mamba.py
+++ b/mamba_ssm/models/config_mamba.py
@@ -12,3 +12,4 @@ class MambaConfig:
     residual_in_fp32: bool = True
     fused_add_norm: bool = True
     pad_vocab_size_multiple: int = 8
+    tie_embeddings: bool = True

--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -220,8 +220,9 @@ class MambaLMHeadModel(nn.Module, GenerationMixin):
         self.tie_weights()
 
     def tie_weights(self):
-        self.lm_head.weight = self.backbone.embedding.weight
-
+        if self.config.tie_embeddings:
+            self.lm_head.weight = self.backbone.embedding.weight
+    
     def allocate_inference_cache(self, batch_size, max_seqlen, dtype=None, **kwargs):
         return self.backbone.allocate_inference_cache(batch_size, max_seqlen, dtype=dtype, **kwargs)
 


### PR DESCRIPTION
I encountered problems when trying to use a Mamba model trained with untied embed + unembed weights in this codebase because `MambaLMHeadModel.tie_weights()` is always called.

This PR adds a `tie_embeddings` field to the config which defaults to true, and only ties the input + output embeddings if the config value is true.