### PR TITLE
refactor: fold the dt softplus into the kernel on the non-fused Mamba2 path

### DIFF
--- a/mamba_ssm/modules/mamba2_simple.py
+++ b/mamba_ssm/modules/mamba2_simple.py
@@ -159,7 +159,6 @@ class Mamba2Simple(nn.Module):
             z, xBC, dt = torch.split(
                 zxbcdt, [self.d_inner, self.d_inner + 2 * self.ngroups * self.d_state, self.nheads], dim=-1
             )
-            dt = F.softplus(dt + self.dt_bias)  # (B, L, nheads)
             assert self.activation in ["silu", "swish"]
 
             # 1D Convolution
@@ -190,6 +189,8 @@ class Mamba2Simple(nn.Module):
                 z=None,
                 seq_idx=seq_idx,
                 initial_states=initial_states,
+                dt_bias=self.dt_bias,
+                dt_softplus=True,
                 **dt_limit_kwargs,
             )
             y = rearrange(y, "b l h p -> b l (h p)")


### PR DESCRIPTION
## What this is

**A refactor, not a bug fix.** The original description claimed `softplus` was applied twice on the non-fused path. That was wrong — see the discussion below. Retitled and rewritten to describe what the change actually does.

## The change

On the non-fused path, `Mamba2Simple.forward` applies the timestep transform in Python before calling the kernel:

```python
dt = F.softplus(dt + self.dt_bias)          # (B, L, nheads)
...
y = mamba_chunk_scan_combined(..., dt, ...)  # dt_bias=None, dt_softplus=False
```

The fused path a few lines above hands `self.dt_bias` straight to `mamba_split_conv1d_scan_combined` and lets the kernel do it. This makes the non-fused branch do the same:

```python
y = mamba_chunk_scan_combined(..., dt_bias=self.dt_bias, dt_softplus=True, **dt_limit_kwargs)
```

Net −1/+2 lines.

## Why it's equivalent

Ordering is preserved. `_chunk_cumsum_fwd` applies `dt_bias` and `softplus` before the `dt_limit` clamp, which is the same order as the current code (Python softplus, then `dt_limit` passed through to the same clamp). `dt_limit_kwargs` is unchanged either way.

## Why bother

- The two branches of the same `forward` currently factor the identical operation two different ways, which is what made the "double softplus" misreading easy in the first place.
- One fewer materialised `(B, L, nheads)` intermediate on the non-fused path.

## What I have not verified

I don't have a GPU to hand, so the Triton path is unexercised locally and the equivalence above is by inspection of `ssd_combined.py`, not by measurement. The backward pass in particular moves from PyTorch autograd through `F.softplus` to `_chunk_cumsum_bwd`'s `ddt_bias` computation. Both should be correct; only one of them is currently exercised from this call site.

If that's not worth the churn on a working path, I'm happy for this to be closed instead — it's a tidiness change, not a fix.
