### PR TITLE
Fix dtype mismatch in _chunk_scan_bwd_dstates_kernel Triton backward

### DIFF
--- a/mamba_ssm/ops/triton/ssd_chunk_scan.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_scan.py
@@ -497,7 +497,7 @@ def _chunk_scan_bwd_dstates_kernel(
             seq_idx_k = tl.load(seq_idx_ptrs, mask=offs_k < chunk_size_limit - k, other=-1)
             scale_k = tl.where(seq_idx_k == seq_idx_prev, tl.exp(dA_cs_k), 0.0)
         dout = (dout * scale_k).to(dout_ptr.dtype.element_ty)
-        c = tl.load(c_ptrs, mask=(offs_k[:, None] < chunk_size_limit - k) & (offs_n[None, :] < dstate), other=0.0)
+        c = tl.load(c_ptrs, mask=(offs_k[:, None] < chunk_size_limit - k) & (offs_n[None, :] < dstate), other=0.0).to(dout_ptr.dtype.element_ty)
         acc += tl.dot(dout, c)
         dout_ptrs += BLOCK_SIZE_K * stride_dout_seqlen
         c_ptrs += BLOCK_SIZE_K * stride_c_seqlen


### PR DESCRIPTION
# Fix dtype mismatch in `_chunk_scan_bwd_dstates_kernel` Triton backward

## Summary

- Fixes #854  — `_chunk_scan_bwd_dstates_kernel` fails to compile with `bf16` inputs, causing a crash during the backward pass.
- Adds the missing `.to(dout_ptr.dtype.element_ty)` cast on the `c` tensor load, matching the established pattern used in every other backward kernel in the same file.

## Problem

In the inner loop of `_chunk_scan_bwd_dstates_kernel` (`ssd_chunk_scan.py`), `dout` is explicitly cast to the pointer dtype (`bf16` under autocast), but `c` is not. Because the `C` matrix is typically kept in `fp32`, `c` loads as `fp32`:

```python
dout = (dout * scale_k).to(dout_ptr.dtype.element_ty)  # → bf16
c = tl.load(c_ptrs, mask=..., other=0.0)                # stays fp32
acc += tl.dot(dout, c)                                   # bf16 × fp32 → CompilationError
```

This causes `tl.dot` to fail with `"Both operands must be same dtype"`, crashing the training loop via `ChunkScanFn.backward` during gradient computation.

## Fix

A simple one-line change to cast `c` to match `dout`'s element type before the dot product:

```diff
- c = tl.load(c_ptrs, mask=(offs_k[:, None] < chunk_size_limit - k) & (offs_n[None, :] < dstate), other=0.0)
+ c = tl.load(c_ptrs, mask=(offs_k[:, None] < chunk_size_limit - k) & (offs_n[None, :] < dstate), other=0.0).to(dout_ptr.dtype.element_ty)
```

This exactly matches the existing pattern in the same file:
- `_chunk_scan_bwd_dc_kernel`: `prev_states = prev_states.to(dout_ptrs.dtype.element_ty)`
- `_chunk_scan_bwd_dx_kernel`: `cb = cb.to(dout_ptr.dtype.element_ty)`
- `_chunk_scan_fwd_kernel`: `prev_states = prev_states.to(C_ptr.dtype.element_ty)`