### PR TITLE
Fix unpacking error

### DIFF
--- a/mamba_ssm/modules/mha.py
+++ b/mamba_ssm/modules/mha.py
@@ -180,7 +180,8 @@ class MHA(nn.Module):
             ).transpose(1, 2)
         else:
             batch = q.shape[0]
-            kv_cache = inference_params.key_value_memory_dict[self.layer_idx][:batch]
+            kv_cache, _ = inference_params.key_value_memory_dict[self.layer_idx]
+            kv_cache = kv_cache[:batch]
             cache_seqlens = (
                 inference_params.lengths_per_sample[:batch]
                 if inference_params.lengths_per_sample is not None


### PR DESCRIPTION
Fix unpacking error.
In MHA, inference_params.key_value_memory_dict is a tuple of kv_cache and conv1d