### PR TITLE
Fix ROCm version parsing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ def get_hip_version(rocm_dir):
 
     for line in raw_output.split("\n"):
         if "HIP version" in line:
-            rocm_version = parse(line.split()[-1].replace("-", "+")) # local version is not parsed correctly
+            rocm_version = parse(line.split()[-1].rstrip('-').replace('-', '+')) # local version is not parsed correctly
             return line, rocm_version
 
     return None, None
@@ -95,7 +95,7 @@ def get_hip_version(rocm_dir):
 def get_torch_hip_version():
 
     if torch.version.hip:
-        return parse(torch.version.hip.split()[-1].replace("-", "+"))
+        return parse(torch.version.hip.split()[-1].rstrip('-').replace('-', '+'))
     else:
         return None
 


### PR DESCRIPTION
Encountered an issue when building:
`packaging.version.InvalidVersion: Invalid version: '6.0.32831+'`

This error occurs in:
`rocm_version = parse(line.split()[-1].replace("-", "+"))`

The current implementation replaces "-" with "+" in version strings, that can leave a trailing "+" that violates PEP 440 standards. 

The same issue could occur here:
`return parse(torch.version.hip.split()[-1].replace("-", "+"))`