### PR TITLE
Fixes typo when indexing after self.conv1d

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -230,7 +230,7 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
             if causal_conv1d_fn is None or self.activation not in ["silu", "swish"]:
                 assert seq_idx is None, "varlen conv1d requires the causal_conv1d package"
                 xBC = self.act(
-                    self.conv1d(xBC.transpose(1, 2)).transpose(1, 2)[:, -(self.dconv - 1):]
+                    self.conv1d(xBC.transpose(1, 2)).transpose(1, 2)[:, :-(self.d_conv - 1)]
                 )  # (B, L, self.d_ssm + 2 * ngroups * d_state)
             else:
                 xBC = causal_conv1d_fn(


### PR DESCRIPTION
Addresses two errors when use_eff_mem_path is set to False (to avoid causal_conv1d):
1) There is a typo at line 233 - currently the class references self.dconv (which doesn't exist) instead of self.d_conv. This gives rise to an attribute missing error.
2) Assuming I've understood correctly, the original code indexes the post-conv1d tensor incorrectly. For example, if the sequence length were 20 and the post-conv1d tensor has length 23, it is indexed to the last 3 items rather than the first 20.