### PR TITLE
Fix unittest for test_selective_state_update_with_heads

### DIFF
--- a/tests/ops/triton/test_selective_state_update.py
+++ b/tests/ops/triton/test_selective_state_update.py
@@ -6,7 +6,7 @@ import torch
 import torch.nn.functional as F
 import pytest
 
-from einops import rearrange
+from einops import rearrange, repeat
 
 from mamba_ssm.ops.triton.selective_state_update import selective_state_update, selective_state_update_ref
 


### PR DESCRIPTION
Dear author, 

We noticed that the unittest `test_selective_state_update_with_heads` was added in [some recent commit](https://github.com/state-spaces/mamba/commit/346230250920130803836b83dec895637305e466), but when we tried to run `pytest tests/`, we found an error occured:

`NameError: name 'repeat' is not defined`.

So we add the missing import part of `from einops import repeat`, and it works.
Hope it helps!

