### PR TITLE
ci: Free up containerd path

### DIFF
--- a/.github/workflows/_build_in_container.yml
+++ b/.github/workflows/_build_in_container.yml
@@ -53,7 +53,10 @@ jobs:
           build-mount-path: "/var/lib/"
 
       - name: Restore /var/lib/containerd/
-        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/* /var/lib"
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/containerd/* /var/lib/containerd"
+
+      - name: Restore /var/lib/docker/
+        run: sudo sh -c "mv ${GITHUB_WORKSPACE}/docker/docker/* /var/lib/docker"
 
       - name: Checkout source
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes a disk-out-of-space issue with our GH runners for building NGC PyT compatible wheels.