### PR TITLE
Support variable-length sequences for mamba block with position indices

### DIFF
--- a/csrc/selective_scan/selective_scan.cpp
+++ b/csrc/selective_scan/selective_scan.cpp
@@ -78,8 +78,9 @@ void set_ssm_params_fwd(SSMParamsBase &params,
                         void* D_ptr,
                         void* delta_bias_ptr,
                         void* x_ptr,
-                        bool has_z,
-                        bool delta_softplus) {
+                        bool has_z, 
+                        bool delta_softplus,
+                        void* index_ptr) {
 
     // Reset the parameters
     memset(&params, 0, sizeof(params));
@@ -109,6 +110,9 @@ void set_ssm_params_fwd(SSMParamsBase &params,
     params.x_ptr = x_ptr;
     params.z_ptr = has_z ? z.data_ptr() : nullptr;
     params.out_z_ptr = has_z ? out_z.data_ptr() : nullptr;
+
+    params.index_ptr = index_ptr;
+
     // All stride are in elements, not bytes.
     params.A_d_stride = A.stride(0);
     params.A_dstate_stride = A.stride(1);
@@ -173,7 +177,8 @@ void set_ssm_params_bwd(SSMParamsBwd &params,
                         void* ddelta_bias_ptr,
                         bool has_z,
                         bool delta_softplus,
-                        bool recompute_out_z) {
+                        bool recompute_out_z,
+                        void* index_ptr) {
     // Pass in "dout" instead of "out", we're not gonna use "out" unless we have z
     set_ssm_params_fwd(params, batch, dim, seqlen, dstate, n_groups, n_chunks, is_variable_B, is_variable_C,
                        u, delta, A, B, C, has_z ? out : dout,
@@ -181,7 +186,7 @@ void set_ssm_params_bwd(SSMParamsBwd &params,
                        // If not recompute_out_z, pass dout instead of out_z.
                        // This won't be used by the bwd kernel
                        recompute_out_z ? out_z : dout,
-                       D_ptr, delta_bias_ptr, x_ptr, has_z, delta_softplus);
+                       D_ptr, delta_bias_ptr, x_ptr, has_z, delta_softplus, index_ptr);
     if (!recompute_out_z) { params.out_z_ptr = nullptr; }
 
     // Set the pointers and strides.
@@ -229,7 +234,8 @@ selective_scan_fwd(const at::Tensor &u, const at::Tensor &delta,
                   const c10::optional<at::Tensor> &D_,
                   const c10::optional<at::Tensor> &z_,
                   const c10::optional<at::Tensor> &delta_bias_,
-                  bool delta_softplus) {
+                  bool delta_softplus,
+                  const c10::optional<at::Tensor> &index_) {
     auto input_type = u.scalar_type();
     auto weight_type = A.scalar_type();
     TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
@@ -292,6 +298,12 @@ selective_scan_fwd(const at::Tensor &u, const at::Tensor &delta,
         TORCH_CHECK(delta_bias.stride(-1) == 1 || delta_bias.size(-1) == 1);
         CHECK_SHAPE(delta_bias, dim);
     }
+    if (index_.has_value()) {
+        auto index = index_.value();
+        TORCH_CHECK(index.scalar_type() == at::ScalarType::Int);
+        TORCH_CHECK(index.is_cuda());
+        CHECK_SHAPE(index, batch_size, seqlen);
+    }
 
     at::Tensor z, out_z;
     const bool has_z = z_.has_value();
@@ -319,7 +331,8 @@ selective_scan_fwd(const at::Tensor &u, const at::Tensor &delta,
                        delta_bias_.has_value() ? delta_bias_.value().data_ptr() : nullptr,
                        x.data_ptr(),
                        has_z,
-                       delta_softplus);
+                       delta_softplus,
+                       index_.has_value() ? index_.value().data_ptr() : nullptr);
 
     // Otherwise the kernel will be launched from cuda:0 device
     // Cast to char to avoid compiler warning about narrowing
@@ -346,7 +359,8 @@ selective_scan_bwd(const at::Tensor &u, const at::Tensor &delta,
                   const c10::optional<at::Tensor> &out_,
                   c10::optional<at::Tensor> &dz_,
                   bool delta_softplus,
-                  bool recompute_out_z) {
+                  bool recompute_out_z,
+                  const c10::optional<at::Tensor> &index_) {
     auto input_type = u.scalar_type();
     auto weight_type = A.scalar_type();
     TORCH_CHECK(input_type == at::ScalarType::Float || input_type == at::ScalarType::Half || input_type == at::ScalarType::BFloat16);
@@ -414,8 +428,15 @@ selective_scan_bwd(const at::Tensor &u, const at::Tensor &delta,
         CHECK_SHAPE(delta_bias, dim);
     }
 
+    if (index_.has_value()) {
+        auto index = index_.value();
+        TORCH_CHECK(index.scalar_type() == at::ScalarType::Int);
+        TORCH_CHECK(index.is_cuda());
+        CHECK_SHAPE(index, batch_size, seqlen);
+    }
     at::Tensor z, out, dz, out_z;
     const bool has_z = z_.has_value();
+    
     if (has_z) {
         z = z_.value();
         TORCH_CHECK(z.scalar_type() == input_type);
@@ -474,7 +495,8 @@ selective_scan_bwd(const at::Tensor &u, const at::Tensor &delta,
                        dout, du, ddelta, dA, dB, dC, dz,
                        D_.has_value() ? dD.data_ptr() : nullptr,
                        delta_bias_.has_value() ? ddelta_bias.data_ptr() : nullptr,
-                       has_z, delta_softplus, recompute_out_z);
+                       has_z, delta_softplus, recompute_out_z,
+                       index_.has_value() ? index_.value().data_ptr() : nullptr);
 
     // Otherwise the kernel will be launched from cuda:0 device
     // Cast to char to avoid compiler warning about narrowing

--- a/csrc/selective_scan/selective_scan.h
+++ b/csrc/selective_scan/selective_scan.h
@@ -66,6 +66,7 @@ struct SSMParamsBase {
     void *__restrict__ x_ptr;
     void *__restrict__ z_ptr;
     void *__restrict__ out_z_ptr;
+    void *__restrict__ index_ptr;
 };
 
 struct SSMParamsBwd: public SSMParamsBase {

--- a/csrc/selective_scan/selective_scan_bwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_bwd_kernel.cuh
@@ -43,6 +43,7 @@ struct Selective_Scan_bwd_kernel_traits {
     static constexpr bool kDeltaSoftplus = kDeltaSoftplus_;
     static constexpr bool kHasZ = kHasZ_;
     static constexpr bool kUseIndex = kUseIndex_;
+    static constexpr int kNLoadsIndex = kNItems / 4;
     // Setting MinBlocksPerMP to be 3 (instead of 2) for 128 threads with float improves occupancy.
     // For complex this would lead to massive register spilling, so we keep it at 2.
     static constexpr int kMinBlocks = kNThreads == 128 && !kIsComplex ? 3 : 2;
@@ -51,7 +52,7 @@ struct Selective_Scan_bwd_kernel_traits {
     using BlockLoadT = cub::BlockLoad<input_t, kNThreads, kNItems, cub::BLOCK_LOAD_WARP_TRANSPOSE>;
     using BlockLoadVecT = cub::BlockLoad<vec_t, kNThreads, kNLoads, cub::BLOCK_LOAD_WARP_TRANSPOSE>;
     using BlockLoadIndexT = cub::BlockLoad<int, kNThreads, kNItems, cub::BLOCK_LOAD_WARP_TRANSPOSE>;
-    using BlockLoadIndexVecT = cub::BlockLoad<vec_t, kNThreads, kNLoads, cub::BLOCK_LOAD_WARP_TRANSPOSE>;
+    using BlockLoadIndexVecT = cub::BlockLoad<uint4, kNThreads, kNLoadsIndex, cub::BLOCK_LOAD_WARP_TRANSPOSE>;
     using BlockLoadWeightT = cub::BlockLoad<input_t, kNThreads, !kIsComplex ? kNItems : kNItems * 2, cub::BLOCK_LOAD_WARP_TRANSPOSE>;
     using BlockLoadWeightVecT = cub::BlockLoad<vec_t, kNThreads, !kIsComplex ? kNLoads : kNLoads * 2, cub::BLOCK_LOAD_WARP_TRANSPOSE>;
     using BlockStoreT = cub::BlockStore<input_t, kNThreads, kNItems, cub::BLOCK_STORE_WARP_TRANSPOSE>;

--- a/csrc/selective_scan/selective_scan_common.h
+++ b/csrc/selective_scan/selective_scan_common.h
@@ -169,10 +169,9 @@ inline __device__ void load_index(int *u,
                                   int seqlen) {
     if constexpr (Ktraits::kIsEvenLen) {
         auto& smem_load_index_vec = reinterpret_cast<typename Ktraits::BlockLoadIndexVecT::TempStorage&>(smem_load_index);
-        using vec_t = typename Ktraits::vec_t;
         Ktraits::BlockLoadIndexVecT(smem_load_index_vec).Load(
-            reinterpret_cast<vec_t*>(u),
-            reinterpret_cast<vec_t(&)[Ktraits::kNLoads]>(u_vals)
+            reinterpret_cast<uint4*>(u),
+            reinterpret_cast<uint4(&)[Ktraits::kNLoadsIndex]>(u_vals)
        );
     } else {
         Ktraits::BlockLoadIndexT(smem_load_index).Load(u, u_vals, seqlen, 0);

--- a/csrc/selective_scan/selective_scan_common.h
+++ b/csrc/selective_scan/selective_scan_common.h
@@ -163,6 +163,23 @@ inline __device__ void load_input(typename Ktraits::input_t *u,
 }
 
 template<typename Ktraits>
+inline __device__ void load_index(int *u,
+                                  int (&u_vals)[Ktraits::kNItems],
+                                  typename Ktraits::BlockLoadIndexT::TempStorage &smem_load_index,
+                                  int seqlen) {
+    if constexpr (Ktraits::kIsEvenLen) {
+        auto& smem_load_index_vec = reinterpret_cast<typename Ktraits::BlockLoadIndexVecT::TempStorage&>(smem_load_index);
+        using vec_t = typename Ktraits::vec_t;
+        Ktraits::BlockLoadIndexVecT(smem_load_index_vec).Load(
+            reinterpret_cast<vec_t*>(u),
+            reinterpret_cast<vec_t(&)[Ktraits::kNLoads]>(u_vals)
+       );
+    } else {
+        Ktraits::BlockLoadIndexT(smem_load_index).Load(u, u_vals, seqlen, 0);
+    }
+}
+
+template<typename Ktraits>
 inline __device__ void load_weight(typename Ktraits::input_t *Bvar,
                                    typename Ktraits::weight_t (&B_vals)[Ktraits::kNItems],
                                    typename Ktraits::BlockLoadWeightT::TempStorage &smem_load_weight,

--- a/mamba_ssm/modules/mamba_simple.py
+++ b/mamba_ssm/modules/mamba_simple.py
@@ -116,9 +116,10 @@ class Mamba(nn.Module):
 
         self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=bias, **factory_kwargs)
 
-    def forward(self, hidden_states, inference_params=None):
+    def forward(self, hidden_states, position_indices=None, inference_params=None):
         """
         hidden_states: (B, L, D)
+        position_indices: (B, L)  a tensor that stores the positional indexes of elements within sequences.
         Returns: same shape as hidden_states
         """
         batch, seqlen, dim = hidden_states.shape
@@ -157,6 +158,7 @@ class Mamba(nn.Module):
                 self.D.float(),
                 delta_bias=self.dt_proj.bias.float(),
                 delta_softplus=True,
+                position_indices = position_indices,
             )
         else:
             x, z = xz.chunk(2, dim=1)

--- a/setup_onlyCUDA.py
+++ b/setup_onlyCUDA.py
@@ -1,0 +1,168 @@
+# Copyright (c) 2023, Albert Gu, Tri Dao.
+import sys
+import warnings
+import os
+import re
+import ast
+from pathlib import Path
+from packaging.version import parse, Version
+import platform
+import shutil
+
+from setuptools import setup, find_packages
+import subprocess
+
+import urllib.request
+import urllib.error
+from wheel.bdist_wheel import bdist_wheel as _bdist_wheel
+
+import torch
+from torch.utils.cpp_extension import (
+    BuildExtension,
+    CppExtension,
+    CUDAExtension,
+    CUDA_HOME,
+)
+
+
+with open("README.md", "r", encoding="utf-8") as fh:
+    long_description = fh.read()
+
+
+# ninja build does not work unless include_dirs are abs path
+this_dir = os.path.dirname(os.path.abspath(__file__))
+
+PACKAGE_NAME = "mamba_ssm"
+
+BASE_WHEEL_URL = "https://github.com/state-spaces/mamba/releases/download/{tag_name}/{wheel_name}"
+
+# FORCE_BUILD: Force a fresh build locally, instead of attempting to find prebuilt wheels
+# SKIP_CUDA_BUILD: Intended to allow CI to use a simple `python setup.py sdist` run to copy over raw files, without any cuda compilation
+FORCE_BUILD = os.getenv("MAMBA_FORCE_BUILD", "FALSE") == "TRUE"
+# SKIP_CUDA_BUILD = os.getenv("MAMBA_SKIP_CUDA_BUILD", "FALSE") == "TRUE"
+# For CI, we want the option to build with C++11 ABI since the nvcr images use C++11 ABI
+FORCE_CXX11_ABI = os.getenv("MAMBA_FORCE_CXX11_ABI", "FALSE") == "TRUE"
+
+
+def get_platform():
+    """
+    Returns the platform name as used in wheel filenames.
+    """
+    if sys.platform.startswith("linux"):
+        return "linux_x86_64"
+    elif sys.platform == "darwin":
+        mac_version = ".".join(platform.mac_ver()[0].split(".")[:2])
+        return f"macosx_{mac_version}_x86_64"
+    elif sys.platform == "win32":
+        return "win_amd64"
+    else:
+        raise ValueError("Unsupported platform: {}".format(sys.platform))
+
+
+def get_cuda_bare_metal_version(cuda_dir):
+    raw_output = subprocess.check_output(
+        [cuda_dir + "/bin/nvcc", "-V"], universal_newlines=True
+    )
+    output = raw_output.split()
+    release_idx = output.index("release") + 1
+    bare_metal_version = parse(output[release_idx].split(",")[0])
+
+    return raw_output, bare_metal_version
+
+
+def check_if_cuda_home_none(global_option: str) -> None:
+    if CUDA_HOME is not None:
+        return
+    # warn instead of error because user could be downloading prebuilt wheels, so nvcc won't be necessary
+    # in that case.
+    warnings.warn(
+        f"{global_option} was requested, but nvcc was not found.  Are you sure your environment has nvcc available?  "
+        "If you're installing within a container from https://hub.docker.com/r/pytorch/pytorch, "
+        "only images whose names contain 'devel' will provide nvcc."
+    )
+
+
+def append_nvcc_threads(nvcc_extra_args):
+    return nvcc_extra_args + ["--threads", "4"]
+
+
+cmdclass = {}
+ext_modules = []
+
+
+print("\n\ntorch.__version__  = {}\n\n".format(torch.__version__))
+TORCH_MAJOR = int(torch.__version__.split(".")[0])
+TORCH_MINOR = int(torch.__version__.split(".")[1])
+
+check_if_cuda_home_none(PACKAGE_NAME)
+# Check, if CUDA11 is installed for compute capability 8.0
+cc_flag = []
+if CUDA_HOME is not None:
+    _, bare_metal_version = get_cuda_bare_metal_version(CUDA_HOME)
+    if bare_metal_version < Version("11.6"):
+        raise RuntimeError(
+            f"{PACKAGE_NAME} is only supported on CUDA 11.6 and above.  "
+            "Note: make sure nvcc has a supported version by running nvcc -V."
+        )
+
+cc_flag.append("-gencode")
+cc_flag.append("arch=compute_70,code=sm_70")
+cc_flag.append("-gencode")
+cc_flag.append("arch=compute_80,code=sm_80")
+if bare_metal_version >= Version("11.8"):
+    cc_flag.append("-gencode")
+    cc_flag.append("arch=compute_90,code=sm_90")
+
+# HACK: The compiler flag -D_GLIBCXX_USE_CXX11_ABI is set to be the same as
+# torch._C._GLIBCXX_USE_CXX11_ABI
+# https://github.com/pytorch/pytorch/blob/8472c24e3b5b60150096486616d98b7bea01500b/torch/utils/cpp_extension.py#L920
+if FORCE_CXX11_ABI:
+    torch._C._GLIBCXX_USE_CXX11_ABI = True
+
+ext_modules.append(
+    CUDAExtension(
+        name="selective_scan_cuda",
+        sources=[
+            "csrc/selective_scan/selective_scan.cpp",
+            "csrc/selective_scan/selective_scan_fwd_fp32.cu",
+            "csrc/selective_scan/selective_scan_fwd_fp16.cu",
+            "csrc/selective_scan/selective_scan_fwd_bf16.cu",
+            "csrc/selective_scan/selective_scan_bwd_fp32_real.cu",
+            "csrc/selective_scan/selective_scan_bwd_fp32_complex.cu",
+            "csrc/selective_scan/selective_scan_bwd_fp16_real.cu",
+            "csrc/selective_scan/selective_scan_bwd_fp16_complex.cu",
+            "csrc/selective_scan/selective_scan_bwd_bf16_real.cu",
+            "csrc/selective_scan/selective_scan_bwd_bf16_complex.cu",
+        ],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "nvcc": append_nvcc_threads(
+                [
+                    "-O3",
+                    "-std=c++17",
+                    "-U__CUDA_NO_HALF_OPERATORS__",
+                    "-U__CUDA_NO_HALF_CONVERSIONS__",
+                    "-U__CUDA_NO_BFLOAT16_OPERATORS__",
+                    "-U__CUDA_NO_BFLOAT16_CONVERSIONS__",
+                    "-U__CUDA_NO_BFLOAT162_OPERATORS__",
+                    "-U__CUDA_NO_BFLOAT162_CONVERSIONS__",
+                    "--expt-relaxed-constexpr",
+                    "--expt-extended-lambda",
+                    "--use_fast_math",
+                    "--ptxas-options=-v",
+                    "-lineinfo",
+                ]
+                + cc_flag
+            ),
+        },
+        include_dirs=[Path(this_dir) / "csrc" / "selective_scan"],
+    )
+)
+
+
+
+setup(
+    name="selective_scan_cuda",
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/tests/ops/test_mamba_cu_seqlens_equivalence.py
+++ b/tests/ops/test_mamba_cu_seqlens_equivalence.py
@@ -1,0 +1,187 @@
+import random
+import torch
+
+from mamba_ssm.modules.mamba_simple import Mamba
+
+class AlignTimer:
+    def __init__(self, message='kernel_no_name'):
+        self.message = message
+
+    def __enter__(self):
+        torch.cuda.synchronize()  
+        self.starter = torch.cuda.Event(enable_timing=True)
+        self.starter.record()
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.ender = torch.cuda.Event(enable_timing=True)
+        self.ender.record()
+        torch.cuda.synchronize()  
+        self.time = self.starter.elapsed_time(self.ender)
+        print('{} uses time {:.4f} ms'.format(self.message, self.time))
+'''
+unpack function: convert packed_hidden_states (batch_size=1) to hidden_states
+'''
+def unpack(packed_hidden_states, cu_seqlens):
+    batch_size = packed_hidden_states.shape[0]
+    package_num = cu_seqlens.shape[0] - 1
+    seq_len = (cu_seqlens[1:] - cu_seqlens[:-1]).max()
+    hidden_dim = packed_hidden_states.shape[2]
+    hidden_states = torch.zeros(package_num * batch_size, seq_len, hidden_dim, dtype=packed_hidden_states.dtype, device=packed_hidden_states.device)
+    for j in range(batch_size):
+        for i in range(package_num):
+            line = j * package_num + i
+            hidden_states[line, : cu_seqlens[i + 1] - cu_seqlens[i], :] = packed_hidden_states[j, cu_seqlens[i] : cu_seqlens[i + 1], :]
+    return hidden_states
+
+
+'''
+pack function: convert hidden_states to packed_hidden_states (batch_size=1)
+'''
+def pack(hidden_states, cu_seqlens, batch_size):
+    package_num, seq_len, hidden_dim = hidden_states.shape
+    seq_len_list = cu_seqlens[1:] - cu_seqlens[:-1]
+    seq_len_list_3d = seq_len_list.unsqueeze(1).unsqueeze(2)
+    indices_3d = (
+        torch.arange(seq_len, device=hidden_states.device)
+        .unsqueeze(0)
+        .unsqueeze(2)
+        .repeat(package_num, 1, hidden_dim)
+    )
+    mask_3d = indices_3d < seq_len_list_3d.repeat(batch_size, 1, 1)
+    packed_hidden_states = hidden_states[mask_3d].view(batch_size,-1, hidden_dim)
+    return packed_hidden_states
+
+    
+'''
+Generate random cu_seqlens for testing
+'''
+def generate_random_cu_seqlens(seq_len, packages_num = 2):
+    
+    if packages_num > 1:
+        ret = sorted(random.sample(range(1, seq_len), packages_num - 1))
+    else:
+        ret = []
+    cu_seqlens = [0] + ret + [seq_len]
+    assert packages_num == len(cu_seqlens) - 1
+    index = []
+    for i in range(1, len(cu_seqlens)):
+        token_len = cu_seqlens[i] - cu_seqlens[i-1]
+        index.extend(list(range(token_len)))
+    return cu_seqlens, index
+
+
+def main():
+    # config tested with A100
+    hidden_dim = 4
+    seq_len = 1024
+    batch_size = 2
+    device='cuda'
+    
+    itype = torch.half
+    rtol, atol = (6e-4, 2e-3) if itype == torch.float32 else (3e-3, 5e-3)
+    if itype == torch.bfloat16:
+        rtol, atol = 3e-2, 5e-2
+    rtolw, atolw = (1e-3, 1e-3)
+    # If we have z, the errors on the weights seem higher
+    rtolw = max(rtolw, rtol)
+    atolw = max(atolw, atol)
+    packages_num = 8
+    # Generate random cu_seqlens for testing
+    cu_seqlens, index = generate_random_cu_seqlens(seq_len, packages_num = packages_num)
+    cu_seqlens = torch.tensor(cu_seqlens).cuda()
+    index = torch.tensor(index, dtype=torch.int32).unsqueeze(0).expand(batch_size, -1).contiguous().cuda()
+    print("cu_seqlens:", cu_seqlens, "index:",index)
+    # Generate packed_hidden_states with random values for testing
+    # packed_hidden_states (batch_size=1) should be forwarded with cu_seqlens
+    hidden_states_list = [torch.randn(l, hidden_dim, device=device) for l in (cu_seqlens[1:] - cu_seqlens[:-1]).tolist()]
+    packed_hidden_states = torch.cat(hidden_states_list, dim=0).unsqueeze(0)
+    packed_hidden_states = packed_hidden_states.expand(batch_size, -1,-1).contiguous()
+    # hidden_states should be forwarded without cu_seqlens
+    hidden_states = unpack(packed_hidden_states, cu_seqlens)
+
+
+    # Check: sum of seq_len of item in hidden_states_list should be equal to seq_len of packed_hidden_states
+    assert sum([hs.shape[0] for hs in hidden_states_list]) == packed_hidden_states.shape[1]
+    # Check: max of seq_len of item in hidden_states_list should be equal to seq_len of hidden_states
+    assert max([hs.shape[0] for hs in hidden_states_list]) == hidden_states.shape[1]
+
+
+    grads = {}
+    
+
+    # creat one simple mamba block
+    mamba = Mamba(
+        # This module uses roughly 3 * expand * d_model^2 parameters
+        d_model=hidden_dim, # Model dimension d_model
+        d_state=16,  # SSM state expansion factor
+        d_conv=4,    # Local convolution width
+        expand=2,    # Block expansion factor
+    ).to(device)
+    
+    mamba_ref = Mamba(
+    # This module uses roughly 3 * expand * d_model^2 parameters
+    d_model=hidden_dim, # Model dimension d_model
+    d_state=16,  # SSM state expansion factor
+    d_conv=4,    # Local convolution width
+    expand=2,    # Block expansion factor
+    ).to(device)
+    mamba_ref.load_state_dict(mamba.state_dict())
+    
+    # reference output for forwardding hidden_states
+    with AlignTimer("pack_fwd"):
+        out = mamba(packed_hidden_states, index)
+    
+    with AlignTimer("unpack_fwd"):
+        out_ref = mamba_ref(hidden_states)
+    out_ref_pack = pack(out_ref, cu_seqlens, batch_size)
+    
+    # with AlignTimer("unpack"):
+    #     out_ref = mamba_ref(hidden_states)
+    # out_ref_pack = pack(out_ref, cu_seqlens, batch_size)
+    # output for forwardding packed_hidden_states with cu_seqlens
+
+
+    # Testing the max/mean diff
+    import numpy as np
+    np.testing.assert_allclose(out.detach().cpu().numpy(), out_ref_pack.detach().cpu().numpy(), rtol = rtol, atol=atol)
+    print(f'Output max diff: {(out - out_ref_pack).abs().max().item()}')
+    print(f'Output mean diff: {(out - out_ref_pack).abs().mean().item()}')
+    assert torch.allclose(out, out_ref_pack, rtol=rtol, atol=atol)
+    
+    g = torch.randn(out.shape).to(device)  
+    with AlignTimer("pack_bwd"):
+        out.backward(g)
+    gradients = {name: param.grad.clone() for name, param in mamba.named_parameters()}
+
+    g_ref = unpack(g, cu_seqlens)
+    with AlignTimer("unpack_bwd"):
+        out_ref.backward(g_ref)
+    gradients_ref = {name: param.grad.clone() for name, param in mamba_ref.named_parameters()}
+    
+        
+    # 比较两组梯度
+    for name in gradients_ref:
+        if name in gradients:
+            is_equal = torch.allclose(gradients_ref[name], gradients[name], rtol=rtol, atol=atol)
+            print(f"Gradients for {name} are {'equal' if is_equal else 'not equal'}")
+            if not is_equal:
+                print(f"Gradient difference for {name}: {torch.abs(gradients_ref[name] - gradients[name]).max()}")
+        else:
+            print(f"Parameter {name} not found in the second set of gradients")
+    
+    # grad_results = torch.load('use_position_grad_results.pt')
+    # grad_results_ref = torch.load('no_position_grad_results.pt')
+    # print(grad_results)
+    # for name in grad_results_ref:
+    #     if name in grad_results and grad_results[name] is not None:
+    #         is_equal = torch.allclose(grad_results_ref[name], grad_results[name], rtol=rtol, atol=atol)
+    #         print(f"Gradients for {name} are {'equal' if is_equal else 'not equal'}")
+    #         if not is_equal:
+    #             print(f"Gradient difference for {name}: {torch.abs(grad_results_ref[name] - grad_results[name]).max()}")
+    #     else:
+    #         print(f"Parameter {name} not found in the second set of gradients")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Enable the mamba block to support variable-length sequence inputs using positional encoding.  Passing Positional Indices results in negligible performance loss for the mamba block. For common variable-length sequence distributions, performance can be improved by **4-6x.**

- Modification: 
Refer to the link https://github.com/state-spaces/mamba/pull/244 to replace cumulative sequences with a positional encoding matrix. The position encoding is more suitable for parallel acceleration and is more commonly found in the outputs of various dataloaders.
> For example, a packaged sequence of length 16 consists of four independent sub-sequences with lengths of 3, 5, 6, 2. Then corresponding:
> Cumulative sequence: `[0, 3, 8, 14, 16]`
> Position encoding:  `[0, 1, 2, 0, 1, 2, 3, 4, 0, 1, 2, 3, 4, 5, 0, 1]`

In the Mamba module, there are two steps that are not sequence-wise: conv1d and selective_scan. Sub-sequences within the same sequence can affect each other, and we have modified **causal-conv1d** and **selective_scan**. These two CUDA operators are implemented using position encoding to eliminate the mutual influence between sub-sequences.

- How to use:
1. Setup two cuda_operators:
```
git clone --branch feat/pack_with_position_indices https://github.com/ptxu78/pack_mamba.git
python setup .../pack_mamba/setup_onlyCUDA.py install
git clone --branch feat/pack_with_position_indices https://github.com/ptxu78/causal-conv1d-pack.git
python setup .../causal-conv1d-pack/setup_onlyCUDA.py install
```
2. Pack the variable-length sequences and input them, along with the corresponding position encoding.


