### PR TITLE
Mamba-3 SISO: always typecast derived input tensors to bf16

### DIFF
--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
@@ -387,6 +387,17 @@ def mamba3_siso_combined(
     all_states_absent = (Input_SSM_State is None) and (Input_K_State is None) and (Input_V_State is None) and (Input_Angle_State is None)
     assert all_states_present or all_states_absent, "Input states must be provided together or all be None."
 
+    # Typecast all derived tensors to bf16.
+    # ADT, DT should be in fp32 for stability
+    # Q_bias, K_bias, D should be in fp32 as they are model parameters
+    Q = Q.to(torch.bfloat16)
+    K = K.to(torch.bfloat16)
+    V = V.to(torch.bfloat16)
+    Trap = Trap.to(torch.bfloat16)
+    Angles = Angles.to(torch.bfloat16)
+    if Z is not None:
+        Z = Z.to(torch.bfloat16)
+
     return _Mamba3Function.apply(
         Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, D, Z,
         Input_Angle_State, Input_SSM_State, Input_K_State, Input_V_State, cu_seqlens, chunk_size, return_final_states


### PR DESCRIPTION
Fix for issue: https://github.com/state-spaces/mamba/issues/868

Mamba-3 typecasts all derived input tensors (Q,K,V,Z,Angles,Trap) to bf16 for processing.