### PR TITLE
make selective ssm and ssd triton kernels compatible with the latest triton

### DIFF
--- a/mamba_ssm/ops/triton/softplus.py
+++ b/mamba_ssm/ops/triton/softplus.py
@@ -1,0 +1,17 @@
+import triton
+import triton.language as tl
+from packaging import version
+
+TRITON3 = version.parse(triton.__version__) >= version.parse("3.0.0")
+
+
+if TRITON3:
+    @triton.jit
+    def softplus(dt):
+        dt = tl.where(dt <= 20.0, tl.math.log(tl.math.exp(dt) + 1), dt)
+        return dt
+else:
+    @triton.jit
+    def softplus(dt):
+        dt = tl.where(dt <= 20.0, tl.math.log1p(tl.exp(dt)), dt)
+        return dt


### PR DESCRIPTION
This PR made mamba's triton kernels compatible to triton version >= 3.0.0.
Specifically, tl.math.log1p() was deprecated so it's replaced by "tl.math.log(tl.math.exp(dt) + 1)".