### PR TITLE
Add HF integration, better discoverability

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -31,8 +31,10 @@ from mamba_ssm.distributed.distributed_utils import all_reduce, reduce_scatter
 from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
 from mamba_ssm.ops.triton.ssd_combined import mamba_split_conv1d_scan_combined
 
+from huggingface_hub import PyTorchModelHubMixin
 
-class Mamba2(nn.Module):
+
+class Mamba2(nn.Module, PyTorchModelHubMixin):
     def __init__(
         self,
         d_model,


### PR DESCRIPTION
Hi @tridao and team,

I wrote a quick PoC to showcase that you can easily have integration with the 🤗 hub so that you can automatically load the various Mamba models using `from_pretrained` (and push them using `push_to_hub`), track download numbers for your models (similar to models in the Transformers library), and have nice model cards on a per-model basis. It leverages the [PyTorchModelHubMixin](https://huggingface.co/docs/huggingface_hub/package_reference/mixins#huggingface_hub.PyTorchModelHubMixin) class which allows to inherits these methods.

Yes this works for any custom PyTorch models, it's not limited to Transformers/Diffusers :)

Usage is as follows:

```python
from mamba_ssm import Mamba2

model = Mamba2(
    # This module uses roughly 3 * expand * d_model^2 parameters
    d_model=dim, # Model dimension d_model
    d_state=64,  # SSM state expansion factor, typically 64 or 128
    d_conv=4,    # Local convolution width
    expand=2,    # Block expansion factor
).to("cuda")
y = model(x)
assert y.shape == x.shape

# optionally, one can push a trained model to the hub
model.push_to_hub("state-space/mamba2-demo")

# reload
model = Mamba2.from_pretrained("state-space/mamba2-demo")
```

This means people don't need to manually download a checkpoint first in their local environment, it just loads automatically from the hub. All checkpoints could be hosted as part of the [state-spaces organization ](https://huggingface.co/state-spaces)on the hub or a personal user account if you're interested.

Would you be interested in this integration?

Kind regards,

Niels
ML @ HF