### PR TITLE
Fix tuple unpacking error in inference_params.key_value_memory_dict

### DIFF
--- a/mamba_ssm/modules/mha.py
+++ b/mamba_ssm/modules/mha.py
@@ -180,7 +180,7 @@ class MHA(nn.Module):
             ).transpose(1, 2)
         else:
             batch = q.shape[0]
-            kv_cache = inference_params.key_value_memory_dict[self.layer_idx][:batch]
+            kv_cache, _ = inference_params.key_value_memory_dict[self.layer_idx]
             cache_seqlens = (
                 inference_params.lengths_per_sample[:batch]
                 if inference_params.lengths_per_sample is not None


### PR DESCRIPTION
`kv_cache` was incorrectly parsed by `batch` index, causing an error. Because `inference_params.key_value_memory_dict[self.layer_idx]` is a tuple containing `kv_cache` and `conv_state`. Updated to correctly unpack the tuple.

Changed:
`kv_cache = inference_params.key_value_memory_dict[self.layer_idx][:batch]` 
To:
`kv_cache, _ = inference_params.key_value_memory_dict[self.layer_idx]`
This ensures proper handling of `kv_cache` and avoids parsing errors.