### PR TITLE
Revert "Fix dtype mismatch in `mamba3_siso_bwd_kernel_dqkv` Triton kernel"

### DIFF
--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_bwd.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_bwd.py
@@ -486,7 +486,7 @@ def mamba3_siso_bwd_kernel_dqkv(
         acc_dq = tl.dot(tl.trans(s_block).to(k_block.dtype), k_block)  # (CHUNK_SIZE, HEADDIM_QK)
 
         # Inter-chunk: gradient through states from previous chunks
-        acc_dq += tl.dot(do_block, ssm_states_block.to(do_block.dtype)) * exp_da_cs[:, None]
+        acc_dq += tl.dot(do_block, ssm_states_block) * exp_da_cs[:, None]
 
         dq_desc.store([chunk_start, 0], acc_dq)
 
@@ -563,7 +563,7 @@ def mamba3_siso_bwd_kernel_dqkv(
         # Compute dADT Gradient (Part 2): From Inter-chunk States
         # ============================================================
         # Gradient from Q @ States^T term
-        QS = tl.dot(q_block, tl.trans(ssm_states_block.to(q_block.dtype)))  # (CHUNK_SIZE, HEADDIM_V)
+        QS = tl.dot(q_block, tl.trans(ssm_states_block))  # (CHUNK_SIZE, HEADDIM_V)
         dM_rev_vector += tl.sum(QS * dO_reloaded, axis=1) * exp_da_cs  # (CHUNK_SIZE,)
 
         # ============================================================


### PR DESCRIPTION
Reverts state-spaces/mamba#869