### PR TITLE
Clarifying no build isolation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ with an efficient hardware-aware design and implementation in the spirit of [Fla
 
 It can also be built from source with `pip install .` from this repository.
 
-If `pip` complains about PyTorch versions, try passing `--no-build-isolation` to `pip`.
+Try passing `--no-build-isolation` to `pip` if installation encounters difficulties either when building from source or installing from PyPi. Common `pip` complaints that can be resolved in this way include PyTorch versions, but other cases exist as well.
 
 Other requirements:
 - Linux


### PR DESCRIPTION
Clarifying that "no build isolation" option might help with other problems, not only PyTorch versions.