### PR TITLE
Fix typo in min_p sampling

### DIFF
--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -105,7 +105,7 @@ def sample(logits, top_k=1, top_p=0.0, min_p=0.0, temperature=1.0):
                 logits_top = logits.clone()
                 max_prob = logits_top[..., 0].item()
                 min_prob = max_prob * min_p
-                modify_logits_for_min_p_filtering(logits_top, min_p)
+                modify_logits_for_min_p_filtering(logits_top, min_prob)
                 if temperature != 1.0:
                     logits_top /= temperature
                 return torch.multinomial(torch.softmax(logits_top, dim=-1), num_samples=1).squeeze(dim=-1)


### PR DESCRIPTION
Hey guys, quite a while ago I made a PR for min_p sampling support in Mamba,
and it was merged. 

Unfortunately, there was a small mistake in the code, which
I've discovered only later and forgot to create a PR with the fix. Sorry about that, my bad. 

News of Mamba2 release reminded me about the issue, so here is the fix. 