### PR TITLE
[transformers] Fixed decode output cls

### DIFF
--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -11,7 +11,7 @@ import torch.nn.functional as F
 from einops import rearrange, repeat
 from torch import Tensor
 from torch.profiler import ProfilerActivity, profile, record_function
-from transformers.generation import GreedySearchDecoderOnlyOutput, SampleDecoderOnlyOutput, TextStreamer
+from transformers.generation import GenerateDecoderOnlyOutput, TextStreamer
 
 
 @dataclass
@@ -146,7 +146,7 @@ def decode(
         max_length: int
         teacher_outputs (optional): (batch, seq_len). If provided, instead of sampling from the
             logits, the next token is taken from the teacher_outputs. Useful for testing.
-    Returns: GreedySearchDecoderOnlyOutput or SampleDecoderOnlyOutput, with the following fields:
+    Returns: GenerateDecoderOnlyOutput, with the following fields:
         sequences: (batch, max_length)
         scores: tuples of (batch, vocab_size)
     """
@@ -240,8 +240,7 @@ def decode(
         end.record()
         torch.cuda.synchronize()
         print(f"Prompt processing + decoding time: {(start.elapsed_time(end)):.0f}ms")
-    output_cls = GreedySearchDecoderOnlyOutput if top_k == 1 else SampleDecoderOnlyOutput
-    return output_cls(sequences=torch.cat(sequences, dim=1), scores=tuple(scores))
+    return GenerateDecoderOnlyOutput(sequences=torch.cat(sequences, dim=1), scores=tuple(scores))
 
 
 class GenerationMixin:


### PR DESCRIPTION
The generation class `GreedySearchDecoderOnlyOutput`, `SampleDecoderOnlyOutput` have been deprecated from the `transformers` library and will be removed in the next version. I have updated it with the ouput class which is more generic.

Since the transformers version is not pinned in `setup.py`, this fix is crucial. The fix is backward compatible and hence won't break anything.

For example, with the current release of transformers, `transformers==4.57.1`, this code works:

```python
import mamba_ssm

selective_state_update = mamba_ssm.ops.triton.selective_state_update.selective_state_update
mamba_chunk_scan_combined = mamba_ssm.ops.triton.ssd_combined.mamba_chunk_scan_combined
mamba_split_conv1d_scan_combined = mamba_ssm.ops.triton.ssd_combined.mamba_split_conv1d_scan_combined
```

but as soon as we install transformers from main, even the import breaks

```bash
Traceback (most recent call last):
  File "/workspace/mamba/test.py", line 1, in <module>
    import mamba_ssm
  File "/workspace/mamba/mamba_ssm/__init__.py", line 6, in <module>
    from mamba_ssm.models.mixer_seq_simple import MambaLMHeadModel
  File "/workspace/mamba/mamba_ssm/models/mixer_seq_simple.py", line 20, in <module>
    from mamba_ssm.utils.generation import GenerationMixin
  File "/workspace/mamba/mamba_ssm/utils/generation.py", line 14, in <module>
    from transformers.generation import GreedySearchDecoderOnlyOutput, SampleDecoderOnlyOutput, TextStreamer
ImportError: cannot import name 'GreedySearchDecoderOnlyOutput' from 'transformers.generation' (/workspace/transformers/src/transformers/generation/__init__.py). Did you mean: 'GenerateBeamDecoderOnlyOutput'?
```

After the fix in the PR, this import issue is solved.