### PR TITLE
fix: add sm_89 (Ada Lovelace) gencode and fix Python/dep versions

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [
     { name = "Tri Dao", email = "tri@tridao.me" },
     { name = "Albert Gu", email = "agu@cs.cmu.edu" }
 ]
-requires-python = ">= 3.9"
+requires-python = ">= 3.10"
 dynamic = ["version"]
 license = { file = "LICENSE" }  # Include a LICENSE file in your repo
 keywords = ["cuda", "pytorch", "state-space model"]
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
     "torch",
     "tilelang==0.1.8",
-    "quack-kernels==0.3.1",
+    "quack-kernels==0.3.4",
     "triton>=3.5.0",
     "ninja",
     "einops",

--- a/setup.py
+++ b/setup.py
@@ -186,6 +186,8 @@ if not SKIP_CUDA_BUILD:
         cc_flag.append("arch=compute_87,code=sm_87")
         if bare_metal_version >= Version("11.8"):
             cc_flag.append("-gencode")
+            cc_flag.append("arch=compute_89,code=sm_89")
+            cc_flag.append("-gencode")
             cc_flag.append("arch=compute_90,code=sm_90")
         if bare_metal_version >= Version("12.8"):
             cc_flag.append("-gencode")


### PR DESCRIPTION
## Summary

- Add `-gencode arch=compute_89,code=sm_89` for RTX 40xx (Ada Lovelace) GPUs under CUDA >= 11.8
- Bump `requires-python` to `>=3.10` (`quack-kernels` requires it)
- Sync `quack-kernels` to 0.3.4 to match `setup.py`

## Context

RTX 40xx GPUs (RTX 4060/4070/4080/4090) use Ada Lovelace architecture with compute capability 8.9 (sm_89). Without this gencode flag, CUDA kernels fall back to sm_87 instead of native sm_89 compilation.

CUDA 11.8+ supports sm_89, so the flag is added in the same block as sm_90.

## Test plan
- [x] Built mamba-ssm from source on RTX 4080 Laptop GPU with CUDA 12.8
- [x] Verified `selective_scan_cuda` extension loads correctly with sm_89
- [x] Ran pretrained model inference (mamba-130m, mamba-370m) successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)