### PR TITLE
Square plus instead of Softplus

### DIFF
--- a/csrc/selective_scan/selective_scan.cpp
+++ b/csrc/selective_scan/selective_scan.cpp
@@ -79,7 +79,7 @@ void set_ssm_params_fwd(SSMParamsBase &params,
                         void* delta_bias_ptr,
                         void* x_ptr,
                         bool has_z,
-                        bool delta_softplus
+                        bool delta_softplus,
                         bool delta_squareplus) {
 
     // Reset the parameters
@@ -232,7 +232,7 @@ selective_scan_fwd(const at::Tensor &u, const at::Tensor &delta,
                   const c10::optional<at::Tensor> &D_,
                   const c10::optional<at::Tensor> &z_,
                   const c10::optional<at::Tensor> &delta_bias_,
-                  bool delta_softplus
+                  bool delta_softplus,
                   bool delta_squareplus) {
     auto input_type = u.scalar_type();
     auto weight_type = A.scalar_type();

--- a/csrc/selective_scan/selective_scan.cpp
+++ b/csrc/selective_scan/selective_scan.cpp
@@ -79,7 +79,8 @@ void set_ssm_params_fwd(SSMParamsBase &params,
                         void* delta_bias_ptr,
                         void* x_ptr,
                         bool has_z,
-                        bool delta_softplus) {
+                        bool delta_softplus
+                        bool delta_squareplus) {
 
     // Reset the parameters
     memset(&params, 0, sizeof(params));
@@ -93,6 +94,7 @@ void set_ssm_params_fwd(SSMParamsBase &params,
     params.dim_ngroups_ratio = dim / n_groups;
 
     params.delta_softplus = delta_softplus;
+    params.delta_squareplus = delta_squareplus;
 
     params.is_variable_B = is_variable_B;
     params.is_variable_C = is_variable_C;
@@ -173,6 +175,7 @@ void set_ssm_params_bwd(SSMParamsBwd &params,
                         void* ddelta_bias_ptr,
                         bool has_z,
                         bool delta_softplus,
+                        bool delta_squareplus,
                         bool recompute_out_z) {
     // Pass in "dout" instead of "out", we're not gonna use "out" unless we have z
     set_ssm_params_fwd(params, batch, dim, seqlen, dstate, n_groups, n_chunks, is_variable_B, is_variable_C,
@@ -181,7 +184,7 @@ void set_ssm_params_bwd(SSMParamsBwd &params,
                        // If not recompute_out_z, pass dout instead of out_z.
                        // This won't be used by the bwd kernel
                        recompute_out_z ? out_z : dout,
-                       D_ptr, delta_bias_ptr, x_ptr, has_z, delta_softplus);
+                       D_ptr, delta_bias_ptr, x_ptr, has_z, delta_softplus, delta_squareplus);
     if (!recompute_out_z) { params.out_z_ptr = nullptr; }
 
     // Set the pointers and strides.
@@ -229,7 +232,8 @@ selective_scan_fwd(const at::Tensor &u, const at::Tensor &delta,
                   const c10::optional<at::Tensor> &D_,
                   const c10::optional<at::Tensor> &z_,
                   const c10::optional<at::Tensor> &delta_bias_,
-                  bool delta_softplus) {
+                  bool delta_softplus
+                  bool delta_squareplus) {
     auto input_type = u.scalar_type();
     auto weight_type = A.scalar_type();
     TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
@@ -319,7 +323,8 @@ selective_scan_fwd(const at::Tensor &u, const at::Tensor &delta,
                        delta_bias_.has_value() ? delta_bias_.value().data_ptr() : nullptr,
                        x.data_ptr(),
                        has_z,
-                       delta_softplus);
+                       delta_softplus,
+                       delta_squareplus);
 
     // Otherwise the kernel will be launched from cuda:0 device
     // Cast to char to avoid compiler warning about narrowing
@@ -346,6 +351,7 @@ selective_scan_bwd(const at::Tensor &u, const at::Tensor &delta,
                   const c10::optional<at::Tensor> &out_,
                   c10::optional<at::Tensor> &dz_,
                   bool delta_softplus,
+                  bool delta_squareplus,
                   bool recompute_out_z) {
     auto input_type = u.scalar_type();
     auto weight_type = A.scalar_type();
@@ -474,7 +480,7 @@ selective_scan_bwd(const at::Tensor &u, const at::Tensor &delta,
                        dout, du, ddelta, dA, dB, dC, dz,
                        D_.has_value() ? dD.data_ptr() : nullptr,
                        delta_bias_.has_value() ? ddelta_bias.data_ptr() : nullptr,
-                       has_z, delta_softplus, recompute_out_z);
+                       has_z, delta_softplus, delta_squareplus, recompute_out_z);
 
     // Otherwise the kernel will be launched from cuda:0 device
     // Cast to char to avoid compiler warning about narrowing

--- a/csrc/selective_scan/selective_scan.h
+++ b/csrc/selective_scan/selective_scan.h
@@ -32,6 +32,7 @@ struct SSMParamsBase {
     bool is_variable_C;
 
     bool delta_softplus;
+    bool delta_squareplus;
 
     index_t A_d_stride;
     index_t A_dstate_stride;

--- a/csrc/selective_scan/selective_scan_bwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_bwd_kernel.cuh
@@ -168,7 +168,7 @@ void selective_scan_bwd_kernel(SSMParamsBwd params) {
             if constexpr (kDeltaSoftplus) {
                 delta_vals[i] = delta_vals[i] <= 20.f ? log1pf(expf(delta_vals[i])) : delta_vals[i];
             } else if constexper (kDeltaSquareplus) {
-                delta_vals[i] = (delta_vals[r][i] + sqrtf(delta_vals[r][i] * delta_vals[r][i] + 4.0)) / 2.0;
+                delta_vals[i] = (delta_vals[i] + sqrtf(delta_vals[i] * delta_vals[i] + 4.0)) / 2.0;
             }
         }
 

--- a/csrc/selective_scan/selective_scan_fwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_fwd_kernel.cuh
@@ -153,7 +153,11 @@ void selective_scan_fwd_kernel(SSMParamsBase params) {
                 delta_vals[r][i] = float(delta_vals_load[r][i]) + delta_bias[r];
                 if (params.delta_softplus) {
                     delta_vals[r][i] = delta_vals[r][i] <= 20.f ? log1pf(expf(delta_vals[r][i])) : delta_vals[r][i];
+                } else if (params.delta_squareplus]) {
+                    // (x + torch.sqrt(torch.square(x) + b))/2
+                    delta_vals[r][i] = (delta_vals[r][i] + sqrtf(delta_vals[r][i] * delta_vals[r][i] + 4.0)) / 2.0;
                 }
+                
                 delta_u_vals[r][i] = delta_vals[r][i] * u_val;
                 out_vals[r][i] = D_val[r] * u_val;
             }

--- a/csrc/selective_scan/selective_scan_fwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_fwd_kernel.cuh
@@ -153,7 +153,7 @@ void selective_scan_fwd_kernel(SSMParamsBase params) {
                 delta_vals[r][i] = float(delta_vals_load[r][i]) + delta_bias[r];
                 if (params.delta_softplus) {
                     delta_vals[r][i] = delta_vals[r][i] <= 20.f ? log1pf(expf(delta_vals[r][i])) : delta_vals[r][i];
-                } else if (params.delta_squareplus]) {
+                } else if (params.delta_squareplus) {
                     // (x + torch.sqrt(torch.square(x) + b))/2
                     delta_vals[r][i] = (delta_vals[r][i] + sqrtf(delta_vals[r][i] * delta_vals[r][i] + 4.0)) / 2.0;
                 }

--- a/mamba_ssm/ops/selective_scan_interface.py
+++ b/mamba_ssm/ops/selective_scan_interface.py
@@ -94,6 +94,7 @@ class SelectiveScanFn(torch.autograd.Function):
                 dz,
                 ddelta_bias if delta_bias is not None else None,
                 None,
+                None,
                 None)
 
 
@@ -326,7 +327,7 @@ class MambaInnerFn(torch.autograd.Function):
                 dout_proj_weight, dout_proj_bias,
                 dA, dB, dC, dD,
                 ddelta_bias if delta_bias is not None else None,
-                dB_proj_bias, dC_proj_bias, None)
+                dB_proj_bias, dC_proj_bias, None, None)
 
 
 def mamba_inner_fn(

--- a/tests/ops/test_selective_scan.py
+++ b/tests/ops/test_selective_scan.py
@@ -24,7 +24,7 @@ from mamba_ssm.ops.selective_scan_interface import mamba_inner_fn, mamba_inner_r
 # @pytest.mark.parametrize('has_delta_bias', [False, True])
 @pytest.mark.parametrize('has_delta_bias', [True])
 # @pytest.mark.parametrize('delta_softplus', [False, True])
-@pytest.mark.parametrize('delta_softplus', [True])
+@pytest.mark.parametrize('delta_softplus', [True, False])
 # @pytest.mark.parametrize('has_z', [False, True])
 @pytest.mark.parametrize('has_z', [True])
 # @pytest.mark.parametrize('has_D', [False, True])
@@ -94,14 +94,14 @@ def test_selective_scan(is_variable_B, is_variable_C, varBC_groups, has_D, has_z
     delta_bias_ref = delta_bias.detach().clone().requires_grad_() if delta_bias is not None else None
     out, *rest = selective_scan_fn(
         u, delta, A, B, C, D, z=z,
-        delta_bias=delta_bias, delta_softplus=delta_softplus,
+        delta_bias=delta_bias, delta_softplus=delta_softplus, delta_squareplus=not delta_softplus,
         return_last_state=return_last_state
     )
     if return_last_state:
         state = rest[0]
     out_ref, *rest = selective_scan_ref(
         u_ref, delta_ref, A_ref, B_ref, C_ref, D_ref, z=z_ref,
-        delta_bias=delta_bias_ref, delta_softplus=delta_softplus,
+        delta_bias=delta_bias_ref, delta_softplus=delta_softplus, delta_squareplus=not delta_softplus,
         return_last_state=return_last_state
     )
     if return_last_state:
@@ -206,11 +206,11 @@ def test_mamba_inner_fn(is_variable_B, is_variable_C, seqlen, itype, wtype):
     delta_bias_ref = delta_bias.detach().clone().requires_grad_() if delta_bias is not None else None
     out = mamba_inner_fn(xz, conv1d_weight, conv1d_bias, x_proj_weight, delta_proj_weight,
                          out_proj_weight, out_proj_bias,
-                         A, B, C, D, delta_bias=delta_bias, delta_softplus=True)
+                         A, B, C, D, delta_bias=delta_bias, delta_squareplus=True)
     out_ref = mamba_inner_ref(xz_ref, conv1d_weight_ref, conv1d_bias_ref, x_proj_weight_ref,
                               delta_proj_weight_ref, out_proj_weight_ref, out_proj_bias_ref,
                               A_ref, B_ref, C_ref, D_ref,
-                              delta_bias=delta_bias_ref, delta_softplus=True)
+                              delta_bias=delta_bias_ref, delta_squareplus=True)
     # dA = torch.exp(torch.einsum('bdl,dn->bdln', delta, A))
     # dt_u = delta * u
 


### PR DESCRIPTION
Add a flag to the mamba kernels to use squareplus instead of softplus to avoid log/exps

- [ ] tests failing