### PR TITLE
add support for multiple architectures via semicolon-separated HIP_ARCHITECTURES

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -217,7 +217,8 @@ if not SKIP_CUDA_BUILD:
             "nvcc": [
                 "-O3",
                 "-std=c++17",
-                f"--offload-arch={os.getenv('HIP_ARCHITECTURES', 'native')}",
+                # Support multiple architectures via semicolon-separated HIP_ARCHITECTURES
+                *[f'--offload-arch={arch}' for arch in os.getenv('HIP_ARCHITECTURES', 'native').split(';')],
                 "-U__CUDA_NO_HALF_OPERATORS__",
                 "-U__CUDA_NO_HALF_CONVERSIONS__",
                 "-fgpu-flush-denormals-to-zero",


### PR DESCRIPTION
Fix mamba build for multiple HIP architectures.

Root cause:

`HIP_ARCHITECTURES="gfx942;gfx950"` translates to `--offload-arch="gfx942;gfx950"`.

Solution:

Translate `HIP_ARCHITECTURES="gfx942;gfx950"` to `--offload-arch="gfx942" --offload-arch="gfx950"`.