### PR TITLE
Fix for Issue #412 [AMD official]

### DIFF
--- a/csrc/selective_scan/selective_scan_bwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_bwd_kernel.cuh
@@ -536,12 +536,6 @@ template<typename input_t, typename weight_t>
 void selective_scan_bwd_cuda(SSMParamsBwd &params, cudaStream_t stream) {
 
     #ifndef USE_ROCM
-        #define warp_size 32
-    #else
-        #define warp_size ROCM_WARP_SIZE
-    #endif
-
-    #if warp_size == 32 
         if (params.seqlen <= 128) {
             selective_scan_bwd_launch<32, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 256) {

--- a/csrc/selective_scan/selective_scan_fwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_fwd_kernel.cuh
@@ -351,12 +351,6 @@ template<typename input_t, typename weight_t>
 void selective_scan_fwd_cuda(SSMParamsBase &params, cudaStream_t stream) {
 
     #ifndef USE_ROCM
-        #define warp_size 32
-    #else
-        #define warp_size ROCM_WARP_SIZE
-    #endif
-
-    #if warp_size == 32
         if (params.seqlen <= 128) {           
             selective_scan_fwd_launch<32, 4, input_t, weight_t>(params, stream);
         } else if (params.seqlen <= 256) {

--- a/setup.py
+++ b/setup.py
@@ -199,23 +199,6 @@ if not SKIP_CUDA_BUILD:
 
     if HIP_BUILD:
 
-        try:
-            # set warp size based on gcn architecure 
-            gcn_arch_name = torch.cuda.get_device_properties(0).gcnArchName
-            if "gfx10" in gcn_arch_name or "gfx11" in gcn_arch_name:
-                # radeon
-                warp_size = 32
-            else:
-                # instinct
-                warp_size = 64
-        except AttributeError as e:
-            # fall back to crude method to set warp size
-            device_name = torch.cuda.get_device_properties(0).name
-            if 'instinct' in device_name.lower():
-                warp_size = 64
-            else:
-                warp_size = 32
-
         extra_compile_args = {
             "cxx": ["-O3", "-std=c++17"],
             "nvcc": [
@@ -226,7 +209,6 @@ if not SKIP_CUDA_BUILD:
                 "-U__CUDA_NO_HALF_CONVERSIONS__",
                 "-DCK_FMHA_FWD_FAST_EXP2=1",
                 "-fgpu-flush-denormals-to-zero",
-                f"-DROCM_WARP_SIZE={warp_size}"
             ]
             + cc_flag,
         }


### PR DESCRIPTION
This PR addresses the issue https://github.com/state-spaces/mamba/issues/412

This install error is caused by a bug related to the warp size of Radeon GPUs in one of the ROCm libraries (rocprim). As a result, the warp size 32 based kernel launch fails to compile. In this fix, we use the same kernel parameters for both Instinct and Radeon GPUs. The performance hit is negligible.

The bug in rocmprim has been fixed (https://github.com/ROCm/rocPRIM/issues/542) but is not in the release yet. We can open another PR to revert the code once this rocprim fix is in the release.