### PR TITLE
Update PR 713 stride fix for packed sequence

### DIFF
--- a/mamba_ssm/ops/triton/ssd_combined.py
+++ b/mamba_ssm/ops/triton/ssd_combined.py
@@ -926,6 +926,7 @@ class MambaSplitConv1dScanCombinedFn(torch.autograd.Function):
             doutproj_weight, doutproj_bias = None, None
         dxBC_given_update, dweight, dbias, *_ = causal_conv1d_bwd_function(
             rearrange(ensure_stride(xBC), "b s d -> b d s"), conv1d_weight, conv1d_bias,
+            # It might be okay to not run ensure_stride on dxBC, but we're not sure. So playing safe here.
             rearrange(ensure_stride(dxBC), "b s d -> b d s"), seq_idx, None, None,
             rearrange(ensure_stride(dxBC_given), "b s d -> b d s"), False, ctx.activation in ["silu", "swish"]
         )


### PR DESCRIPTION
Credit to @matthieule, who contributed a significant amount to this solution.

`causal_con1d` takes an input tensor of `shape=[batch, channels, length]`. The strides of this tensor can take two different forms:
1. `strides=[channels*length, length, 1]`, which means that the input tensor is contiguous. This is represented inside `causal_conv1d` by `is_channels_last=False`
2. `strides=[length*channels, 1, channels]`, which means that the input tensor was created by rearranging a contiguous tensor of `shape=[batch, length, channels]` (`strides=[length*channels, channels, 1]`) to `shape=[batch, channels, length]`. This is represented inside `causal_conv1d` by `is_channels_last=True`. This is what `mamba_split_conv1d_scan_combined` normally uses.

PR [713](https://github.com/state-spaces/mamba/pull/713) addressed the error `causal_conv1d with channel last layout requires strides (x.stride(0) and x.stride(2)) to be multiples of 8`. It avoided the error by running `contiguous` on the tensor before passing it to `causal_conv1d`. This changed the tensor from `is_channels_last=True` to `is_channels_last==False`.

Subsequently, while training with packed sequences (`seq_idx != None`), we ran into the following error: `seq_idx is only supported for channel last layout`.

The error originally addressed by PR 713 was occurring because the tensor entering `mamba_split_conv1d_scan_combined` did not have a channels stride that was a multiple of 8, even though the channels dimension was a multiple of 8. In our model, this was due to upstream processing to support context parallel.

This current PR addresses both errors by checking if the incoming tensor has a channel stride that is a multiple of 8 and running `contiguous` on that tensor if not, before it's rearranged to `shape=[batch, channels, length]`. This both fixes the stride issue and ensures that the `is_channels_last=True` path is always taken through `causal_conv1d`. It is a more comprehensive and correct fix than PR 713.

These changes have been convergence-tested.