### PR TITLE
Fix Incorrect Gradients and Illegal Memory Access Error in Mamba2

### DIFF
--- a/mamba_ssm/ops/triton/ssd_chunk_scan.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_scan.py
@@ -1133,7 +1133,7 @@ def _chunk_scan_bwd_ddAcs_stable_kernel(
         # If there's seq_idx, we already zero'ed out cb[i, j] for seq_idx[i] != seq_idx[j]
         cb = tl.load(cb_ptrs, mask=(offs_m[:, None] < chunk_size) & (offs_n[None, :] < chunk_size - start_n), other=0.0).to(tl.float32)
         acc *= cb
-        dA_cs_n = tl.load(dA_cumsum_ptr + start_n + offs_n * stride_dA_cs_csize, mask=offs_n < chunk_size - start_n, other=0.0).to(tl.float32)
+        dA_cs_n = tl.load(dA_cumsum_ptr + (start_n + offs_n) * stride_dA_cs_csize, mask=offs_n < chunk_size - start_n, other=0.0).to(tl.float32)
         acc *= tl.exp(dA_cs_m[:, None] - dA_cs_n[None, :])
         mask = offs_m[:, None] >= start_n + offs_n[None, :] + 1
         acc = tl.where(mask, acc, 0.0)

--- a/mamba_ssm/ops/triton/ssd_chunk_scan.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_scan.py
@@ -1055,11 +1055,11 @@ def _chunk_scan_bwd_ddAcs_stable_kernel_old(
 @triton.autotune(
     configs=[
         triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4),
-        triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4),
-        triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4),
+        # triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4),
+        # triton.Config({'BLOCK_SIZE_M': 32, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4),
-        triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4),
+        # triton.Config({'BLOCK_SIZE_M': 64, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 32}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 64}, num_stages=3, num_warps=4),
         triton.Config({'BLOCK_SIZE_M': 128, 'BLOCK_SIZE_N': 128}, num_stages=3, num_warps=4),


### PR DESCRIPTION
Hey Tri and Albert,

Digging through the code base, I have found a bug in the backward pass for the gradient calculations in the function `_chunk_scan_bwd_ddAcs_stable_kernel`. I think this solves the issue given by #503, however, it will definitely fix incorrect gradient calculations for $\Delta A$.

Essentially, all that was going on lines [1146-1149](https://github.com/Hprairie/mamba/blob/b069d47659435f613d3820d6f5a5e188ad46a4f2/mamba_ssm/ops/triton/ssd_chunk_scan.py#L1146) if `BLOCK_SIZE_N` was greater then `BLOCK_SIZE_M` then it would update the pointer by `BLOCK_SIZE_N`. Then when we try to zero out the remainder of the sequence in lines [1152:1154](https://github.com/Hprairie/mamba/blob/b069d47659435f613d3820d6f5a5e188ad46a4f2/mamba_ssm/ops/triton/ssd_chunk_scan.py#L1152), the loop assumes that pointer of `ddA_cs_ptr` is at `hi=(pid_m + 1) * BLOCK_SIZE_M` when we could have overshot it, given that `BLOCK_SIZE_M < BLOCK_SIZE_N`. 

All that I do in the PR is remove the potential for us to overshoot by disabling the kernel configs where `BLOCK_SIZE_N > BLOCK_SIZE_M`. This means that at the end of the first loop we will always have out ptr updated by `(pid_m + ) * BLOCK_SIZE_M`. More complicated things can be done to fix this, however, I don't want to add complexity to the kernel, so I think that this works for now.

I found that incorrect gradient calculations for `dA` were incredibly common when this bug was present, thus I don't know how much this will have affected model training.

Let me know if you need any clarifications or if I can do anything else to help!