### PR TITLE
ROCm warp size fix [AMD official]

### DIFF
--- a/csrc/selective_scan/selective_scan_bwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_bwd_kernel.cuh
@@ -538,11 +538,10 @@ void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
     #ifndef USE_ROCM
         constexpr int warp_size = 32;
     #else
-        constexpr int warp_size = rocprim::warp_size();
+        constexpr int warp_size = ROCM_WARP_SIZE;
     #endif
 
-    #if warp_size == 32
-
+    #if warp_size == 32 
         if (params.seqlen <= 128) {
             selective_scan_bwd_launch<32, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 256) {
@@ -554,9 +553,8 @@ void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
         } else {
             selective_scan_bwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-
+    }
     #else 
-
         if (params.seqlen <= 256) {
             selective_scan_bwd_launch<64, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 512) {
@@ -566,6 +564,5 @@ void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
         } else {
             selective_scan_bwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-
     #endif
 }

--- a/csrc/selective_scan/selective_scan_bwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_bwd_kernel.cuh
@@ -536,9 +536,9 @@ template<typename input_t, typename weight_t>
 void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
 
     #ifndef USE_ROCM
-        constexpr int warp_size = 32;
+        #define warp_size 32
     #else
-        constexpr int warp_size = ROCM_WARP_SIZE;
+        #define warp_size ROCM_WARP_SIZE
     #endif
 
     #if warp_size == 32 

--- a/csrc/selective_scan/selective_scan_bwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_bwd_kernel.cuh
@@ -518,7 +518,7 @@ void selective_scan_bwd_launch(SSMParamsBwd &params, cudaStream_t stream) {
                             #else
                             C10_CUDA_CHECK(cudaFuncSetAttribute(
                                 (void *) kernel, cudaFuncAttributeMaxDynamicSharedMemorySize, kSmemSize));
-                            std::cerr << "Warning (selective_scan_fwd_kernel): attempting to set maxDynamicSharedMemorySize on an AMD GPU which is currently a non-op (in ROCm versions <= 6.1). This might lead to undefined behavior. \n" << std::endl;
+                            std::cerr << "Warning (selective_scan_bwd_kernel): attempting to set maxDynamicSharedMemorySize on an AMD GPU which is currently a non-op (in ROCm versions <= 6.1). This might lead to undefined behavior. \n" << std::endl;
                             #endif
 
                         }
@@ -541,7 +541,8 @@ void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
         constexpr int warp_size = rocprim::warp_size();
     #endif
 
-    if (warp_size == 32) {
+    #if warp_size == 32
+
         if (params.seqlen <= 128) {
             selective_scan_bwd_launch<32, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 256) {
@@ -553,9 +554,9 @@ void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
         } else {
             selective_scan_bwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-    }
-    #ifdef USE_ROCM
-    else {
+
+    #else 
+
         if (params.seqlen <= 256) {
             selective_scan_bwd_launch<64, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 512) {
@@ -565,6 +566,6 @@ void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
         } else {
             selective_scan_bwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-    }
+
     #endif
 }

--- a/csrc/selective_scan/selective_scan_bwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_bwd_kernel.cuh
@@ -553,7 +553,6 @@ void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
         } else {
             selective_scan_bwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-    }
     #else 
         if (params.seqlen <= 256) {
             selective_scan_bwd_launch<64, 4, input_t, weight_t>(params, stream);

--- a/csrc/selective_scan/selective_scan_fwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_fwd_kernel.cuh
@@ -351,9 +351,9 @@ template<typename input_t, typename weight_t>
 void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
 
     #ifndef USE_ROCM
-        constexpr int warp_size = 32;
+        #define warp_size 32
     #else
-        constexpr int warp_size = ROCM_WARP_SIZE;
+        #define warp_size ROCM_WARP_SIZE
     #endif
 
     #if warp_size == 32

--- a/csrc/selective_scan/selective_scan_fwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_fwd_kernel.cuh
@@ -356,7 +356,8 @@ void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
         constexpr int warp_size = rocprim::warp_size();
     #endif
 
-    if (warp_size == 32) {
+    #if warp_size == 32
+
         if (params.seqlen <= 128) {           
             selective_scan_fwd_launch<32, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 256) {
@@ -368,9 +369,9 @@ void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
         } else {
             selective_scan_fwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-    }
-    #ifdef USE_ROCM
-    else {
+
+    #else
+
         if (params.seqlen <= 256) {
             selective_scan_fwd_launch<64, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 512) {
@@ -380,6 +381,6 @@ void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
         } else {
             selective_scan_fwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-    }
+
     #endif
 }

--- a/csrc/selective_scan/selective_scan_fwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_fwd_kernel.cuh
@@ -353,11 +353,10 @@ void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
     #ifndef USE_ROCM
         constexpr int warp_size = 32;
     #else
-        constexpr int warp_size = rocprim::warp_size();
+        constexpr int warp_size = ROCM_WARP_SIZE;
     #endif
 
     #if warp_size == 32
-
         if (params.seqlen <= 128) {           
             selective_scan_fwd_launch<32, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 256) {
@@ -369,9 +368,8 @@ void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
         } else {
             selective_scan_fwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-
+    
     #else
-
         if (params.seqlen <= 256) {
             selective_scan_fwd_launch<64, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 512) {
@@ -381,6 +379,5 @@ void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
         } else {
             selective_scan_fwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-
     #endif
 }

--- a/csrc/selective_scan/selective_scan_fwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_fwd_kernel.cuh
@@ -368,7 +368,6 @@ void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
         } else {
             selective_scan_fwd_launch<128, 16, input_t, weight_t>(params, stream);
         }
-    
     #else
         if (params.seqlen <= 256) {
             selective_scan_fwd_launch<64, 4, input_t, weight_t>(params, stream);


### PR DESCRIPTION
This PR is a small follow-up fix to the recently merged PR [#359 ](https://github.com/state-spaces/mamba/pull/359)
 
We changed the way we handle conditional compilation for kernel launches. On certain AMD architectures we were getting a compile time error due to code with an unsupported warp size even though the code is not reachable at run time. We now pass a ROCM_WARP_SIZE compile flag from setup.py and do conditional compilation based on it, using preprocessing directives.
 
There is also a minor typo fix in the warning text.