### PR TITLE
Add new PyTorch version (2.8 and 2.9) builds to publish workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -44,7 +44,7 @@ jobs:
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04]
         python-version: ["3.9", "3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.4.0", "2.5.1", "2.6.0", "2.7.1"]
+        torch-version: ["2.4.0", "2.5.1", "2.6.0", "2.7.1", "2.8.0", "2.9.0"]
         cuda-version: ["11.8.0", "12.9.1"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.


### PR DESCRIPTION
Fixes #818 