### PR TITLE
Add triton as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ classifiers = [
 ]
 dependencies = [
     "torch",
+    "triton",
     "ninja",
     "einops",
     "transformers",

--- a/setup.py
+++ b/setup.py
@@ -371,7 +371,7 @@ setup(
         "packaging",
         "ninja",
         "einops",
-        # "triton",
+        "triton",
         "transformers",
         # "causal_conv1d>=1.4.0",
     ],


### PR DESCRIPTION
Added triton as dependency.


Otherwise it fails on import:
```
$ python -c 'import mamba_ssm'
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/tmp/coulombc/26517/lib/python3.11/site-packages/mamba_ssm/__init__.py", line 3, in <module>
    from mamba_ssm.ops.selective_scan_interface import selective_scan_fn, mamba_inner_fn
  File "/tmp/coulombc/26517/lib/python3.11/site-packages/mamba_ssm/ops/selective_scan_interface.py", line 16, in <module>
    from mamba_ssm.ops.triton.layer_norm import _layer_norm_fwd
  File "/tmp/coulombc/26517/lib/python3.11/site-packages/mamba_ssm/ops/triton/layer_norm.py", line 16, in <module>
    import triton
ModuleNotFoundError: No module named 'triton'
```