### PR TITLE
Fix dtype mismatch in `mamba3_siso_bwd_kernel_dqkv` Triton kernel

### DIFF
--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_bwd.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_bwd.py
@@ -486,7 +486,7 @@ def mamba3_siso_bwd_kernel_dqkv(
         acc_dq = tl.dot(tl.trans(s_block).to(k_block.dtype), k_block)  # (CHUNK_SIZE, HEADDIM_QK)
 
         # Inter-chunk: gradient through states from previous chunks
-        acc_dq += tl.dot(do_block, ssm_states_block) * exp_da_cs[:, None]
+        acc_dq += tl.dot(do_block, ssm_states_block.to(do_block.dtype)) * exp_da_cs[:, None]
 
         dq_desc.store([chunk_start, 0], acc_dq)
 
@@ -563,7 +563,7 @@ def mamba3_siso_bwd_kernel_dqkv(
         # Compute dADT Gradient (Part 2): From Inter-chunk States
         # ============================================================
         # Gradient from Q @ States^T term
-        QS = tl.dot(q_block, tl.trans(ssm_states_block))  # (CHUNK_SIZE, HEADDIM_V)
+        QS = tl.dot(q_block, tl.trans(ssm_states_block.to(q_block.dtype)))  # (CHUNK_SIZE, HEADDIM_V)
         dM_rev_vector += tl.sum(QS * dO_reloaded, axis=1) * exp_da_cs  # (CHUNK_SIZE,)
 
         # ============================================================


### PR DESCRIPTION
## Summary
 
- Fixes #868  `mamba3_siso_bwd_kernel_dqkv` failing to compile with `bf16` and `fp32` inputs, causing a crash during the backward pass. Similar to #855 
- Adds the missing `.to()` casts on `ssm_states_block` in two `tl.dot` calls, matching the existing casting convention in the kernel.
 
## Problem
 
In `mamba3_siso_bwd_kernel_dqkv` (`mamba3_siso_bwd.py`), `do_block` and `q_block` are cast to `fp32`, but `ssm_states_block` retains the pointer's native dtype (`bf16` under autocast). Two `tl.dot` calls pass these mismatched operands directly:
 
```python
# dQ inter-chunk
acc_dq += tl.dot(do_block, ssm_states_block) * exp_da_cs[:, None]  # fp32 × bf16
 
# dADT Part 2
QS = tl.dot(q_block, tl.trans(ssm_states_block))  # fp32 × bf16
```
 
This causes `tl.dot` to fail with `"Both operands must be same dtype. Got fp32 and bf16"`, crashing the training loop via `mamba3_siso_combined.backward` during gradient computation.
 
## Fix
 
Two one-line changes to cast `ssm_states_block` to match the other operand's dtype before the dot product:
 
```diff
- acc_dq += tl.dot(do_block, ssm_states_block) * exp_da_cs[:, None]
+ acc_dq += tl.dot(do_block, ssm_states_block.to(do_block.dtype)) * exp_da_cs[:, None]
```
 
```diff
- QS = tl.dot(q_block, tl.trans(ssm_states_block))
+ QS = tl.dot(q_block, tl.trans(ssm_states_block).to(q_block.dtype))
```
 
This exactly matches the existing pattern in the same kernel:
 
- `tl.dot(v_block, d_ssm_states_acc.to(v_block.dtype))`
- `tl.dot(k_block, tl.trans(d_ssm_states_acc).to(k_block.dtype))`
- `tl.dot(tl.trans(dO_reloaded).to(q_block.dtype), q_block)`
- `tl.dot(dp_t_block.to(q_block.dtype), q_block)`
- `tl.dot(p_t_block.to(do_block.dtype), do_block)`
 