### PR TITLE
Remove unused runtime dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,11 +18,9 @@ classifiers = [
 dependencies = [
     "torch",
     "triton",
-    "ninja",
     "einops",
     "transformers",
     "packaging",
-    "setuptools>=61.0.0",
 ]
 [project.urls]
 Repository = "https://github.com/state-spaces/mamba"


### PR DESCRIPTION
setuptools and ninja are not used at runtime, and already exist in the build-system list of dependencies (and are overridden by some installs in the build workflow)

xref: https://github.com/conda-forge/staged-recipes/pull/30861