### PR TITLE
Add support for Nvidia Jetson hw

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -104,11 +104,19 @@ if not SKIP_CUDA_BUILD:
                 f"{PACKAGE_NAME} is only supported on CUDA 11.6 and above.  "
                 "Note: make sure nvcc has a supported version by running nvcc -V."
             )
-
+            
+    cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_53,code=sm_53")
+    cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_62,code=sm_62")
     cc_flag.append("-gencode")
     cc_flag.append("arch=compute_70,code=sm_70")
     cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_72,code=sm_72")
+    cc_flag.append("-gencode")
     cc_flag.append("arch=compute_80,code=sm_80")
+    cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_87,code=sm_87")
     if bare_metal_version >= Version("11.8"):
         cc_flag.append("-gencode")
         cc_flag.append("arch=compute_90,code=sm_90")


### PR DESCRIPTION
Added support for Nvidia Jetson hardware, GPUs supported:
- [Jetson AGX Orin](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/), [Jetson Orin NX](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/), [Jetson Orin Nano](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-orin/) 	8.7
- [Jetson AGX Xavier](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-agx-xavier/), [Jetson Xavier NX](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-xavier-nx/) 	7.2
- [Jetson TX2](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-tx2/) 	6.2
- [Jetson Nano](https://www.nvidia.com/en-us/autonomous-machines/embedded-systems/jetson-nano/) 	5.3

reference - https://developer.nvidia.com/cuda-gpus