### PR TITLE
Support HF integration in Mamba and Mamba2Simple + add metadata

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -5,8 +5,8 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from einops import rearrange, repeat
+from huggingface_hub import PyTorchModelHubMixin
 
 try:
     from causal_conv1d import causal_conv1d_fn, causal_conv1d_update
@@ -31,10 +31,14 @@ from mamba_ssm.distributed.distributed_utils import all_reduce, reduce_scatter
 from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
 from mamba_ssm.ops.triton.ssd_combined import mamba_split_conv1d_scan_combined
 
-from huggingface_hub import PyTorchModelHubMixin
 
-
-class Mamba2(nn.Module, PyTorchModelHubMixin):
+class Mamba2(
+        nn.Module,
+        PyTorchModelHubMixin,
+        library_name="mamba_ssm",
+        repo_url="https://github.com/state-spaces/mamba",
+        tags=["mamba2", "arXiv:2312.00752", "arXiv:2405.21060"],
+    ):
     def __init__(
         self,
         d_model,

--- a/mamba_ssm/modules/mamba2_simple.py
+++ b/mamba_ssm/modules/mamba2_simple.py
@@ -4,8 +4,8 @@ import math
 import torch
 import torch.nn as nn
 import torch.nn.functional as F
-
 from einops import rearrange, repeat
+from huggingface_hub import PyTorchModelHubMixin
 
 try:
     from causal_conv1d import causal_conv1d_fn
@@ -21,7 +21,13 @@ from mamba_ssm.ops.triton.ssd_combined import mamba_chunk_scan_combined
 from mamba_ssm.ops.triton.ssd_combined import mamba_split_conv1d_scan_combined
 
 
-class Mamba2Simple(nn.Module):
+class Mamba2Simple(
+        nn.Module,
+        PyTorchModelHubMixin,
+        library_name="mamba_ssm",
+        repo_url="https://github.com/state-spaces/mamba",
+        tags=["mamba2simple", "arXiv:2312.00752", "arXiv:2405.21060"],
+    ):
     def __init__(
         self,
         d_model,

--- a/mamba_ssm/modules/mamba_simple.py
+++ b/mamba_ssm/modules/mamba_simple.py
@@ -9,6 +9,7 @@ import torch.nn.functional as F
 from torch import Tensor
 
 from einops import rearrange, repeat
+from huggingface_hub import PyTorchModelHubMixin
 
 from mamba_ssm.ops.selective_scan_interface import selective_scan_fn, mamba_inner_fn
 
@@ -28,7 +29,13 @@ except ImportError:
     RMSNorm, layer_norm_fn, rms_norm_fn = None, None, None
 
 
-class Mamba(nn.Module):
+class Mamba(
+        nn.Module,
+        PyTorchModelHubMixin,
+        library_name="mamba_ssm",
+        repo_url="https://github.com/state-spaces/mamba",
+        tags=["mamba", "arXiv:2312.00752"],
+    ):
     def __init__(
         self,
         d_model,

--- a/setup.py
+++ b/setup.py
@@ -374,6 +374,7 @@ setup(
         "einops",
         "triton",
         "transformers",
+        "huggingface_hub>=0.22",
         # "causal_conv1d>=1.4.0",
     ],
 )


### PR DESCRIPTION
Hi @tridao and team,

This is a follow-up PR after https://github.com/state-spaces/mamba/pull/469 (cc @NielsRogge). This PR adds:
- `huggingface_hub` as an explicit dependency. It is already a dependency since `mamba_ssm` depends on `transformers` which depends on `huggingface_hub` but it's better to be explicit. I also pinned a recent version (~4month old) that contains all recent `PyTochModelHubMixin` updates
- the `PyTochModelHubMixin` introduced in #469 to `Mamba` and `Mamba2Simple` modules so that API is the same for all three modules
- metadata to the modules. When a module is pushed to the HF Hub using `Mamba(...).push_to_hub("username/my-cool-mamba")`, a model card will be automatically created with some metadata in it. This improves a lot the UX on the Hub: better discoverability, better documentation, etc. In particular, I have added:
    - `library_name: mamba_ssm` to all modules. I've opened a PR on our side to make `mamba_ssm` recognized as a library by the Hub (see https://github.com/huggingface/huggingface.js/pull/802). Users landing on a `mamba_ssm` model will automatically get a code snippet on how to instanciate the model + link to the mamba repo + download count enabled
    - `https://github.com/state-spaces/mamba` as "repo_url" => all model cards will have a sentence "this model have been pushed using https://github.com/state-spaces/mamba" => better for documentation
    - `mamba`/ `mamba2`/`mamba2simple` as tag => this is needed to generate correct code snippets on the Hub (knowing which architecture to load). It will also be useful for users to filter "all models on the Hub that have `library_name: mamba_ssm` and `mamba2` as tag" (see [link](https://huggingface.co/models?library=mamba_ssm&other=mamba2)) => better for discoverability
    - `arXiv:2312.00752` and `arXiv:2405.21060` as tags so that your papers will be automatically linked to all Mamba models uploaded on the Hub => better for referencing 


In parallel of this PR, it would be good to update metadata on all state-spaces models on the HF Hub ([link](https://huggingface.co/models?sort=trending&author=state-spaces)) so that they can be loaded with this new interface + tagged correctly (for code snippets). How do you want to proceed for this?