### PR TITLE
Feat: varlen support for Mamba-3

### DIFF
--- a/mamba_ssm/modules/mamba3.py
+++ b/mamba_ssm/modules/mamba3.py
@@ -9,13 +9,20 @@ import torch.nn.functional as F
 
 from mamba_ssm.ops.triton.layernorm_gated import RMSNorm as RMSNormGated
 
-from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo import mamba3_mimo as mamba3_mimo_combined
+try:
+    from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo import mamba3_mimo as mamba3_mimo_combined
+except ImportError:
+    mamba3_mimo_combined = None
+
 from mamba_ssm.ops.triton.angle_cumsum import angle_dt
 from mamba_ssm.ops.triton.mamba3.mamba3_siso_combined import mamba3_siso_combined
 
 from mamba_ssm.ops.triton.mamba3.mamba3_mimo_rotary_step import apply_rotary_qk_inference_fwd
 
-from mamba_ssm.ops.cute.mamba3.mamba3_step_fn import mamba3_step_fn
+try:
+    from mamba_ssm.ops.cute.mamba3.mamba3_step_fn import mamba3_step_fn
+except ImportError:    
+    mamba3_step_fn = None
 
 class Mamba3(nn.Module):
     def __init__(
@@ -59,6 +66,8 @@ class Mamba3(nn.Module):
         self.mimo_rank = mimo_rank
         if not self.is_mimo:
             self.mimo_rank = 1
+        else:
+            assert mamba3_mimo_combined is not None, "Fails to import Mamba-3 MIMO kernels. Please ensure you installed the necessary dependencies, such as TileLang."
 
         self.d_inner = int(self.expand * self.d_model)
         assert self.d_inner % self.headdim == 0
@@ -298,6 +307,7 @@ class Mamba3(nn.Module):
             nxt_k_state: (batch, R, nheads, d_state), where R = mimo_rank (R=1 if not MIMO)
             nxt_v_state: (batch, nheads, headdim)
         """
+        assert mamba3_step_fn is not None, "Cute Mamba-3 step function is not available. Please ensure you installed the necessary dependencies, such as nvidia-cutlass-dsl and quack-kernels."
 
         # in_proj
         zxBCdt = self.in_proj(u)

--- a/mamba_ssm/modules/mamba3.py
+++ b/mamba_ssm/modules/mamba3.py
@@ -139,8 +139,6 @@ class Mamba3(nn.Module):
         Returns: same shape as u
         """
         batch, seqlen, dim = u.shape
-        if cu_seqlens is not None:
-            raise NotImplementedError("Currently does not support varlen in Mamba-3 (MIMO).")
 
         angle_dt_state, ssm_state, k_state, v_state  = None, None, None, None
         if inference_params is not None:
@@ -205,6 +203,7 @@ class Mamba3(nn.Module):
                 rotary_dim_divisor=self.rotary_dim_divisor,
                 dtype=x.dtype,
                 return_state=ssm_state is not None,
+                cu_seqlens=cu_seqlens,
             )
             if ssm_state is not None:
                 y, last_angle, last_state, last_k, last_v, *rest = y
@@ -236,6 +235,7 @@ class Mamba3(nn.Module):
                 chunk_size=self.chunk_size,
                 Input_States=None,
                 return_final_states=ssm_state is not None,
+                cu_seqlens=cu_seqlens,
             )
             if ssm_state is not None:
                 y, last_angle, last_state, last_k, last_v, *rest = y

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
@@ -13,9 +13,14 @@ import torch
 from torch import Tensor
 
 # Import kernels
+from mamba_ssm.ops.triton.mamba3.mamba3_mimo_utils import compute_dacs_segsum_triton, compute_dacs_segsum_triton_varlen
+
 from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_fwd import mamba_mimo_forward
-from mamba_ssm.ops.triton.mamba3.mamba3_mimo_utils import compute_dacs_segsum_triton
+from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_fwd_varlen import mamba_mimo_forward_varlen
+
 from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_bwd import mamba_mimo_bwd_combined
+from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_bwd_varlen import mamba_mimo_bwd_combined_varlen
+
 
 # =============================================================================
 # Autograd Function
@@ -45,6 +50,7 @@ class _Mamba3Function(torch.autograd.Function):
         rotary_dim_divisor: int,
         dtype: torch.dtype,
         return_state: bool,
+        cu_seqlens: Optional[Tensor],
     ) -> Tensor | Tuple[Tensor, Tuple]:
         """Forward pass: call Triton/Tilelang kernel and save tensors for backward."""
         ctx.chunk_size = chunk_size
@@ -57,21 +63,35 @@ class _Mamba3Function(torch.autograd.Function):
             )
         )
 
-        DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton(ADT, chunk_size)
-        Out, Final_SSM_State, Final_K = mamba_mimo_forward(
-            Q, K, V, Q_bias, K_bias, MIMO_V, MIMO_Out,
-            Z, D, MIMO_Z, Angles,
-            DA_CS, DA_CS_REV, DT, Trap, Segsum, 
-            return_state=return_state,
-            chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor,
-            dtype=dtype,
-        )
+        if cu_seqlens is not None:
+            DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton_varlen(ADT, chunk_size, cu_seqlens=cu_seqlens)
+            Out, Final_SSM_State, Final_K = mamba_mimo_forward_varlen(
+                Q, K, V, Q_bias, K_bias, MIMO_V, MIMO_Out,
+                Z, D, MIMO_Z, Angles,
+                DA_CS, DA_CS_REV, DT, Trap, Segsum, 
+                cu_seqlens=cu_seqlens,
+                return_state=return_state,
+                chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor,
+                dtype=dtype,
+            )
+
+        else:
+            DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton(ADT, chunk_size)
+            Out, Final_SSM_State, Final_K = mamba_mimo_forward(
+                Q, K, V, Q_bias, K_bias, MIMO_V, MIMO_Out,
+                Z, D, MIMO_Z, Angles,
+                DA_CS, DA_CS_REV, DT, Trap, Segsum, 
+                return_state=return_state,
+                chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor,
+                dtype=dtype,
+            )
 
         ctx.chunk_size = chunk_size
         ctx.save_for_backward(
             Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles,
             D, Z,
             MIMO_V, MIMO_Out, MIMO_Z,
+            cu_seqlens,
         )
 
         if not return_state:
@@ -98,35 +118,64 @@ class _Mamba3Function(torch.autograd.Function):
         (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles,
             D, Z,
             MIMO_V, MIMO_Out, MIMO_Z,
+            cu_seqlens
             ) = ctx.saved_tensors
     
-        DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton(ADT, ctx.chunk_size)
-
-        (dQ, dK, dV, 
-            dADT, dDT, dTrap, dQ_bias, dK_bias,
-            dMIMO_V, dMIMO_Z, dMIMO_Out, dAngles, 
-            dD, dZ) = mamba_mimo_bwd_combined(
-                dout,
-                Q, 
-                K, 
-                V, 
-                Q_bias,
-                K_bias,
-                MIMO_V, 
-                MIMO_Out,
-                Z,
-                MIMO_Z,
-                Angles,
-                DA_CS,
-                DA_CS_REV,
-                DT,
-                Trap,
-                D,
-                Segsum,
-                ctx.chunk_size,
-                ctx.rotary_dim_divisor,
-                ctx.dtype,
-            )
+        if cu_seqlens is not None:
+            DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton_varlen(ADT, ctx.chunk_size, cu_seqlens=cu_seqlens)
+            (dQ, dK, dV, 
+                dADT, dDT, dTrap, dQ_bias, dK_bias,
+                dMIMO_V, dMIMO_Z, dMIMO_Out, dAngles, 
+                dD, dZ) = mamba_mimo_bwd_combined_varlen(
+                    dout,
+                    Q, 
+                    K, 
+                    V, 
+                    Q_bias,
+                    K_bias,
+                    MIMO_V, 
+                    MIMO_Out,
+                    Z,
+                    MIMO_Z,
+                    Angles,
+                    DA_CS,
+                    DA_CS_REV,
+                    DT,
+                    Trap,
+                    D,
+                    Segsum,
+                    ctx.chunk_size,
+                    ctx.rotary_dim_divisor,
+                    ctx.dtype,
+                    cu_seqlens=cu_seqlens,
+                )
+        else:
+            DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton(ADT, ctx.chunk_size)
+            (dQ, dK, dV, 
+                dADT, dDT, dTrap, dQ_bias, dK_bias,
+                dMIMO_V, dMIMO_Z, dMIMO_Out, dAngles, 
+                dD, dZ) = mamba_mimo_bwd_combined(
+                    dout,
+                    Q, 
+                    K, 
+                    V, 
+                    Q_bias,
+                    K_bias,
+                    MIMO_V, 
+                    MIMO_Out,
+                    Z,
+                    MIMO_Z,
+                    Angles,
+                    DA_CS,
+                    DA_CS_REV,
+                    DT,
+                    Trap,
+                    D,
+                    Segsum,
+                    ctx.chunk_size,
+                    ctx.rotary_dim_divisor,
+                    ctx.dtype,
+                )
 
         return (
             dQ,
@@ -143,7 +192,7 @@ class _Mamba3Function(torch.autograd.Function):
             dAngles,
             dD,
             dZ,
-            None, None, None, None,
+            None, None, None, None, None,
         )
 
 
@@ -170,6 +219,7 @@ def mamba3_mimo(
     rotary_dim_divisor: int,
     dtype: torch.dtype,
     return_state: bool = False,
+    cu_seqlens: Optional[Tensor] = None,
 ) -> Tensor | Tuple[Tensor, Tuple]:
     """Mamba-3 attention with Tilelang kernels and automatic differentiation.
     
@@ -190,21 +240,29 @@ def mamba3_mimo(
         Z: Optional gating tensor (batch, seqlen, nheads, headdim_v)
         chunk_size: Chunk size for state computation (default: 64//R)  
         rotary_dim_divisor: Divisor for rotary embedding dimensions (default: 4, meaning angles have 1/4 of headdim_qk)
-    
+        dtype: Data type for lower-precision computation (e.g., torch.bfloat16)
+        return_state: Whether to return final state for autoregressive decoding (default: False)
+        cu_seqlens: Optional tensor of cumulative sequence lengths for variable-length sequences. 
+         If provided, should be a tensor of shape (num_seq + 1,) where cu_seqlens[i] is 
+         the cumulative sequence length up to sequence i. This is used for efficient processing of 
+         variable-length sequences in the kernel.
+              
     Returns:
         output: (batch, seqlen, nheads, headdim_v) if MIMO_Out is not None
                 (batch, seqlen, mimo_rank, nheads, headdim_v) if MIMO_Out is None
         final_state: Tuple of tensors representing the running Angle sum, final SSM state, final K, and final V for autoregressive decoding. Only returned if return_state=True.
 
     NOTE: The kernel is most optimized for seqlen: 2048, nheads_qk: 1, nheads: 32
-    headdim_qk: 128, headdim_v: 64, mimo_rank: 4, and chunk_size: 16. On H100.
+     headdim_qk: 128, headdim_v: 64, mimo_rank: 4, and chunk_size: 16. On H100.
     NOTE: The code is still prone to smem over-allocation and Tilelang compilation error
-    once headdim_qk, headdim_v, mimo_rank, chunk_size, or hardware type deviate from the combinations tested.
+     once headdim_qk, headdim_v, mimo_rank, chunk_size, or hardware type deviate from the combinations tested.
     NOTE: Chunk size of 64/R is recommended, where R is the MIMO rank. However, it may be necessary to reduce chunk size
-    in case of smem over-allocation, which can occur with larger headdim_qk, headdim_v, or mimo_rank values.
-    NOTE: Currently final_state is currently intended to be a non-differentiable side output. In particular,
-    loss = f(output) is fine, but loss = f(output, final_state) will not work properly since the backward does not compute gradients for final_state components.
-
+     in case of smem over-allocation, which can occur with larger headdim_qk, headdim_v, or mimo_rank values.
+    NOTE: Currently final_state is intended to be a non-differentiable side output. In particular,
+     loss = f(output) is fine, but loss = f(output, final_state) will not work properly since the backward does not compute gradients for final_state components.
+    NOTE: Currently we have a separate set of kernels for variable-length sequences with cu_seqlens input, 
+     which can be more efficient than padding to max length. However, the variable-length kernels 
+     incur noticeable overhead, so we have separate scripts for the non-varlen case.
 
     """
     
@@ -248,4 +306,5 @@ def mamba3_mimo(
         rotary_dim_divisor,
         dtype,
         return_state,
+        cu_seqlens,
     )

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
@@ -6,6 +6,7 @@ Copyright (c) 2026, Dao AI Lab, Goombalab
 
 """
 
+import math
 import torch
 import tilelang
 import tilelang.language as T
@@ -59,6 +60,7 @@ def mamba_mimo_bwd_fwd(
     accum_dtype = 'float32'
 
     nchunks = tilelang.cdiv(S, chunk_size)
+    tail_len = S % chunk_size
     fused_chunk_size = chunk_size * R
 
     if reduceO:
@@ -469,7 +471,10 @@ def mamba_mimo_bwd_fwd(
 
                 # DA_CS(last) applies chunk-level decay to the carried state.
                 da_cs_sum = T.alloc_var(T.float32)
-                T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum)
+                if tail_len > 0 and i == nchunks - 1:
+                    T.copy(DA_CS[i_b, i_h, S - 1], da_cs_sum)
+                else:
+                    T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum)
                 for n, p in T.Parallel(N, P):
                     states_frag[n, p] *= T.exp(da_cs_sum)
                 T.gemm(k_state_frag, PsiV_shared, states_frag, transpose_A=True, clear_accum=False)
@@ -518,6 +523,7 @@ def mamba_mimo_bwd_bwd(
     accum_dtype = 'float32'
 
     nchunks = tilelang.cdiv(S, chunk_size)
+    tail_len = S % chunk_size
     fused_chunk_size = chunk_size * R
 
     if reduceO:
@@ -996,7 +1002,10 @@ def mamba_mimo_bwd_bwd(
                 ddA_state_passing = T.alloc_fragment([1], T.float32)
                 ddA_state_passing_prereduce_frag = T.alloc_fragment([N, P], T.float32)
                 da_cs_sum = T.alloc_var(T.float32)
-                T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum)
+                if tail_len > 0 and chunk_idx == nchunks - 1:
+                    T.copy(DA_CS[i_b, i_h, S - 1], da_cs_sum)
+                else:
+                    T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum)
                 for n, p in T.Parallel(N, P):
                     ddA_state_passing_prereduce_frag[n, p] = (
                         states_frag[n, p] 
@@ -1123,7 +1132,10 @@ def mamba_mimo_bwd_bwd(
 
                 # --- Update Reverse-Passed State Gradient ---
                 da_cs_sum_dstates = T.alloc_var(T.float32)
-                T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum_dstates)
+                if tail_len > 0 and chunk_idx == nchunks - 1:
+                    T.copy(DA_CS[i_b, i_h, S - 1], da_cs_sum_dstates)
+                else:
+                    T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum_dstates)
                 for n, p in T.Parallel(N, P):
                     dstates_frag[n, p] *= T.exp(da_cs_sum_dstates)
                 dPhiO_scaled_frag = T.alloc_fragment([fused_chunk_size, P], dtype)
@@ -1175,7 +1187,7 @@ def mamba_mimo_bwd_combined(
     reduceO = mimo_o is not None
 
     dmimo_o = torch.empty([B, H, R, P], dtype=mimo_v.dtype, device=mimo_v.device) if reduceO else None
-    states = torch.empty([B, H, S//chunk_size, N, P], dtype=v.dtype, device=v.device) # NOTE: states dtype is set to v.dtype
+    states = torch.empty([B, H, math.ceil(S/chunk_size), N, P], dtype=v.dtype, device=v.device) # NOTE: states dtype is set to v.dtype
     
     if z is not None:
         dz_tilelang = torch.empty_like(v)
@@ -1236,7 +1248,7 @@ def mamba_mimo_bwd_combined(
     dfactor = torch.zeros([B, H, S], dtype=torch.float32, device=trap.device)
     dgamma_diag = torch.zeros([B, H, S], dtype=torch.float32, device=trap.device)
     ddA = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
-    dSSdA = torch.zeros([B, H, S//chunk_size, chunk_size, chunk_size], dtype=torch.float32, device=dt.device)
+    dSSdA = torch.zeros([B, H, math.ceil(S/chunk_size), chunk_size, chunk_size], dtype=torch.float32, device=dt.device)
     ddA_cs_rev = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
     ddA_cs = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
     

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
@@ -24,8 +24,8 @@ The backward pass is split into two TileLang kernels (same as non-varlen):
        DMIMO_V, DD, DANGLES, DDA, DFACTOR, DGAMMA_DIAG, …).
 
 Public API:
-    tilelang_bwd_combined_varlen(..., cu_seqlens=None) — combined backward;
-        falls back to the non-varlen ``tilelang_bwd_combined`` when
+    mamba_mimo_bwd_combined_varlen(..., cu_seqlens=None) — combined backward;
+        falls back to the non-varlen ``mamba_mimo_bwd_combined`` when
         cu_seqlens is None.
 
 Copyright (c) 2026, Dao AI Lab, Goombalab

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
@@ -1,0 +1,1389 @@
+"""
+Tilelang implementation of the Mamba3 backward kernels with MIMO support
+and variable-length sequence (varlen) support.
+
+This is the varlen counterpart of ``mamba3_mimo_bwd.py``.  The two files
+share the same mathematical kernels; the differences mirror those in the
+forward file (see ``mamba3_mimo_fwd_varlen.py``):
+
+* **NS parameter** — number of packed sequences; activates the extra
+  ``i_ns`` grid dimension.
+* **CU_SEQLENS tensor** — int32 prefix-sum array of shape ``[NS+1]``.
+* **max_nchunks** — ``(S // chunk_size) + NS``.
+* **DMIMO_O / DMIMO_Z / DMIMO_V / DD shapes** — ``[B, H, NS, R, P]`` /
+  ``[B, H, NS]``, vs. ``[B, H, R, P]`` / ``[B, H]`` in the non-varlen
+  version.  The NS dimension is summed-reduced in the wrapper before
+  returning to the caller.
+
+The backward pass is split into two TileLang kernels (same as non-varlen):
+    1. ``mamba_mimo_bwd_fwd_varlen`` — bwd-fwd pass: re-runs the
+       forward recurrence, saves STATES and QK_DOT for the bwd-bwd pass,
+       and computes DMIMO_O / DMIMO_Z.
+    2. ``mamba_mimo_bwd_bwd_varlen`` — bwd-bwd pass: uses the cached
+       STATES and QK_DOT to compute all remaining gradients (DQ, DK, DV,
+       DMIMO_V, DD, DANGLES, DDA, DFACTOR, DGAMMA_DIAG, …).
+
+Public API:
+    tilelang_bwd_combined_varlen(..., cu_seqlens=None) — combined backward;
+        falls back to the non-varlen ``tilelang_bwd_combined`` when
+        cu_seqlens is None.
+
+Copyright (c) 2026, Dao AI Lab, Goombalab
+"""
+
+import torch
+import tilelang
+import tilelang.language as T
+from triton.testing import do_bench
+
+import argparse
+from typing import Optional, Tuple
+
+from mamba_ssm.ops.triton.mamba3.mamba3_mimo_utils import bwd_dadt_fused_triton_varlen, bwd_dtrap_ddt_triton_varlen
+from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_bwd import mamba_mimo_bwd_combined
+
+# def get_configs():
+#     iter_params = dict(num_stages=[0, 1, 2, 3], threads=[128, 256, 512])
+#     # iter_params = dict(num_stages=[2], threads=[128])
+#     return [dict(zip(iter_params, values)) for values in itertools.product(*iter_params.values())]
+
+# @autotune(
+#     configs=get_configs(),
+#     warmup=3,
+#     rep=20,
+# )
+@tilelang.jit(
+    out_idx=[],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+    })
+def mamba_mimo_bwd_fwd(
+    B,
+    S,
+    H,
+    G,
+    N,
+    P,
+    R,
+    hasZ,
+    hasD,
+    reduceO,
+    NS: int = 1,
+    chunk_size: int = 16,
+    rotary_dim_divisor: int = 4,
+    dtype: str = 'float16',
+    threads: int = 128,
+    num_stages: int = 0,
+) -> torch.Tensor:
+    """
+    TileLang kernel factory for the varlen Mamba3 bwd-fwd pass.
+
+    The bwd-fwd pass re-runs the forward recurrence in *forward* chunk order
+    to (a) cache the per-chunk recurrent STATES for use by the bwd-bwd pass,
+    (b) cache QK_DOT (per-step Q·K diagonal blocks), and (c) accumulate
+    DMIMO_O and DMIMO_Z.
+
+    Varlen additions vs. ``mamba_mimo_bwd_fwd`` in
+    ``mamba3_mimo_bwd.py``:
+
+    * Grid: ``T.Kernel(H, NS, B)`` — extra ``i_ns`` dimension for packed
+      sequences.
+    * Per-sequence bounds are derived from ``CU_SEQLENS[i_ns]``.
+    * DMIMO_O / DMIMO_Z shape: ``[B, H, NS, R, P]`` (extra NS dim).
+    * STATES shape: ``[B, H, max_nchunks, N, P]`` with
+      ``max_nchunks = (S // chunk_size) + NS``.
+    """
+    accum_dtype = 'float32'
+    max_nchunks = (S // chunk_size) + NS
+    fused_chunk_size = chunk_size * R
+
+    if reduceO:
+        DOUT_shape = (B, S, H, P)
+    else:
+        DOUT_shape = (B, S, R, H, P)
+
+    @T.prim_func
+    def mamba_mimo_bwd_fwd_kernel(
+            DOUT: T.Tensor(DOUT_shape, dtype),  # type: ignore
+            Q: T.Tensor([B, S, R, G, N], dtype),  # type: ignore
+            K: T.Tensor([B, S, R, G, N], dtype),  # type: ignore
+            V: T.Tensor([B, S, H, P], dtype),  # type: ignore
+            Q_BIAS: T.Tensor([H, R, N], T.float32),  # type: ignore
+            K_BIAS: T.Tensor([H, R, N], T.float32),  # type: ignore
+            MIMO_V: T.Tensor([H, R, P], T.float32),  # type: ignore
+            MIMO_O: T.Tensor([H, R, P], T.float32),  # type: ignore
+            DMIMO_O: T.Tensor([B, H, NS, R, P], T.float32),  # type: ignore
+            STATES: T.Tensor([B, H, max_nchunks, N, P], dtype),  # type: ignore
+            Z: T.Tensor([B, S, H, P], dtype),  # type: ignore
+            MIMO_Z: T.Tensor([H, R, P], T.float32),  # type: ignore
+            DZ: T.Tensor([B, S, H, P], dtype),  # type: ignore
+            DMIMO_Z: T.Tensor([B, H, NS, R, P], T.float32),  # type: ignore
+            ANGLES: T.Tensor([B, S, H, N // rotary_dim_divisor], T.float32),  # type: ignore
+            DA_CS: T.Tensor([B, H, S], T.float32),  # type: ignore
+            DA_CS_REV: T.Tensor([B, H, S], T.float32),  # type: ignore
+            DT: T.Tensor([B, H, S], T.float32),  # type: ignore
+            TRAP: T.Tensor([B, H, S], dtype),  # type: ignore
+            D: T.Tensor([H], T.float32),  # type: ignore
+            QK_DOT: T.Tensor([B, H, S, R, R], dtype),  # type: ignore
+            SEGSUM: T.Tensor([B, H, max_nchunks, chunk_size, chunk_size], T.float32),  # type: ignore
+            CU_SEQLENS: T.Tensor([NS + 1], dtype=T.int32),  # type: ignore
+            ):
+        """
+        Varlen bwd-fwd kernel: re-runs the forward recurrence per sequence.
+
+        Inputs:
+            - DOUT: upstream gradient.
+            - Q, K, V: packed activations.
+            - Q_BIAS, K_BIAS, MIMO_V, MIMO_O, MIMO_Z: projection params.
+            - Z, D: optional gating / skip-connection tensors.
+            - ANGLES: rotary angles.
+            - DA_CS, DA_CS_REV, DT, TRAP, SEGSUM: discretization tensors.
+            - CU_SEQLENS: int32 prefix-sum of per-sequence lengths,
+              shape ``[NS+1]``.
+
+        Outputs (written in place):
+            - DMIMO_O: gradient of the Phi projection, shape
+              ``[B, H, NS, R, P]`` (sum-reduced over NS by the wrapper).
+            - DMIMO_Z: gradient of the Zeta projection, same shape.
+            - STATES: per-chunk recurrent states cached for the bwd-bwd
+              pass, shape ``[B, H, max_nchunks, N, P]``.
+            - QK_DOT: per-step Q·K diagonal blocks, shape
+              ``[B, H, S, R, R]``.
+            - DZ: gradient of Z (if hasZ).
+        """
+
+        with T.Kernel(H, NS, B, threads=threads) as (i_h, i_ns, i_b):
+            i_h_qk = i_h // (H // G)
+
+            q_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            k_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            PsiV_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+            qs_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+            o_shared = T.alloc_shared([chunk_size, P], dtype)
+            v_shared = T.alloc_shared([chunk_size, P], dtype)
+            states_accum_cast_shared = T.alloc_shared([N, P], dtype)
+            qk_dot_full_shared = T.alloc_shared([fused_chunk_size, fused_chunk_size], dtype)
+
+            if reduceO:
+                dPhi_shared = T.alloc_shared([R, P], accum_dtype)
+                T.clear(dPhi_shared)
+
+            dout_shared = T.alloc_shared([chunk_size, P], dtype)
+            z_shared = T.alloc_shared([chunk_size, P], dtype)
+            dZeta_shared = T.alloc_shared([R, P], accum_dtype)
+            T.clear(dZeta_shared)
+
+            T.annotate_layout({
+                q_shared: tilelang.layout.make_swizzled_layout(q_shared),
+                k_shared: tilelang.layout.make_swizzled_layout(k_shared),
+                PsiV_shared: tilelang.layout.make_swizzled_layout(PsiV_shared),
+                qs_shared: tilelang.layout.make_swizzled_layout(qs_shared),
+                o_shared: tilelang.layout.make_swizzled_layout(o_shared),
+                states_accum_cast_shared: tilelang.layout.make_swizzled_layout(states_accum_cast_shared),
+                qk_dot_full_shared: tilelang.layout.make_swizzled_layout(qk_dot_full_shared),
+                dout_shared: tilelang.layout.make_swizzled_layout(dout_shared),
+                z_shared: tilelang.layout.make_swizzled_layout(z_shared),
+            })
+            T.use_swizzle(10, "row")
+            T.no_set_max_nreg()
+
+            states_frag = T.alloc_fragment([N, P], accum_dtype)
+            T.clear(states_frag)
+
+            if reduceO:
+                phi_frag_intrachunk = T.alloc_fragment([R, P], dtype=dtype)
+                T.copy(MIMO_O[i_h, :, :], phi_frag_intrachunk)
+            Psi_frag = T.alloc_fragment([R, P], dtype)
+            T.copy(MIMO_V[i_h, :, :], Psi_frag)
+
+            q_bias_frag = T.alloc_fragment([R, N], dtype)
+            k_bias_frag = T.alloc_fragment([R, N], dtype)
+            T.copy(Q_BIAS[i_h, :, :], q_bias_frag)
+            T.copy(K_BIAS[i_h, :, :], k_bias_frag)
+
+            # --- Per-sequence bounds ---
+            start_seq_ind = T.alloc_var(T.int32)
+            start_chunk_ind = T.alloc_var(T.int32)
+            seq_len = T.alloc_var(T.int32)
+            seq_end = T.alloc_var(T.int32)
+            full_nchunks = T.alloc_var(T.int32)
+            tail_len = T.alloc_var(T.int32)
+            if NS > 1:
+                start_seq_ind = CU_SEQLENS[i_ns]
+                start_chunk_ind = (start_seq_ind // chunk_size) + i_ns
+                seq_len = CU_SEQLENS[i_ns + 1] - CU_SEQLENS[i_ns]
+                seq_end = start_seq_ind + seq_len
+                full_nchunks = seq_len // chunk_size
+                tail_len = seq_len % chunk_size
+            else:
+                start_seq_ind = 0
+                start_chunk_ind = 0
+                seq_len = S
+                seq_end = S
+                full_nchunks = S // chunk_size
+                tail_len = S % chunk_size
+            if tail_len > 0:
+                full_nchunks += 1
+
+            for i in T.Pipelined(0, full_nchunks, num_stages=num_stages):
+                chunk_start = start_seq_ind + i * chunk_size
+                fused_chunk_start = chunk_start * R
+                global_chunk_idx = start_chunk_ind + i
+                eff_tail = T.alloc_var(T.int32)
+                eff_tail = chunk_size
+                if i == full_nchunks - 1:
+                    if tail_len > 0:
+                        eff_tail = tail_len
+                da_cs_end_idx = T.alloc_var(T.int32)
+                da_cs_end_idx = chunk_start + chunk_size - 1
+                if eff_tail < chunk_size:
+                    da_cs_end_idx = seq_end - 1
+
+                # --- Discretization Factors ---
+                trap_shifted_frag = T.alloc_fragment([chunk_size], T.float32)
+                dt_shifted_frag = T.alloc_fragment([chunk_size], dtype)
+                shifted_gamma_frag = T.alloc_fragment([chunk_size], dtype)
+                if i == full_nchunks - 1:
+                    # Last chunk: shifted positions may exceed seq_end.
+                    for cs in T.Parallel(chunk_size):
+                        trap_shifted_frag[cs] = T.if_then_else(
+                            cs + 1 < eff_tail,
+                            TRAP[i_b, i_h, chunk_start + cs + 1], 0.0)
+                        dt_shifted_frag[cs] = T.if_then_else(
+                            cs + 1 < eff_tail,
+                            DT[i_b, i_h, chunk_start + cs + 1], 0.0)
+                    for cs in T.Parallel(chunk_size):
+                        shifted_gamma_frag[cs] = T.if_then_else(
+                            cs + 1 < eff_tail,
+                            dt_shifted_frag[cs] * (T.sigmoid(-trap_shifted_frag[cs])), 0.0)
+                else:
+                    # Non-last chunk: chunk_start+1 .. chunk_start+chunk_size are all in bounds.
+                    T.copy(TRAP[i_b, i_h, chunk_start + 1:chunk_start + 1 + chunk_size], trap_shifted_frag)
+                    T.copy(DT[i_b, i_h, chunk_start + 1:chunk_start + 1 + chunk_size], dt_shifted_frag)
+                    for cs in T.Parallel(chunk_size):
+                        shifted_gamma_frag[cs] = dt_shifted_frag[cs] * (T.sigmoid(-trap_shifted_frag[cs]))
+                shifted_gamma_shared = T.alloc_shared([chunk_size], dtype)
+                T.copy(shifted_gamma_frag, shifted_gamma_shared)
+
+                trap_frag = T.alloc_fragment([chunk_size], T.float32)
+                T.copy(TRAP[i_b, i_h, chunk_start:chunk_start + chunk_size], trap_frag)
+                dt_frag = T.alloc_fragment([chunk_size], dtype)
+                T.copy(DT[i_b, i_h, chunk_start:chunk_start + chunk_size], dt_frag)
+                gamma_frag = T.alloc_fragment([chunk_size], T.float32)
+                for cs in T.Parallel(chunk_size):
+                    gamma_frag[cs] = dt_frag[cs] * T.sigmoid(trap_frag[cs])
+                trap_scale_frag = T.alloc_fragment([chunk_size], dtype)
+                for cs in T.Parallel(chunk_size):
+                    trap_scale_frag[cs] = gamma_frag[cs] + shifted_gamma_shared[cs]
+                trap_scale_shared = T.alloc_shared([chunk_size], dtype)
+                T.copy(trap_scale_frag, trap_scale_shared)
+
+                # --- Up-Project V and Prepare Biased Q/K ---
+                PsiV_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                T.copy(V[i_b, chunk_start:chunk_start + chunk_size, i_h, :], v_shared)
+                for cs, r, p in T.Parallel(chunk_size, R, P):
+                    PsiV_frag[cs, r, p] = v_shared[cs, p] * Psi_frag[r, p]
+                PsiV_reshaped_frag = T.view(PsiV_frag, shape=[fused_chunk_size, P])
+                T.copy(PsiV_reshaped_frag, PsiV_shared)
+
+                q_reshaped_shared = T.view(q_shared, shape=[chunk_size, R, N])
+                T.copy(Q[i_b, chunk_start:chunk_start + chunk_size, :, i_h_qk, :], q_reshaped_shared)
+                q_frag = T.alloc_fragment([chunk_size, R, N], dtype)
+                T.copy(q_reshaped_shared, q_frag)
+                for cs, r, n in T.Parallel(chunk_size, R, N):
+                    q_frag[cs, r, n] += q_bias_frag[r, n]
+                T.copy(q_frag, q_reshaped_shared)
+
+                k_reshaped_shared = T.view(k_shared, shape=[chunk_size, R, N])
+                T.copy(K[i_b, chunk_start:chunk_start + chunk_size, :, i_h_qk, :], k_reshaped_shared)
+                k_frag = T.alloc_fragment([chunk_size, R, N], dtype)
+                T.copy(k_reshaped_shared, k_frag)
+                for cs, r, n in T.Parallel(chunk_size, R, N):
+                    k_frag[cs, r, n] += k_bias_frag[r, n]
+                T.copy(k_frag, k_reshaped_shared)
+
+                # --- QK dot ---
+                qk_dot_frag = T.alloc_fragment([fused_chunk_size, fused_chunk_size], dtype=accum_dtype)
+                T.gemm(q_shared, k_shared, qk_dot_frag, transpose_B=True, clear_accum=True)
+                T.copy(qk_dot_frag, qk_dot_full_shared)
+                # Write QK_DOT; for full chunks eff_tail == chunk_size so cs < eff_tail is
+                # always true and the predication has no effect on non-tail iterations.
+                for cs, r_out, r_in in T.Parallel(chunk_size, R, R):
+                    if cs < eff_tail:
+                        QK_DOT[i_b, i_h, chunk_start + cs, r_out, r_in] = \
+                            qk_dot_full_shared[cs * R + r_out, cs * R + r_in]
+
+                # --- Rotary Q/K ---
+                q_first_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                q_second_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    q_first_half_frag[cs, r, n] = q_shared[cs * R + r, n]
+                    q_second_half_frag[cs, r, n] = q_shared[cs * R + r, N // 2 + n]
+                angles_frag = T.alloc_fragment([chunk_size, N // rotary_dim_divisor], T.float32)
+                T.copy(ANGLES[i_b, chunk_start:chunk_start + chunk_size, i_h, :], angles_frag)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    q_shared[cs * R + r, n] = T.cos(angles_frag[cs, n]) * q_first_half_frag[cs, r, n] - T.sin(angles_frag[cs, n]) * q_second_half_frag[cs, r, n]
+                    q_shared[cs * R + r, N // 2 + n] = T.sin(angles_frag[cs, n]) * q_first_half_frag[cs, r, n] + T.cos(angles_frag[cs, n]) * q_second_half_frag[cs, r, n]
+
+                k_first_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                k_second_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    k_first_half_frag[cs, r, n] = k_shared[cs * R + r, n]
+                    k_second_half_frag[cs, r, n] = k_shared[cs * R + r, N // 2 + n]
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    k_shared[cs * R + r, n] = T.cos(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] - T.sin(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
+                    k_shared[cs * R + r, N // 2 + n] = T.sin(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] + T.cos(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
+
+                k_trap_scaled_frag = T.alloc_fragment([fused_chunk_size, N], dtype)
+                T.copy(k_shared, k_trap_scaled_frag)
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    k_trap_scaled_frag[csr, n] *= trap_scale_shared[csr // R]
+                T.copy(k_trap_scaled_frag, k_shared)
+
+                # --- Interchunk + Intrachunk Output ---
+                q_state_out_frag = T.alloc_fragment([fused_chunk_size, P], dtype=accum_dtype)
+                T.copy(states_frag, states_accum_cast_shared)
+                T.gemm(q_shared, states_accum_cast_shared, q_state_out_frag, clear_accum=True)
+
+                qk_intrachunk_frag = T.alloc_fragment([fused_chunk_size, fused_chunk_size], dtype=accum_dtype)
+                T.gemm(q_shared, k_shared, qk_intrachunk_frag, transpose_B=True, clear_accum=True)
+
+                da_cs__or__exp_da_cs_shared = T.alloc_shared([chunk_size], T.float32)
+                T.copy(DA_CS[i_b, i_h, chunk_start:chunk_start + chunk_size], da_cs__or__exp_da_cs_shared)
+                for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
+                    qk_intrachunk_frag[csr_i, csr_j] = T.if_then_else(
+                        csr_i // R > csr_j // R,
+                        qk_intrachunk_frag[csr_i, csr_j] * T.exp(SEGSUM[i_b, i_h, global_chunk_idx, csr_i // R, csr_j // R]),
+                        0.0)
+                qk_intrachunk_masked_shared = T.alloc_shared([fused_chunk_size, fused_chunk_size], dtype=dtype)
+                for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
+                    qk_intrachunk_masked_shared[csr_i, csr_j] = qk_intrachunk_frag[csr_i, csr_j]
+
+                for cs in T.Parallel(chunk_size):
+                    da_cs__or__exp_da_cs_shared[cs] = T.exp(da_cs__or__exp_da_cs_shared[cs])
+                exp_da_cs_frag = T.alloc_fragment([chunk_size], dtype=T.float32)
+                T.copy(da_cs__or__exp_da_cs_shared, exp_da_cs_frag)
+                for csr, p in T.Parallel(fused_chunk_size, P):
+                    q_state_out_frag[csr, p] *= exp_da_cs_frag[csr // R]
+
+                o_mimo_accum_frag = T.alloc_fragment([fused_chunk_size, P], dtype=accum_dtype)
+                T.gemm(qk_intrachunk_masked_shared, PsiV_shared, o_mimo_accum_frag, clear_accum=True)
+                for cs, p in T.Parallel(fused_chunk_size, P):
+                    o_mimo_accum_frag[cs, p] += q_state_out_frag[cs, p]
+
+                # --- Diagonal Terms ---
+                qkdot_psiv_frag = T.alloc_fragment([chunk_size, R, P], dtype=dtype)
+                T.clear(qkdot_psiv_frag)
+                for cs, r_out, p in T.Parallel(chunk_size, R, P):
+                    for r_in in T.serial(R):
+                        qkdot_psiv_frag[cs, r_out, p] += qk_dot_full_shared[cs * R + r_out, cs * R + r_in] * PsiV_shared[cs * R + r_in, p]
+                    qkdot_psiv_frag[cs, r_out, p] *= gamma_frag[cs]
+                qkdot_psiv_reshaped_frag = T.view(qkdot_psiv_frag, shape=[fused_chunk_size, P])
+                for csr, p in T.Parallel(fused_chunk_size, P):
+                    o_mimo_accum_frag[csr, p] += qkdot_psiv_reshaped_frag[csr, p]
+
+                if hasD:
+                    D_var = T.alloc_var(T.float32)
+                    T.copy(D[i_h], D_var)
+                    PsiV_D_frag = T.alloc_fragment([fused_chunk_size, P], T.float32)
+                    T.copy(PsiV_shared, PsiV_D_frag)
+                    for csr, p in T.Parallel(fused_chunk_size, P):
+                        o_mimo_accum_frag[csr, p] += D_var * PsiV_D_frag[csr, p]
+
+                # --- DMIMO_O / DZ projection ---
+                if reduceO:
+                    out_prereduced_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+                    T.copy(o_mimo_accum_frag, out_prereduced_shared)
+
+                    o_gated_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                    if hasZ:
+                        T.copy(Z[i_b, chunk_start:chunk_start + chunk_size, i_h, :], z_shared)
+                        z_o_frag = T.alloc_fragment([chunk_size, P], T.float32)
+                        T.copy(z_shared, z_o_frag)
+                        Zeta_o_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(MIMO_Z[i_h, :, :], Zeta_o_frag)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            tmp = z_o_frag[cs, p] * Zeta_o_frag[r, p] * 0.5
+                            o_gated_frag[cs, r, p] = tmp * T.tanh(tmp) + tmp
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            o_gated_frag[cs, r, p] *= out_prereduced_shared[cs * R + r, p]
+                    else:
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            o_gated_frag[cs, r, p] = out_prereduced_shared[cs * R + r, p]
+
+                    dPhi_frag = T.alloc_fragment([R, P], T.float32)
+                    T.copy(dPhi_shared, dPhi_frag)
+                    dout_frag = T.alloc_fragment([chunk_size, P], dtype)
+                    T.copy(DOUT[i_b, chunk_start:chunk_start + chunk_size, i_h, :], dout_shared)
+                    if eff_tail < chunk_size:
+                        for cs, p in T.Parallel(chunk_size, P):
+                            dout_shared[cs, p] = T.if_then_else(cs < eff_tail, dout_shared[cs, p], 0.0)
+                    T.copy(dout_shared, dout_frag)
+                    for r, p in T.Parallel(R, P):
+                        for cs in T.serial(chunk_size):
+                            dPhi_frag[r, p] += o_gated_frag[cs, r, p] * dout_frag[cs, p]
+                    T.copy(dPhi_frag, dPhi_shared)
+
+                    if hasZ:
+                        Phi_frag = T.alloc_fragment([R, P], dtype)
+                        T.copy(MIMO_O[i_h, :, :], Phi_frag)
+                        dPhiO_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                        dout_preexpand_frag = T.alloc_fragment([chunk_size, P], dtype)
+                        T.copy(dout_shared, dout_preexpand_frag)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhiO_frag[cs, r, p] = dout_frag[cs, p] * Phi_frag[r, p]
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhiO_frag[cs, r, p] *= out_prereduced_shared[cs * R + r, p]
+                        z_frag = T.alloc_fragment([chunk_size, P], T.float32)
+                        T.copy(z_shared, z_frag)
+                        Zeta_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(MIMO_Z[i_h, :, :], Zeta_frag)
+                        dZetaZ_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZetaZ_frag[cs, r, p] = z_frag[cs, p] * Zeta_frag[r, p]
+                            dZetaZ_frag[cs, r, p] = dPhiO_frag[cs, r, p] * T.sigmoid(dZetaZ_frag[cs, r, p]) * \
+                                (1 + dZetaZ_frag[cs, r, p] * (T.sigmoid(-dZetaZ_frag[cs, r, p])))
+                        dZ_frag = T.alloc_fragment([chunk_size, P], dtype)
+                        T.clear(dZ_frag)
+                        for cs, p in T.Parallel(chunk_size, P):
+                            for r in T.serial(R):
+                                dZ_frag[cs, p] += dZetaZ_frag[cs, r, p] * Zeta_frag[r, p]
+                        if eff_tail < chunk_size:
+                            for cs, p in T.Parallel(chunk_size, P):
+                                if cs < eff_tail:
+                                    DZ[i_b, chunk_start + cs, i_h, p] = dZ_frag[cs, p]
+                        else:
+                            T.copy(dZ_frag, DZ[i_b, chunk_start:chunk_start + chunk_size, i_h, :])
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZetaZ_frag[cs, r, p] *= z_frag[cs, p]
+                        dZeta_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(dZeta_shared, dZeta_frag)
+                        T.reduce_sum(dZetaZ_frag, dZeta_frag, clear=False, dim=0)
+                        T.copy(dZeta_frag, dZeta_shared)
+                else:
+                    if hasZ:
+                        out_prereduced_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+                        T.copy(o_mimo_accum_frag, out_prereduced_shared)
+                        T.copy(Z[i_b, chunk_start:chunk_start + chunk_size, i_h, :], z_shared)
+                        dPhiO_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhiO_frag[cs, r, p] = DOUT[i_b, chunk_start + cs, r, i_h, p]
+                        if eff_tail < chunk_size:
+                            for cs, r, p in T.Parallel(chunk_size, R, P):
+                                dPhiO_frag[cs, r, p] = T.if_then_else(cs < eff_tail, dPhiO_frag[cs, r, p], 0.0)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhiO_frag[cs, r, p] *= out_prereduced_shared[cs * R + r, p]
+                        z_frag = T.alloc_fragment([chunk_size, P], T.float32)
+                        T.copy(z_shared, z_frag)
+                        Zeta_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(MIMO_Z[i_h, :, :], Zeta_frag)
+                        dZetaZ_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZetaZ_frag[cs, r, p] = z_frag[cs, p] * Zeta_frag[r, p]
+                            dZetaZ_frag[cs, r, p] = dPhiO_frag[cs, r, p] * T.sigmoid(dZetaZ_frag[cs, r, p]) * \
+                                (1 + dZetaZ_frag[cs, r, p] * (T.sigmoid(-dZetaZ_frag[cs, r, p])))
+                        dZ_frag = T.alloc_fragment([chunk_size, P], dtype)
+                        T.clear(dZ_frag)
+                        for cs, p in T.Parallel(chunk_size, P):
+                            for r in T.serial(R):
+                                dZ_frag[cs, p] += dZetaZ_frag[cs, r, p] * Zeta_frag[r, p]
+                        if eff_tail < chunk_size:
+                            for cs, p in T.Parallel(chunk_size, P):
+                                if cs < eff_tail:
+                                    DZ[i_b, chunk_start + cs, i_h, p] = dZ_frag[cs, p]
+                        else:
+                            T.copy(dZ_frag, DZ[i_b, chunk_start:chunk_start + chunk_size, i_h, :])
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZetaZ_frag[cs, r, p] *= z_frag[cs, p]
+                        dZeta_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(dZeta_shared, dZeta_frag)
+                        T.reduce_sum(dZetaZ_frag, dZeta_frag, clear=False, dim=0)
+                        T.copy(dZeta_frag, dZeta_shared)
+
+                # --- Save and Update Recurrent State ---
+                T.copy(states_frag, STATES[i_b, i_h, global_chunk_idx, :, :])
+
+                dA_cs_rev_frag = T.alloc_fragment([chunk_size], T.float32)
+                T.copy(DA_CS_REV[i_b, i_h, chunk_start:chunk_start + chunk_size], dA_cs_rev_frag)
+                k_state_frag = T.alloc_fragment([fused_chunk_size, N], dtype)
+                T.copy(k_shared, k_state_frag)
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    k_state_frag[csr, n] *= T.exp(dA_cs_rev_frag[csr // R])
+
+                da_cs_sum = T.alloc_var(T.float32)
+                T.copy(DA_CS[i_b, i_h, da_cs_end_idx], da_cs_sum)
+                for n, p in T.Parallel(N, P):
+                    states_frag[n, p] *= T.exp(da_cs_sum)
+                T.gemm(k_state_frag, PsiV_shared, states_frag, transpose_A=True, clear_accum=False)
+
+            if reduceO:
+                T.copy(dPhi_shared, DMIMO_O[i_b, i_h, i_ns, :, :])
+            if hasZ:
+                T.copy(dZeta_shared, DMIMO_Z[i_b, i_h, i_ns, :, :])
+
+    return mamba_mimo_bwd_fwd_kernel
+
+# def get_configs():
+#     iter_params = dict(num_stages=[0], threads=[128, 256])
+#     return [dict(zip(iter_params, values)) for values in itertools.product(*iter_params.values())]
+
+# @autotune(
+#     configs=get_configs(),
+#     warmup=3,
+#     rep=20,
+# )
+@tilelang.jit(
+    out_idx=[],
+    pass_configs={
+        tilelang.PassConfigKey.TL_DISABLE_TMA_LOWER: True,
+        tilelang.PassConfigKey.TL_DISABLE_WARP_SPECIALIZED: True,
+        tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
+    })
+def mamba_mimo_bwd_bwd(
+    B,
+    S,
+    H,
+    G,
+    N,
+    P,
+    R,
+    hasZ,
+    hasD,
+    reduceO,
+    NS: int = 1,
+    chunk_size: int = 16,
+    rotary_dim_divisor: int = 4,
+    dtype: str = 'float16',
+    threads: int = 256,
+    num_stages: int = 0,
+) -> torch.Tensor:
+    """
+    TileLang kernel factory for the varlen Mamba3 bwd-bwd pass.
+
+    The bwd-bwd pass iterates chunks in *reverse* order, consuming the
+    STATES and QK_DOT cached by the bwd-fwd pass, and writes all remaining
+    gradients: DQ, DK, DV, DMIMO_V, DD, DANGLES, DDA, DFACTOR,
+    DGAMMA_DIAG, DDA_CS, DDA_CS_REV, DSSDA.
+
+    Varlen additions vs. ``mamba_mimo_bwd_bwd`` in
+    ``mamba3_mimo_bwd.py``:
+
+    * Grid: ``T.Kernel(H, NS, B)`` — extra ``i_ns`` dimension.
+    * Per-sequence bounds from ``CU_SEQLENS[i_ns]``.
+    * DMIMO_V / DD shapes: ``[B, H, NS, R, P]`` / ``[B, H, NS]``.
+    * DSSDA shape: ``[B, H, max_nchunks, C, C]`` with
+      ``max_nchunks = (S // chunk_size) + NS``.
+    """
+    accum_dtype = 'float32'
+    max_nchunks = (S // chunk_size) + NS
+    fused_chunk_size = chunk_size * R
+
+    if reduceO:
+        DOUT_shape = (B, S, H, P)
+    else:
+        DOUT_shape = (B, S, R, H, P)
+
+    @T.prim_func
+    def mamba_mimo_bwd_bwd_kernel(
+            DOUT: T.Tensor(DOUT_shape, dtype),  # type: ignore
+            Q: T.Tensor([B, S, R, G, N], dtype),  # type: ignore
+            K: T.Tensor([B, S, R, G, N], dtype),  # type: ignore
+            V: T.Tensor([B, S, H, P], dtype),  # type: ignore
+            Q_BIAS: T.Tensor([H, R, N], T.float32),  # type: ignore
+            K_BIAS: T.Tensor([H, R, N], T.float32),  # type: ignore
+            MIMO_V: T.Tensor([H, R, P], T.float32),  # type: ignore
+            MIMO_O: T.Tensor([H, R, P], T.float32),  # type: ignore
+            DK: T.Tensor([B, S * R, H, N], dtype),  # type: ignore
+            DV: T.Tensor([B, S, H, P], dtype),  # type: ignore
+            DMIMO_V: T.Tensor([B, H, NS, R, P], T.float32),  # type: ignore
+            STATES: T.Tensor([B, H, max_nchunks, N, P], dtype),  # type: ignore
+            DQ: T.Tensor([B, S * R, H, N], dtype),  # type: ignore
+            Z: T.Tensor([B, S, H, P], dtype),  # type: ignore
+            MIMO_Z: T.Tensor([H, R, P], T.float32),  # type: ignore
+            ANGLES: T.Tensor([B, S, H, N // rotary_dim_divisor], T.float32),  # type: ignore
+            DA_CS: T.Tensor([B, H, S], T.float32),  # type: ignore
+            DA_CS_REV: T.Tensor([B, H, S], T.float32),  # type: ignore
+            DT: T.Tensor([B, H, S], T.float32),  # type: ignore
+            TRAP: T.Tensor([B, H, S], dtype),  # type: ignore
+            DFACTOR: T.Tensor([B, H, S], T.float32),  # type: ignore
+            DGAMMA_DIAG: T.Tensor([B, H, S], T.float32),  # type: ignore
+            DANGLES: T.Tensor([B, S, H, N // rotary_dim_divisor], T.float32),  # type: ignore
+            D: T.Tensor([H], T.float32),  # type: ignore
+            DD: T.Tensor([B, H, NS], T.float32),  # type: ignore
+            QK_DOT: T.Tensor([B, H, S, R, R], dtype),  # type: ignore
+            DDA: T.Tensor([B, H, S], T.float32),  # type: ignore
+            DSSDA: T.Tensor([B, H, max_nchunks, chunk_size, chunk_size], T.float32),  # type: ignore
+            DDA_CS_REV: T.Tensor([B, H, S], T.float32),  # type: ignore
+            DDA_CS: T.Tensor([B, H, S], T.float32),  # type: ignore
+            SEGSUM: T.Tensor([B, H, max_nchunks, chunk_size, chunk_size], T.float32),  # type: ignore
+            CU_SEQLENS: T.Tensor([NS + 1], dtype=T.int32),  # type: ignore
+            ):
+        """
+        Varlen bwd-bwd kernel: computes all remaining gradients in reverse
+        chunk order.
+
+        Inputs:
+            - DOUT: upstream gradient.
+            - Q, K, V: packed activations.
+            - Q_BIAS, K_BIAS, MIMO_V, MIMO_O, MIMO_Z: projection params.
+            - Z, D: optional gating / skip-connection tensors.
+            - ANGLES: rotary angles.
+            - DA_CS, DA_CS_REV, DT, TRAP, SEGSUM: discretization tensors.
+            - STATES: per-chunk states cached by the bwd-fwd pass,
+              shape ``[B, H, max_nchunks, N, P]``.
+            - QK_DOT: per-step Q·K diagonal blocks cached by bwd-fwd,
+              shape ``[B, H, S, R, R]``.
+            - CU_SEQLENS: int32 prefix-sum of per-sequence lengths,
+              shape ``[NS+1]``.
+
+        Outputs (written in place):
+            - DQ, DK, DV: activation gradients.
+            - DMIMO_V: gradient of Psi, shape ``[B, H, NS, R, P]``.
+            - DD: gradient of D, shape ``[B, H, NS]``.
+            - DANGLES: gradient of rotary angles.
+            - DDA, DDA_CS, DDA_CS_REV, DSSDA, DFACTOR, DGAMMA_DIAG:
+              intermediate discretization gradients consumed by the
+              Triton utility kernels in ``mamba3_utils_varlen.py``.
+        """
+
+        with T.Kernel(H, NS, B, threads=threads) as (i_h, i_ns, i_b):
+            i_h_qk = i_h // (H // G)
+
+            dstates_shared = T.alloc_shared([N, P], dtype)
+            dstates_frag = T.alloc_fragment([N, P], accum_dtype)
+            dout_shared = T.alloc_shared([chunk_size, P], dtype)
+            dPhiO_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+            q_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            k_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            v_shared = T.alloc_shared([chunk_size, P], dtype)
+            states_shared = T.alloc_shared([N, P], dtype)
+            lkq_masked__or__dkq_masked_shared = T.alloc_shared([fused_chunk_size, fused_chunk_size], dtype)
+            dPsiV_combined_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+            dqk_from_diag_shared = T.alloc_shared([fused_chunk_size, fused_chunk_size], accum_dtype)
+            q_pre_rot_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            k_pre_rot_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            dk_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            dq_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            qk_dot_shared = T.alloc_shared([chunk_size, R, R], dtype)
+            k_pre_trap_shared = T.alloc_shared([fused_chunk_size, N], dtype)
+            dangle_dk__or__dq_shared = T.alloc_shared([fused_chunk_size, N // rotary_dim_divisor], T.float32)
+
+            noswizzle_annot = threads == 256 and (N <= 32 or P >= 128) # NOTE: heuristics for when swizzling annotation causes kernel hang, needs more investigation
+            if not noswizzle_annot:
+                T.annotate_layout({
+                    dstates_shared: tilelang.layout.make_swizzled_layout(dstates_shared),
+                    dout_shared: tilelang.layout.make_swizzled_layout(dout_shared),
+                    q_shared: tilelang.layout.make_swizzled_layout(q_shared),
+                    k_shared: tilelang.layout.make_swizzled_layout(k_shared),
+                    v_shared: tilelang.layout.make_swizzled_layout(v_shared),
+                    states_shared: tilelang.layout.make_swizzled_layout(states_shared),
+                    lkq_masked__or__dkq_masked_shared: tilelang.layout.make_swizzled_layout(lkq_masked__or__dkq_masked_shared),
+                    dPsiV_combined_shared: tilelang.layout.make_swizzled_layout(dPsiV_combined_shared),
+                    dqk_from_diag_shared: tilelang.layout.make_swizzled_layout(dqk_from_diag_shared),
+                    k_pre_rot_shared: tilelang.layout.make_swizzled_layout(k_pre_rot_shared),
+                    q_pre_rot_shared: tilelang.layout.make_swizzled_layout(q_pre_rot_shared),
+                    dk_shared: tilelang.layout.make_swizzled_layout(dk_shared),
+                    dq_shared: tilelang.layout.make_swizzled_layout(dq_shared),
+                    k_pre_trap_shared: tilelang.layout.make_swizzled_layout(k_pre_trap_shared),
+                    dangle_dk__or__dq_shared: tilelang.layout.make_swizzled_layout(dangle_dk__or__dq_shared),
+                })
+            T.use_swizzle(10, "row")
+            T.no_set_max_nreg()
+
+            T.clear(dstates_frag)
+            T.clear(dstates_shared)
+
+            if reduceO:
+                Phi_frag = T.alloc_fragment([R, P], dtype)
+                T.copy(MIMO_O[i_h, :, :], Phi_frag)
+            Psi_frag = T.alloc_fragment([R, P], dtype)
+            T.copy(MIMO_V[i_h, :, :], Psi_frag)
+
+            dPsi_acc = T.alloc_fragment([R, P], accum_dtype)
+            T.clear(dPsi_acc)
+
+            if hasD:
+                dD_frag = T.alloc_fragment([1], accum_dtype)
+                T.clear(dD_frag)
+
+            q_bias_frag = T.alloc_fragment([R, N], dtype)
+            k_bias_frag = T.alloc_fragment([R, N], dtype)
+            T.copy(Q_BIAS[i_h, :, :], q_bias_frag)
+            T.copy(K_BIAS[i_h, :, :], k_bias_frag)
+
+            # --- Per-sequence bounds ---
+            start_seq_ind = T.alloc_var(T.int32)
+            start_chunk_ind = T.alloc_var(T.int32)
+            seq_len = T.alloc_var(T.int32)
+            seq_end = T.alloc_var(T.int32)
+            full_nchunks = T.alloc_var(T.int32)
+            tail_len = T.alloc_var(T.int32)
+            if NS > 1:
+                start_seq_ind = CU_SEQLENS[i_ns]
+                start_chunk_ind = (start_seq_ind // chunk_size) + i_ns
+                seq_len = CU_SEQLENS[i_ns + 1] - CU_SEQLENS[i_ns]
+                seq_end = start_seq_ind + seq_len
+                full_nchunks = seq_len // chunk_size
+                tail_len = seq_len % chunk_size
+            else:
+                start_seq_ind = 0
+                start_chunk_ind = 0
+                seq_len = S
+                seq_end = S
+                full_nchunks = S // chunk_size
+                tail_len = S % chunk_size
+            if tail_len > 0:
+                full_nchunks += 1
+
+            for chunk_idx_rev in T.Pipelined(0, full_nchunks, num_stages=num_stages):
+                chunk_idx = full_nchunks - 1 - chunk_idx_rev
+                chunk_start = start_seq_ind + chunk_idx * chunk_size
+                fused_chunk_start = chunk_start * R
+                global_chunk_idx = start_chunk_ind + chunk_idx
+                # Effective tail cutoff: chunk_size for full chunks, tail_len for the last tail chunk.
+                # Used to mask all output writes with a single T.if_then_else + T.copy instead of
+                # many separate if-else blocks.  For full chunks eff_tail == chunk_size so the
+                # masking condition (cs < eff_tail) is trivially true and T.copy runs unguarded.
+                eff_tail = T.alloc_var(T.int32)
+                eff_tail = chunk_size
+                if chunk_idx == full_nchunks - 1:
+                    if tail_len > 0:
+                        eff_tail = tail_len
+                # Index of the last valid DA_CS entry for this chunk (used twice below).
+                da_cs_end_idx = T.alloc_var(T.int32)
+                da_cs_end_idx = chunk_start + chunk_size - 1
+                if eff_tail < chunk_size:
+                    da_cs_end_idx = seq_end - 1
+                # --- Discretization Factors ---
+                # For non-last chunks every shifted position is within sequence bounds, so we
+                # can use vectorised T.copy instead of per-element T.if_then_else. This
+                # replaces 3*chunk_size predicated GMEM loads with 2 bulk T.copy calls for
+                # all but the last chunk in the reverse iteration order (chunk_idx_rev == 0).
+                trap_shifted_frag = T.alloc_fragment([chunk_size], T.float32)
+                dt_shifted_frag = T.alloc_fragment([chunk_size], dtype)
+                shifted_gamma_frag = T.alloc_fragment([chunk_size], dtype)
+                if chunk_idx_rev == 0:
+                    # Last chunk (first in reverse): shifted positions may exceed seq_end.
+                    for cs in T.Parallel(chunk_size):
+                        trap_shifted_frag[cs] = T.if_then_else(
+                            cs + 1 < eff_tail,
+                            TRAP[i_b, i_h, chunk_start + cs + 1], 0.0)
+                        dt_shifted_frag[cs] = T.if_then_else(
+                            cs + 1 < eff_tail,
+                            DT[i_b, i_h, chunk_start + cs + 1], 0.0)
+                    for cs in T.Parallel(chunk_size):
+                        shifted_gamma_frag[cs] = T.if_then_else(
+                            cs + 1 < eff_tail,
+                            dt_shifted_frag[cs] * T.sigmoid(-trap_shifted_frag[cs]), 0.0)
+                else:
+                    # Non-last chunk: chunk_start+1 .. chunk_start+chunk_size are all in bounds.
+                    T.copy(TRAP[i_b, i_h, chunk_start + 1:chunk_start + 1 + chunk_size], trap_shifted_frag)
+                    T.copy(DT[i_b, i_h, chunk_start + 1:chunk_start + 1 + chunk_size], dt_shifted_frag)
+                    for cs in T.Parallel(chunk_size):
+                        shifted_gamma_frag[cs] = dt_shifted_frag[cs] * T.sigmoid(-trap_shifted_frag[cs])
+
+                trap_frag = T.alloc_fragment([chunk_size], T.float32)
+                T.copy(TRAP[i_b, i_h, chunk_start:chunk_start + chunk_size], trap_frag)
+                dt_frag = T.alloc_fragment([chunk_size], dtype)
+                T.copy(DT[i_b, i_h, chunk_start:chunk_start + chunk_size], dt_frag)
+                gamma_frag = T.alloc_fragment([chunk_size], T.float32)
+                for cs in T.Parallel(chunk_size):
+                    gamma_frag[cs] = dt_frag[cs] * T.sigmoid(trap_frag[cs])
+                gamma_cached_frag = T.alloc_fragment([chunk_size], T.float32)
+                T.copy(gamma_frag, gamma_cached_frag)
+                trap_scale_frag = T.alloc_fragment([chunk_size], dtype)
+                for cs in T.Parallel(chunk_size):
+                    trap_scale_frag[cs] = gamma_frag[cs] + shifted_gamma_frag[cs]
+                trap_scale_shared = T.alloc_shared([chunk_size], dtype)
+                T.copy(trap_scale_frag, trap_scale_shared)
+
+                # --- DOUT projection (zero-masked at tail) ---
+                dPhiO_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                if reduceO:
+                    for cs, p in T.Parallel(chunk_size, P):
+                        dout_shared[cs, p] = DOUT[i_b, chunk_start + cs, i_h, p]
+                    if eff_tail < chunk_size:
+                        for cs, p in T.Parallel(chunk_size, P):
+                            dout_shared[cs, p] = T.if_then_else(cs < eff_tail, dout_shared[cs, p], 0.0)
+                    for cs, r, p in T.Parallel(chunk_size, R, P):
+                        dPhiO_frag[cs, r, p] = dout_shared[cs, p] * Phi_frag[r, p]
+                else:
+                    for cs, r, p in T.Parallel(chunk_size, R, P):
+                        dPhiO_frag[cs, r, p] = DOUT[i_b, chunk_start + cs, r, i_h, p]
+                    if eff_tail < chunk_size:
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhiO_frag[cs, r, p] = T.if_then_else(cs < eff_tail, dPhiO_frag[cs, r, p], 0.0)
+
+                if hasZ:
+                    Zeta_frag = T.alloc_fragment([R, P], dtype)
+                    T.copy(MIMO_Z[i_h, :, :], Zeta_frag)
+                    z_frag = T.alloc_fragment([chunk_size, P], dtype)
+                    T.copy(Z[i_b, chunk_start:chunk_start + chunk_size, i_h, :], z_frag)
+                    for cs, r, p in T.Parallel(chunk_size, R, P):
+                        tmp = z_frag[cs, p] * Zeta_frag[r, p] * 0.5
+                        dPhiO_frag[cs, r, p] *= tmp * T.tanh(tmp) + tmp
+                T.copy(T.view(dPhiO_frag, shape=[fused_chunk_size, P]), dPhiO_shared)
+
+                T.copy(V[i_b, chunk_start:chunk_start + chunk_size, i_h, :], v_shared)
+                if hasD:
+                    v_dD_frag = T.alloc_fragment([chunk_size, P], accum_dtype)
+                    Psi_dD_frag = T.alloc_fragment([R, P], accum_dtype)
+                    T.copy(v_shared, v_dD_frag)
+                    T.copy(MIMO_V[i_h, :, :], Psi_dD_frag)
+                    for cs, r, p in T.Parallel(chunk_size, R, P):
+                        dPhiO_frag[cs, r, p] *= v_dD_frag[cs, p] * Psi_dD_frag[r, p]
+                    T.reduce_sum(T.view(dPhiO_frag, shape=[fused_chunk_size * P]), dD_frag, clear=False)
+
+                # --- Load and rotate Q ---
+                for cs, r, n in T.Parallel(chunk_size, R, N):
+                    q_shared[cs * R + r, n] = Q[i_b, chunk_start + cs, r, i_h_qk, n]
+                q_frag = T.alloc_fragment([chunk_size, R, N], dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N):
+                    q_frag[cs, r, n] = q_shared[cs * R + r, n]
+                for cs, r, n in T.Parallel(chunk_size, R, N):
+                    q_frag[cs, r, n] += q_bias_frag[r, n]
+                for cs, r, n in T.Parallel(chunk_size, R, N):
+                    q_shared[cs * R + r, n] = q_frag[cs, r, n]
+                T.copy(q_shared, q_pre_rot_shared)
+                q_first_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                q_second_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    q_first_half_frag[cs, r, n] = q_shared[cs * R + r, n]
+                    q_second_half_frag[cs, r, n] = q_shared[cs * R + r, N // 2 + n]
+                angles_frag = T.alloc_fragment([chunk_size, N // rotary_dim_divisor], T.float32)
+                T.copy(ANGLES[i_b, chunk_start:chunk_start + chunk_size, i_h, :], angles_frag)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    q_shared[cs * R + r, n] = T.cos(angles_frag[cs, n]) * q_first_half_frag[cs, r, n] - T.sin(angles_frag[cs, n]) * q_second_half_frag[cs, r, n]
+                    q_shared[cs * R + r, N // 2 + n] = T.sin(angles_frag[cs, n]) * q_first_half_frag[cs, r, n] + T.cos(angles_frag[cs, n]) * q_second_half_frag[cs, r, n]
+
+                # --- Load and rotate K ---
+                k_reshaped_shared = T.view(k_pre_trap_shared, shape=[chunk_size, R, N])
+                T.copy(K[i_b, chunk_start:chunk_start + chunk_size, :, i_h_qk, :], k_reshaped_shared)
+                k_frag = T.alloc_fragment([chunk_size, R, N], dtype)
+                T.copy(k_reshaped_shared, k_frag)
+                for cs, r, n in T.Parallel(chunk_size, R, N):
+                    k_frag[cs, r, n] += k_bias_frag[r, n]
+                T.copy(k_frag, k_reshaped_shared)
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    k_pre_rot_shared[csr, n] = k_pre_trap_shared[csr, n]
+                k_first_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                k_second_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    k_first_half_frag[cs, r, n] = k_reshaped_shared[cs, r, n]
+                    k_second_half_frag[cs, r, n] = k_reshaped_shared[cs, r, N // 2 + n]
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    k_reshaped_shared[cs, r, n] = T.cos(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] - T.sin(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
+                    k_reshaped_shared[cs, r, N // 2 + n] = T.sin(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] + T.cos(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
+                k_trap_scaled_frag = T.alloc_fragment([fused_chunk_size, N], dtype)
+                T.copy(k_pre_trap_shared, k_trap_scaled_frag)
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    k_trap_scaled_frag[csr, n] *= trap_scale_shared[csr // R]
+                T.copy(k_trap_scaled_frag, k_shared)
+
+                # --- dPsiV: interchunk + intrachunk ---
+                dPsiV_frag = T.alloc_fragment([fused_chunk_size, P], accum_dtype)
+                T.gemm(k_shared, dstates_shared, dPsiV_frag, clear_accum=True)
+                dA_cs_rev_frag = T.alloc_fragment([chunk_size], T.float32)
+                dA_cs_rev_shared = T.alloc_shared([chunk_size], T.float32)
+                T.copy(DA_CS_REV[i_b, i_h, chunk_start:chunk_start + chunk_size], dA_cs_rev_shared)
+                T.copy(dA_cs_rev_shared, dA_cs_rev_frag)
+                for csr, p in T.Parallel(fused_chunk_size, P):
+                    dPsiV_frag[csr, p] *= T.exp(dA_cs_rev_frag[csr // R])
+
+                lkq_frag = T.alloc_fragment([fused_chunk_size, fused_chunk_size], accum_dtype)
+                T.gemm(k_shared, q_shared, lkq_frag, transpose_B=True, clear_accum=True)
+                T.copy(lkq_frag, lkq_masked__or__dkq_masked_shared)
+                if R == 1:
+                    lkq_masked_dtype_buf = T.alloc_fragment([fused_chunk_size, fused_chunk_size], dtype)
+                    T.copy(lkq_masked__or__dkq_masked_shared, lkq_masked_dtype_buf)
+                    for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
+                        lkq_masked_dtype_buf[csr_i, csr_j] = T.if_then_else(
+                            csr_i // R < csr_j // R,
+                            lkq_masked_dtype_buf[csr_i, csr_j] * T.exp(SEGSUM[i_b, i_h, global_chunk_idx, csr_j // R, csr_i // R]),
+                            0.0)
+                else:
+                    for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
+                        lkq_frag[csr_i, csr_j] = T.if_then_else(
+                            csr_i // R < csr_j // R,
+                            lkq_frag[csr_i, csr_j] * T.exp(SEGSUM[i_b, i_h, global_chunk_idx, csr_j // R, csr_i // R]),
+                            0.0)
+                    lkq_masked_dtype_buf = T.alloc_shared([fused_chunk_size, fused_chunk_size], dtype)
+                    T.copy(lkq_frag, lkq_masked_dtype_buf)
+                T.gemm(lkq_masked_dtype_buf, dPhiO_shared, dPsiV_frag, clear_accum=False)
+
+                # --- Diagonal contributions to dPsiV ---
+                dPsiV_D_fused_frag = T.alloc_fragment([fused_chunk_size, P], accum_dtype)
+                if hasD:
+                    D_frag = T.alloc_var(T.float32)
+                    T.copy(D[i_h], D_frag)
+                    for csr, p in T.Parallel(fused_chunk_size, P):
+                        dPsiV_D_fused_frag[csr, p] = dPsiV_frag[csr, p] + dPhiO_shared[csr, p] * D_frag
+                else:
+                    T.copy(dPsiV_frag, dPsiV_D_fused_frag)
+                qk_dot_frag = T.alloc_fragment([chunk_size, R, R], dtype)
+                T.copy(QK_DOT[i_b, i_h, chunk_start:chunk_start + chunk_size, :, :], qk_dot_shared)
+                T.copy(qk_dot_shared, qk_dot_frag)
+                gamma_dPsiV_frag = T.alloc_fragment([chunk_size], dtype)
+                T.copy(gamma_frag, gamma_dPsiV_frag)
+                for csr, p in T.Parallel(fused_chunk_size, P):
+                    cs = csr // R
+                    r_in = csr % R
+                    for r_out in T.serial(R):
+                        csr_out = cs * R + r_out
+                        dPsiV_D_fused_frag[csr, p] += dPhiO_shared[csr_out, p] * qk_dot_frag[cs, r_out, r_in] * gamma_dPsiV_frag[cs]
+                T.copy(dPsiV_D_fused_frag, dPsiV_combined_shared)
+
+                # --- dV and dPsi ---
+                dv_frag = T.alloc_fragment([chunk_size, P], dtype)
+                T.clear(dv_frag)
+                for cs, p in T.Parallel(chunk_size, P):
+                    for r in T.serial(R):
+                        dv_frag[cs, p] += dPsiV_combined_shared[cs * R + r, p] * Psi_frag[r, p]
+                if eff_tail < chunk_size:
+                    for cs, p in T.Parallel(chunk_size, P):
+                        if cs < eff_tail:
+                            DV[i_b, chunk_start + cs, i_h, p] = dv_frag[cs, p]
+                else:
+                    T.copy(dv_frag, DV[i_b, chunk_start:chunk_start + chunk_size, i_h, :])
+
+                dPsi_frag = T.alloc_fragment([R, P], accum_dtype)
+                T.copy(dPsi_acc, dPsi_frag)
+                v_frag = T.alloc_fragment([chunk_size, P], accum_dtype)
+                T.copy(v_shared, v_frag)
+                for r, p in T.Parallel(R, P):
+                    for cs in T.serial(chunk_size):
+                        dPsi_frag[r, p] += dPsiV_combined_shared[cs * R + r, p] * v_frag[cs, p]
+                T.copy(dPsi_frag, dPsi_acc)
+
+                PsiV_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                T.clear(PsiV_frag)
+                for cs, p in T.Parallel(chunk_size, P):
+                    for r in T.serial(R):
+                        PsiV_frag[cs, r, p] += v_frag[cs, p] * Psi_frag[r, p]
+                PsiV_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+                for cs, r, p in T.Parallel(chunk_size, R, P):
+                    PsiV_shared[cs * R + r, p] = PsiV_frag[cs, r, p]
+
+                # --- dqk_from_diag ---
+                dqk_from_diag_frag = T.alloc_fragment([fused_chunk_size, fused_chunk_size], accum_dtype)
+                T.gemm(dPhiO_shared, PsiV_shared, dqk_from_diag_frag, transpose_B=True, clear_accum=True)
+                dgamma_diag_prereduce_frag = T.alloc_fragment([chunk_size, R, R], accum_dtype)
+                T.copy(qk_dot_shared, dgamma_diag_prereduce_frag)
+                T.copy(dqk_from_diag_frag, dqk_from_diag_shared)
+                for cs, r_out, r_in in T.Parallel(chunk_size, R, R):
+                    dgamma_diag_prereduce_frag[cs, r_out, r_in] *= dqk_from_diag_shared[cs * R + r_out, cs * R + r_in]
+                dgamma_diag_reduced_frag = T.alloc_fragment([chunk_size], accum_dtype)
+                T.reduce_sum(T.view(dgamma_diag_prereduce_frag, shape=[chunk_size, R * R]),
+                             dgamma_diag_reduced_frag, dim=-1, clear=True)
+                if eff_tail < chunk_size:
+                    for cs in T.Parallel(chunk_size):
+                        if cs < eff_tail:
+                            DGAMMA_DIAG[i_b, i_h, chunk_start + cs] = dgamma_diag_reduced_frag[cs]
+                else:
+                    T.copy(dgamma_diag_reduced_frag, DGAMMA_DIAG[i_b, i_h, chunk_start:chunk_start + chunk_size])
+                gamma_qk_frag = T.alloc_fragment([chunk_size], accum_dtype)
+                T.copy(gamma_cached_frag, gamma_qk_frag)
+                for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
+                    dqk_from_diag_frag[csr_i, csr_j] *= gamma_qk_frag[csr_i // R]
+                T.copy(dqk_from_diag_frag, dqk_from_diag_shared)
+
+                # --- dK ---
+                dk_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
+                T.gemm(PsiV_shared, dstates_shared, dk_frag, transpose_B=True, clear_accum=True)
+
+                ddA_state_kv_prereduce_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
+                T.copy(k_shared, ddA_state_kv_prereduce_frag)
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    ddA_state_kv_prereduce_frag[csr, n] *= dk_frag[csr, n]
+                ddA_state_kv_prereduce_frag_reshaped = T.view(ddA_state_kv_prereduce_frag, shape=[chunk_size, R * N])
+                ddA_state_kv_frag = T.alloc_fragment([chunk_size], accum_dtype)
+                T.reduce_sum(ddA_state_kv_prereduce_frag_reshaped, ddA_state_kv_frag, dim=-1, clear=True)
+                if eff_tail < chunk_size:
+                    for cs in T.Parallel(chunk_size):
+                        if cs < eff_tail:
+                            DDA_CS_REV[i_b, i_h, chunk_start + cs] = ddA_state_kv_frag[cs]
+                else:
+                    T.copy(ddA_state_kv_frag, DDA_CS_REV[i_b, i_h, chunk_start:chunk_start + chunk_size])
+
+                dA_cs_rev_dk_frag = T.alloc_fragment([chunk_size], T.float32)
+                T.copy(dA_cs_rev_shared, dA_cs_rev_dk_frag)
+                for cs in T.Parallel(chunk_size):
+                    dA_cs_rev_dk_frag[cs] = T.exp(dA_cs_rev_dk_frag[cs])
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    dk_frag[csr, n] *= dA_cs_rev_dk_frag[csr // R]
+
+                dk_intrachunk_frag = T.alloc_fragment([fused_chunk_size, fused_chunk_size], accum_dtype)
+                T.gemm(PsiV_shared, dPhiO_shared, dk_intrachunk_frag, transpose_B=True, clear_accum=True)
+
+                # DSSDA: contributions are auto-zeroed at tail because dPhiO is zero-masked
+                kq_frag = T.alloc_fragment([fused_chunk_size, fused_chunk_size], dtype)
+                T.copy(lkq_masked__or__dkq_masked_shared, kq_frag)
+                for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
+                    kq_frag[csr_i, csr_j] *= dk_intrachunk_frag[csr_i, csr_j]
+                kq_frag_reshaped = T.view(kq_frag, shape=[fused_chunk_size, chunk_size, R])
+                interchunk_dda_prereduce_frag = T.alloc_fragment([fused_chunk_size, chunk_size], accum_dtype)
+                T.reduce_sum(kq_frag_reshaped, interchunk_dda_prereduce_frag, dim=-1, clear=True)
+                interchunk_dda_prereduce_frag_reshaped = T.view(interchunk_dda_prereduce_frag, shape=[chunk_size, R, chunk_size])
+                interchunk_dda_frag = T.alloc_fragment([chunk_size, chunk_size], accum_dtype)
+                T.reduce_sum(interchunk_dda_prereduce_frag_reshaped, interchunk_dda_frag, dim=1, clear=True)
+                T.copy(interchunk_dda_frag, DSSDA[i_b, i_h, global_chunk_idx, :, :])
+
+                for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
+                    dk_intrachunk_frag[csr_i, csr_j] = T.if_then_else(
+                        csr_i // R < csr_j // R,
+                        dk_intrachunk_frag[csr_i, csr_j] * T.exp(SEGSUM[i_b, i_h, global_chunk_idx, csr_j // R, csr_i // R]),
+                        0.0)
+                T.copy(dk_intrachunk_frag, lkq_masked__or__dkq_masked_shared)
+                T.copy(dk_frag, dk_shared)
+                dk_nodiag_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
+                T.copy(dk_shared, dk_nodiag_frag)
+                T.gemm(lkq_masked__or__dkq_masked_shared, q_shared, dk_nodiag_frag, clear_accum=False)
+
+                k_factor_frag = T.alloc_fragment([chunk_size, R, N], accum_dtype)
+                T.copy(k_pre_trap_shared, T.view(k_factor_frag, shape=[fused_chunk_size, N]))
+                dfactor_prereduce_frag = T.alloc_fragment([chunk_size, R, N], accum_dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N):
+                    dfactor_prereduce_frag[cs, r, n] = k_factor_frag[cs, r, n] * dk_nodiag_frag[cs * R + r, n]
+                dfactor_frag = T.alloc_fragment([chunk_size], accum_dtype)
+                T.reduce_sum(T.view(dfactor_prereduce_frag, shape=[chunk_size, R * N]), dfactor_frag, dim=-1, clear=True)
+                if eff_tail < chunk_size:
+                    for cs in T.Parallel(chunk_size):
+                        if cs < eff_tail:
+                            DFACTOR[i_b, i_h, chunk_start + cs] = dfactor_frag[cs]
+                else:
+                    T.copy(dfactor_frag, DFACTOR[i_b, i_h, chunk_start:chunk_start + chunk_size])
+
+                trap_scale_dk_frag = T.alloc_fragment([chunk_size], dtype)
+                T.copy(trap_scale_shared, trap_scale_dk_frag)
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    dk_nodiag_frag[csr, n] *= trap_scale_dk_frag[csr // R]
+                T.copy(dk_nodiag_frag, dk_shared)
+
+                # --- State-passing ddA + interchunk dQ ---
+                T.copy(STATES[i_b, i_h, global_chunk_idx, :, :], states_shared)
+                states_frag = T.alloc_fragment([N, P], T.float32)
+                T.copy(states_shared, states_frag)
+                ddA_state_passing = T.alloc_fragment([1], T.float32)
+                ddA_state_passing_prereduce_frag = T.alloc_fragment([N, P], T.float32)
+                da_cs_sum = T.alloc_var(T.float32)
+                T.copy(DA_CS[i_b, i_h, da_cs_end_idx], da_cs_sum)
+                for n, p in T.Parallel(N, P):
+                    ddA_state_passing_prereduce_frag[n, p] = (
+                        states_frag[n, p] * dstates_frag[n, p] * T.exp(da_cs_sum))
+                T.reduce_sum(T.view(ddA_state_passing_prereduce_frag, shape=[N * P]),
+                             ddA_state_passing, dim=-1, clear=True)
+                if eff_tail < chunk_size:
+                    for cs in T.Parallel(chunk_size):
+                        if cs < eff_tail:
+                            DDA[i_b, i_h, chunk_start + cs] = ddA_state_passing[0]
+                else:
+                    dda_frag = T.alloc_fragment([chunk_size], T.float32)
+                    for cs in T.Parallel(chunk_size):
+                        dda_frag[cs] = ddA_state_passing[0]
+                    T.copy(dda_frag, DDA[i_b, i_h, chunk_start:chunk_start + chunk_size])
+
+                dq_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
+                T.gemm(dPhiO_shared, states_shared, dq_frag, transpose_B=True, clear_accum=True)
+
+                dda_cs_prereduce_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
+                T.copy(q_shared, dda_cs_prereduce_frag)
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    dda_cs_prereduce_frag[csr, n] *= dq_frag[csr, n]
+                dda_cs_frag = T.alloc_fragment([chunk_size], accum_dtype)
+                T.reduce_sum(T.view(dda_cs_prereduce_frag, shape=[chunk_size, R * N]),
+                             dda_cs_frag, dim=-1, clear=True)
+                if eff_tail < chunk_size:
+                    for cs in T.Parallel(chunk_size):
+                        if cs < eff_tail:
+                            DDA_CS[i_b, i_h, chunk_start + cs] = dda_cs_frag[cs]
+                else:
+                    T.copy(dda_cs_frag, DDA_CS[i_b, i_h, chunk_start:chunk_start + chunk_size])
+
+                dA_cs_dq_frag = T.alloc_fragment([chunk_size], T.float32)
+                dA_cs_shared = T.alloc_shared([chunk_size], T.float32)
+                T.copy(DA_CS[i_b, i_h, chunk_start:chunk_start + chunk_size], dA_cs_shared)
+                T.copy(dA_cs_shared, dA_cs_dq_frag)
+                for csr, n in T.Parallel(fused_chunk_size, N):
+                    dq_frag[csr, n] *= T.exp(dA_cs_dq_frag[csr // R])
+                T.copy(dq_frag, dq_shared)
+                dq_combined_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
+                T.copy(dq_shared, dq_combined_frag)
+                T.gemm(lkq_masked__or__dkq_masked_shared, k_shared, dq_combined_frag, transpose_A=True, clear_accum=False)
+                T.copy(dq_combined_frag, dq_shared)
+
+                # --- Inverse rotary for dK and dQ + dAngles ---
+                angles_dk_frag = T.alloc_fragment([chunk_size, N // rotary_dim_divisor], T.float32)
+                T.copy(ANGLES[i_b, chunk_start:chunk_start + chunk_size, i_h, :], angles_dk_frag)
+                dk_first_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                dk_second_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                k_prerot_first_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                k_prerot_second_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    dk_first_half_frag[cs, r, n] = dk_shared[cs * R + r, n]
+                    dk_second_half_frag[cs, r, n] = dk_shared[cs * R + r, N // 2 + n]
+                    k_prerot_first_half_frag[cs, r, n] = k_pre_rot_shared[cs * R + r, n]
+                    k_prerot_second_half_frag[cs, r, n] = k_pre_rot_shared[cs * R + r, N // 2 + n]
+                dangle_dk_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], T.float32)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    dangle_dk_frag[cs, r, n] = \
+                        dk_first_half_frag[cs, r, n] * (-k_prerot_first_half_frag[cs, r, n] * T.sin(angles_dk_frag[cs, n]) - k_prerot_second_half_frag[cs, r, n] * T.cos(angles_dk_frag[cs, n])) + \
+                        dk_second_half_frag[cs, r, n] * (k_prerot_first_half_frag[cs, r, n] * T.cos(angles_dk_frag[cs, n]) - k_prerot_second_half_frag[cs, r, n] * T.sin(angles_dk_frag[cs, n]))
+                T.copy(T.view(dangle_dk_frag, shape=[fused_chunk_size, N // rotary_dim_divisor]), dangle_dk__or__dq_shared)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    dk_shared[cs * R + r, n] = T.cos(angles_dk_frag[cs, n]) * dk_first_half_frag[cs, r, n] + T.sin(angles_dk_frag[cs, n]) * dk_second_half_frag[cs, r, n]
+                    dk_shared[cs * R + r, N // 2 + n] = -T.sin(angles_dk_frag[cs, n]) * dk_first_half_frag[cs, r, n] + T.cos(angles_dk_frag[cs, n]) * dk_second_half_frag[cs, r, n]
+
+                dk_combined_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
+                T.copy(dk_shared, dk_combined_frag)
+                q_dk_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
+                T.copy(q_pre_rot_shared, q_dk_frag)
+                q_dk_frag_reshaped = T.view(q_dk_frag, [chunk_size, R, N])
+                for csr_in, n in T.Parallel(fused_chunk_size, N):
+                    cs = csr_in // R
+                    for r_out in T.serial(R):
+                        csr_out = cs * R + r_out
+                        dk_combined_frag[csr_in, n] += dqk_from_diag_shared[csr_out, csr_in] * q_dk_frag_reshaped[cs, r_out, n]
+                if eff_tail < chunk_size:
+                    for csr, n in T.Parallel(fused_chunk_size, N):
+                        if csr < eff_tail * R:
+                            DK[i_b, fused_chunk_start + csr, i_h, n] = dk_combined_frag[csr, n]
+                else:
+                    T.copy(dk_combined_frag, DK[i_b, fused_chunk_start:fused_chunk_start + fused_chunk_size, i_h, :])
+
+                # dQ inverse rotary
+                angles_dq_frag = T.alloc_fragment([chunk_size, N // rotary_dim_divisor], T.float32)
+                T.copy(ANGLES[i_b, chunk_start:chunk_start + chunk_size, i_h, :], angles_dq_frag)
+                dq_first_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                dq_second_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    dq_first_half_frag[cs, r, n] = dq_shared[cs * R + r, n]
+                    dq_second_half_frag[cs, r, n] = dq_shared[cs * R + r, N // 2 + n]
+                q_prerot_first_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                q_prerot_second_half_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], dtype)
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    q_prerot_first_half_frag[cs, r, n] = q_pre_rot_shared[cs * R + r, n]
+                    q_prerot_second_half_frag[cs, r, n] = q_pre_rot_shared[cs * R + r, N // 2 + n]
+                dangle_dq_frag = T.alloc_fragment([chunk_size, R, N // rotary_dim_divisor], T.float32)
+                T.copy(dangle_dk__or__dq_shared, T.view(dangle_dq_frag, shape=[fused_chunk_size, N // rotary_dim_divisor]))
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    dangle_dq_frag[cs, r, n] += \
+                        dq_first_half_frag[cs, r, n] * (-q_prerot_first_half_frag[cs, r, n] * T.sin(angles_dq_frag[cs, n]) - q_prerot_second_half_frag[cs, r, n] * T.cos(angles_dq_frag[cs, n])) + \
+                        dq_second_half_frag[cs, r, n] * (q_prerot_first_half_frag[cs, r, n] * T.cos(angles_dq_frag[cs, n]) - q_prerot_second_half_frag[cs, r, n] * T.sin(angles_dq_frag[cs, n]))
+                dangle_frag_reduced = T.alloc_fragment([chunk_size, N // rotary_dim_divisor], T.float32)
+                T.clear(dangle_frag_reduced)
+                for cs, n in T.Parallel(chunk_size, N // rotary_dim_divisor):
+                    for r in T.serial(R):
+                        dangle_frag_reduced[cs, n] += dangle_dq_frag[cs, r, n]
+                if eff_tail < chunk_size:
+                    for cs, n in T.Parallel(chunk_size, N // rotary_dim_divisor):
+                        if cs < eff_tail:
+                            DANGLES[i_b, chunk_start + cs, i_h, n] = dangle_frag_reduced[cs, n]
+                else:
+                    T.copy(dangle_frag_reduced, DANGLES[i_b, chunk_start:chunk_start + chunk_size, i_h, :])
+                for cs, r, n in T.Parallel(chunk_size, R, N // rotary_dim_divisor):
+                    dq_shared[cs * R + r, n] = T.cos(angles_dk_frag[cs, n]) * dq_first_half_frag[cs, r, n] + T.sin(angles_dk_frag[cs, n]) * dq_second_half_frag[cs, r, n]
+                    dq_shared[cs * R + r, N // 2 + n] = -T.sin(angles_dk_frag[cs, n]) * dq_first_half_frag[cs, r, n] + T.cos(angles_dk_frag[cs, n]) * dq_second_half_frag[cs, r, n]
+                T.copy(dq_shared, dq_frag)
+                for csr_out, n in T.Parallel(fused_chunk_size, N):
+                    cs = csr_out // R
+                    for r_in in T.serial(R):
+                        csr_in = cs * R + r_in
+                        dq_frag[csr_out, n] += dqk_from_diag_shared[csr_out, csr_in] * k_pre_rot_shared[csr_in, n]
+                if eff_tail < chunk_size:
+                    for csr, n in T.Parallel(fused_chunk_size, N):
+                        if csr < eff_tail * R:
+                            DQ[i_b, fused_chunk_start + csr, i_h, n] = dq_frag[csr, n]
+                else:
+                    T.copy(dq_frag, DQ[i_b, fused_chunk_start:fused_chunk_start + fused_chunk_size, i_h, :])
+
+                # --- Update reverse-passed state gradient ---
+                da_cs_sum_dstates = T.alloc_var(T.float32)
+                T.copy(DA_CS[i_b, i_h, da_cs_end_idx], da_cs_sum_dstates)
+                for n, p in T.Parallel(N, P):
+                    dstates_frag[n, p] *= T.exp(da_cs_sum_dstates)
+                dPhiO_scaled_frag = T.alloc_fragment([fused_chunk_size, P], dtype)
+                T.copy(dPhiO_shared, dPhiO_scaled_frag)
+                dA_cs_dPhiO_frag = T.alloc_fragment([chunk_size], T.float32)
+                T.copy(dA_cs_shared, dA_cs_dPhiO_frag)
+                for csr, p in T.Parallel(fused_chunk_size, P):
+                    dPhiO_scaled_frag[csr, p] *= T.exp(dA_cs_dPhiO_frag[csr // R])
+                T.gemm(q_shared, dPhiO_scaled_frag, dstates_frag, transpose_A=True, clear_accum=False)
+                T.copy(dstates_frag, dstates_shared)
+
+            T.copy(dPsi_acc, DMIMO_V[i_b, i_h, i_ns, :, :])
+            if hasD:
+                T.copy(dD_frag, DD[i_b, i_h, i_ns])
+
+    return mamba_mimo_bwd_bwd_kernel
+
+
+def mamba_mimo_bwd_combined_varlen(
+        dout,
+        q,
+        k,
+        v,
+        q_bias,
+        k_bias,
+        mimo_v,
+        mimo_o,
+        z,
+        mimo_z,
+        angles,
+        dA_cs,
+        dA_cs_rev,
+        dt,
+        trap,
+        D,
+        segsum,
+        chunk_size,
+        rotary_dim_divisor,
+        dtype,
+        cu_seqlens=None,
+        bf_threads=128,
+        bf_num_stages=0,
+        bb_threads=256,
+        bb_num_stages=0,
+        ):
+    """
+    Varlen combined backward pass (bwd-fwd + bwd-bwd).
+
+    Dispatches to ``mamba_mimo_bwd_combined`` (non-varlen) when
+    ``cu_seqlens`` is None; otherwise runs the two varlen TileLang kernels
+    followed by the Triton utility kernels from
+    ``mamba3_mimo_utils.py``.
+
+    Args:
+        dout:             Upstream gradient, shape ``[B, S, H, P]`` or
+                          ``[B, S, R, H, P]`` depending on reduceO.
+        q, k, v:          Packed activations.
+        q_bias, k_bias:   Per-head per-R biases, shape ``[H, R, N]``.
+        mimo_v:           Psi projection, shape ``[H, R, P]``.
+        mimo_o:           Phi projection, shape ``[H, R, P]``, or None.
+        z:                Optional gating tensor, shape ``[B, S, H, P]``.
+        mimo_z:           Optional Zeta projection, shape ``[H, R, P]``.
+        angles:           Rotary angles.
+        dA_cs:            Forward cumsum of discretised A.
+        dA_cs_rev:        Reverse cumsum of discretised A.
+        dt:               Discretised time step.
+        trap:             Pre-sigmoid trapezoidal modulator.
+        D:                Optional skip-connection vector, shape ``[H]``.
+        segsum:           Per-chunk lower-triangular log-decay matrix.
+        chunk_size:       Tokens per chunk.
+        rotary_dim_divisor: Divisor for the rotary head dimension.
+        dtype:            Compute dtype (torch.dtype or string).
+        cu_seqlens:       Optional int32 tensor of shape ``[NS+1]``.
+                          None → dense (non-varlen) path.
+        bf_threads:       Threads for the bwd-fwd kernel.
+        bf_num_stages:    Pipeline stages for the bwd-fwd kernel.
+        bb_threads:       Threads for the bwd-bwd kernel.
+        bb_num_stages:    Pipeline stages for the bwd-bwd kernel.
+
+    Returns:
+        Tuple of gradients:
+            (dq, dk, dv, ddA, ddt, dtrap,
+             dq_bias, dk_bias, dmimo_v, dmimo_z, dmimo_o,
+             dangles, dD, dz)
+    """
+    if cu_seqlens is None:
+        return mamba_mimo_bwd_combined(
+            dout, q, k, v, q_bias, k_bias, mimo_v, mimo_o,
+            z, mimo_z, angles, dA_cs, dA_cs_rev, dt, trap, D,
+            segsum, chunk_size, rotary_dim_divisor, dtype,
+            bf_threads, bf_num_stages, bb_threads, bb_num_stages,
+        )
+
+    B, S, R, G, N = q.shape
+    H, P = v.shape[-2], v.shape[-1]
+    NS = cu_seqlens.shape[0] - 1
+    reduceO = mimo_o is not None
+    max_nchunks = (S // chunk_size) + NS
+
+    if isinstance(dtype, torch.dtype):
+        dtype_str = str(dtype).replace("torch.", "")
+    else:
+        dtype_str = dtype
+
+    dmimo_o = torch.empty([B, H, NS, R, P], dtype=mimo_v.dtype, device=mimo_v.device) if reduceO else None
+    states = torch.empty([B, H, max_nchunks, N, P], dtype=v.dtype, device=v.device)
+
+    if z is not None:
+        dz_tilelang = torch.empty_like(v)
+        dmimo_z = torch.empty([B, H, NS, R, P], dtype=mimo_v.dtype, device=mimo_v.device)
+    else:
+        dz_tilelang = None
+        dmimo_z = None
+    qk_dot = torch.zeros([B, H, S, R, R], dtype=q.dtype, device=q.device)
+
+    bwd_fwd_kernel = mamba_mimo_bwd_fwd(
+        B, S, H, G, N, P, R,
+        z is not None, D is not None, reduceO,
+        NS, chunk_size, rotary_dim_divisor, dtype_str,
+        bf_threads, bf_num_stages)
+    bwd_fwd_kernel(
+        dout, q, k, v, q_bias, k_bias, mimo_v, mimo_o,
+        dmimo_o, states,
+        z, mimo_z, dz_tilelang, dmimo_z,
+        angles, dA_cs, dA_cs_rev, dt, trap, D,
+        qk_dot, segsum, cu_seqlens,
+    )
+    if reduceO:
+        dmimo_o = dmimo_o.sum(dim=(0, 2))
+
+    dq_tilelang = torch.empty([B, S, R, H, N], dtype=q.dtype, device=q.device)
+    dk_tilelang = torch.empty([B, S, R, H, N], dtype=k.dtype, device=k.device)
+    dv_tilelang = torch.empty_like(v)
+    dmimo_v = torch.empty([B, H, NS, R, P], dtype=mimo_v.dtype, device=mimo_v.device)
+    dD = torch.empty([B, H, NS], dtype=D.dtype, device=D.device) if D is not None else None
+    dangles = torch.zeros([B, S, H, N // rotary_dim_divisor], dtype=angles.dtype, device=angles.device)
+    dfactor = torch.zeros([B, H, S], dtype=torch.float32, device=trap.device)
+    dgamma_diag = torch.zeros([B, H, S], dtype=torch.float32, device=trap.device)
+    ddA = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
+    dSSdA = torch.zeros([B, H, max_nchunks, chunk_size, chunk_size], dtype=torch.float32, device=dt.device)
+    ddA_cs_rev = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
+    ddA_cs = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
+
+    bwd_bwd_kernel = mamba_mimo_bwd_bwd(
+        B, S, H, G, N, P, R,
+        z is not None, D is not None, reduceO,
+        NS, chunk_size, rotary_dim_divisor, dtype_str,
+        bb_threads, bb_num_stages)
+    bwd_bwd_kernel(
+        dout, q, k, v, q_bias, k_bias, mimo_v, mimo_o,
+        dk_tilelang.view(B, S * R, H, N),
+        dv_tilelang, dmimo_v, states,
+        dq_tilelang.view(B, S * R, H, N),
+        z, mimo_z, angles, dA_cs, dA_cs_rev, dt, trap,
+        dfactor, dgamma_diag, dangles, D, dD,
+        qk_dot, ddA, dSSdA, ddA_cs_rev, ddA_cs,
+        segsum, cu_seqlens,
+    )
+
+    if G == 1:
+        dq_bias_tilelang = dq_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
+        dk_bias_tilelang = dk_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
+        dq_tilelang = dq_tilelang.sum(dim=3, keepdim=True)
+        dk_tilelang = dk_tilelang.sum(dim=3, keepdim=True)
+        dmimo_v = dmimo_v.sum(dim=(0, 2))
+        dmimo_z = dmimo_z.sum(dim=(0, 2)) if dmimo_z is not None else None
+        dD = dD.sum(dim=(0, 2)) if dD is not None else None
+    elif G == H:
+        dq_bias_tilelang = dq_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
+        dk_bias_tilelang = dk_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
+        dmimo_v = dmimo_v.sum(dim=(0, 2))
+        dmimo_z = dmimo_z.sum(dim=(0, 2)) if dmimo_z is not None else None
+        dD = dD.sum(dim=(0, 2)) if dD is not None else None
+    else:
+        raise ValueError(f"G value of {G} is not currently supported!")
+
+    ddt, dtrap = bwd_dtrap_ddt_triton_varlen(trap, dt, dfactor, dgamma_diag, chunk_size, cu_seqlens)
+
+    ddA += bwd_dadt_fused_triton_varlen(
+        dSSdA, segsum, ddA_cs, ddA_cs_rev, dA_cs, dA_cs_rev, chunk_size, cu_seqlens
+    )
+
+    return (dq_tilelang, dk_tilelang, dv_tilelang, 
+            ddA, ddt, dtrap, dq_bias_tilelang, dk_bias_tilelang,
+            dmimo_v, dmimo_z, dmimo_o, dangles, 
+            dD, dz_tilelang)

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
@@ -21,7 +21,7 @@ share the same mathematical kernel; the differences are:
   the non-varlen shapes).
 
 Public API:
-    tl_fused_chunk_fwd(..., cu_seqlens=None) — forward pass; falls back to
+    mamba_mimo_forward_varlen(..., cu_seqlens=None) — forward pass; falls back to
         the non-varlen path when cu_seqlens is None.
 
 Copyright (c) 2026, Dao AI Lab, Goombalab

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
@@ -1,9 +1,30 @@
 """
-Tilelang implementation of Mamba3 forward kernel,
-with MIMO support.
+Tilelang implementation of the Mamba3 forward kernel with MIMO support
+and variable-length sequence (varlen) support.
+
+This is the varlen counterpart of ``mamba3_mimo_fwd.py``.  The two files
+share the same mathematical kernel; the differences are:
+
+* **NS parameter** — number of packed sequences in the batch.  When NS > 1
+  the kernel dispatches one thread-block per sequence (``i_ns``) in addition
+  to the per-head (``i_h``) and per-batch (``i_b``) dimensions.
+* **CU_SEQLENS tensor** — int32 prefix-sum array of shape ``[NS+1]``; entry
+  ``i`` holds the token offset where sequence ``i`` begins in the packed
+  ``[B, S, ...]`` tensors.
+* **max_nchunks** — ``(S // chunk_size) + NS`` to accommodate the global
+  chunk layout where every sequence boundary introduces an extra padding
+  chunk slot.
+* **SEGSUM shape** — ``[B, H, max_nchunks, C, C]`` (non-varlen uses
+  ``[B, H, nchunks, C, C]`` with ``nchunks = S // chunk_size``).
+* **FINAL_STATE / FINAL_K shapes** — ``(NS, H, N, P)`` / ``(NS, R, H, N)``
+  when NS > 1, or ``(B, H, N, P)`` / ``(B, R, H, N)`` otherwise (matching
+  the non-varlen shapes).
+
+Public API:
+    tl_fused_chunk_fwd(..., cu_seqlens=None) — forward pass; falls back to
+        the non-varlen path when cu_seqlens is None.
 
 Copyright (c) 2026, Dao AI Lab, Goombalab
-
 """
 
 import torch
@@ -46,6 +67,7 @@ def mamba_mimo_fwd(
     hasZ,
     hasD,
     reduceO,
+    NS: int = 1,
     return_final_state=False,
     chunk_size: int = 16,
     rotary_dim_divisor = 4,
@@ -53,11 +75,37 @@ def mamba_mimo_fwd(
     threads: int = 128,
     num_stages: int = 0,
 ) -> torch.Tensor:
+    """
+    TileLang kernel factory for the varlen Mamba3 chunked forward pass.
+
+    Varlen additions vs. ``mamba_mimo_fwd`` in
+    ``mamba3_mimo_fwd.py``:
+
+    * NS > 1 activates the per-sequence (``i_ns``) grid dimension and reads
+      per-sequence token offsets from ``CU_SEQLENS``.
+    * ``max_nchunks = (S // chunk_size) + NS`` accommodates the global chunk
+      layout where each sequence boundary introduces one extra slot.
+    * SEGSUM shape becomes ``[B, H, max_nchunks, C, C]``.
+    * FINAL_STATE shape is ``(NS, H, N, P)`` (vs. ``(B, H, N, P)``).
+    * FINAL_K shape is ``(NS, R, H, N)`` (vs. ``(B, R, H, N)``).
+
+    When NS == 1 (or cu_seqlens is None) the kernel degenerates to the
+    non-varlen behaviour.
+    """
 
     accum_dtype = 'float32'
 
-    nchunks = tilelang.cdiv(S, chunk_size)
-    tail_len = S % chunk_size
+    # Block sizes for K and V dimensions - use full dimensions (no tiling)
+    # assert S % chunk_size == 0, "Sequence length must be divisible by chunk_size"
+
+    if NS > 1:
+        max_nchunks = (S//chunk_size) + NS
+        Final_State_shape = (NS, H, N, P)
+        Final_K_shape = (NS, R, H, N)
+    else:
+        max_nchunks = tilelang.cdiv(S, chunk_size)
+        Final_State_shape = (B, H, N, P)
+        Final_K_shape = (B, R, H, N)
     fused_chunk_size = chunk_size * R
 
     if reduceO:
@@ -84,37 +132,53 @@ def mamba_mimo_fwd(
             DA_CS_REV: T.Tensor([B, H, S], T.float32), # type: ignore
             DT: T.Tensor([B, H, S], T.float32), # type: ignore
             TRAP: T.Tensor([B, H, S], dtype), # type: ignore
-            SEGSUM: T.Tensor([B, H, nchunks, chunk_size, chunk_size], T.float32), # type: ignore
+            SEGSUM: T.Tensor([B, H, max_nchunks, chunk_size, chunk_size], T.float32), # type: ignore
+            CU_SEQLENS: T.Tensor([NS+1], dtype=T.int32), # type: ignore
 
-            FINAL_STATE: T.Tensor([B, H, N, P], T.float32),  # type: ignore
-            FINAL_K: T.Tensor([B, R, H, N], dtype)  # type: ignore
+            FINAL_STATE: T.Tensor(Final_State_shape, T.float32),  # type: ignore
+            FINAL_K: T.Tensor(Final_K_shape, dtype)  # type: ignore
             ):
         """
         Overview:
-            Fused chunked forward pass that combines MIMO projections with recurrent state updates.
-            Computes interchunk and intrachunk contributions with optional D and Z paths,
-            then writes output activations.
+            Varlen fused chunked forward pass.  Identical in math to the dense
+            kernel in ``mamba3_mimo_fwd.py``; differs in the grid and
+            sequence-bounds logic:
+
+            * Grid: ``T.Kernel(H, NS, B)`` — extra ``i_ns`` dimension iterates
+              over packed sequences.
+            * Per-sequence bounds are read from ``CU_SEQLENS[i_ns]`` /
+              ``CU_SEQLENS[i_ns+1]``; the loop only visits chunks that belong to
+              sequence ``i_ns``.
+            * SEGSUM is indexed by the *global* chunk index
+              ``start_chunk_ind + i`` where
+              ``start_chunk_ind = (CU_SEQLENS[i_ns] // chunk_size) + i_ns``.
 
         Inputs:
             - Activations: Q, K, V.
-            - Projection parameters/biases: MIMO_V (Psi), MIMO_O (Phi), optional MIMO_Z (Zeta), ANGLES,
-              and Q_BIAS/K_BIAS.
-            - Optional modifiers: Z, and D.
+            - Projection parameters/biases: MIMO_V (Psi), MIMO_O (Phi),
+              optional MIMO_Z (Zeta), ANGLES, and Q_BIAS/K_BIAS.
+            - Optional modifiers: Z and D.
             - Discretization tensors: DA_CS, DA_CS_REV, DT, TRAP, and SEGSUM.
+            - CU_SEQLENS: int32 prefix-sum of per-sequence lengths, shape
+              ``[NS+1]``.
 
         Outputs:
             - O: fused forward output activations.
-            - FINAL_STATE: final recurrent states (if return_final_state is True).
-            - FINAL_K: final K tensor (if return_state is True, for use in decode)
+            - FINAL_STATE: final recurrent states per sequence (shape
+              ``[NS, H, N, P]`` when NS > 1; written only when
+              return_final_state is True).
+            - FINAL_K: final K per sequence (shape ``[NS, R, H, N]`` when
+              NS > 1; written only when return_final_state is True).
 
         Notation:
-            - Psi: MIMO X projection.
-            - Phi: MIMO O projection.
-            - Zeta: MIMO Z projection.
-            - Trap: convex-combination modulator used in exponential-trapezoidal discretization.
+            - Psi: MIMO X projection (MIMO_V).
+            - Phi: MIMO O projection (MIMO_O).
+            - Zeta: MIMO Z projection (MIMO_Z).
+            - Trap: convex-combination modulator used in
+              exponential-trapezoidal discretization.
         """
         
-        with T.Kernel(H, B, threads=threads) as (i_h, i_b):
+        with T.Kernel(H, NS, B, threads=threads) as (i_h, i_ns, i_b):
             # --- Kernel Setup ---
             # GQA support: map V head to Q/K head
             i_h_qk = i_h // (H // G)
@@ -167,18 +231,47 @@ def mamba_mimo_fwd(
             T.copy(Q_BIAS[i_h, :, :], q_bias_frag)
             T.copy(K_BIAS[i_h, :, :], k_bias_frag)
 
+            # Determine the current sequence length for variable-length support.
+            # Use alloc_var for mutable scalar values to avoid immutable rebind warnings.
+            start_seq_ind = T.alloc_var(T.int32)
+            start_chunk_ind = T.alloc_var(T.int32)
+            seq_len = T.alloc_var(T.int32)
+            seq_end = T.alloc_var(T.int32)
+            full_nchunks = T.alloc_var(T.int32)
+            tail_len = T.alloc_var(T.int32)
+            if NS > 1:
+                start_seq_ind = CU_SEQLENS[i_ns]
+                start_chunk_ind = (start_seq_ind // chunk_size) + i_ns
+                seq_len = CU_SEQLENS[i_ns + 1] - CU_SEQLENS[i_ns]
+                seq_end = start_seq_ind + seq_len
+                full_nchunks = seq_len // chunk_size
+                tail_len = seq_len % chunk_size
+            else:
+                start_seq_ind = 0
+                start_chunk_ind = 0
+                seq_len = S
+                seq_end = S
+                full_nchunks = S // chunk_size
+                tail_len = S % chunk_size
+            if tail_len > 0:
+                full_nchunks += 1
+
             # --- Chunk Loop ---
-            for i in T.Pipelined(0, nchunks, num_stages=num_stages):
-                chunk_start = i * chunk_size
+            for i in T.Pipelined(0, full_nchunks, num_stages=num_stages):
+                chunk_start = start_seq_ind + i * chunk_size
 
                 # --- Discretization Factors (Shifted Gamma + Trap Scale) ---
                 trap_shifted_frag = T.alloc_fragment([chunk_size], T.float32)
                 T.copy(TRAP[i_b, i_h, chunk_start+1: chunk_start+chunk_size+1], trap_shifted_frag)
                 dt_shifted_frag = T.alloc_fragment([chunk_size], dtype)
-                T.copy(DT[i_b, i_h, chunk_start+1: chunk_start+chunk_size+1], dt_shifted_frag)
+                if i == full_nchunks - 1:
+                    for cs in T.Parallel(chunk_size):
+                        dt_shifted_frag[cs] = T.if_then_else(chunk_start + cs + 1 < seq_end, DT[i_b, i_h, chunk_start + 1 + cs], 0.0)
+                else:
+                    T.copy(DT[i_b, i_h, chunk_start+1: chunk_start+chunk_size+1], dt_shifted_frag)
                 shifted_gamma_frag = T.alloc_fragment([chunk_size], dtype)
                 for cs in T.Parallel(chunk_size):
-                    shifted_gamma_frag[cs] = T.if_then_else(chunk_start + cs < (S - 1), 
+                    shifted_gamma_frag[cs] = T.if_then_else(chunk_start + cs < (seq_end - 1), 
                                                             dt_shifted_frag[cs] * T.sigmoid(-trap_shifted_frag[cs]), 
                                                             0.0)
                 shifted_gamma_shared = T.alloc_shared([chunk_size], dtype)
@@ -272,11 +365,16 @@ def mamba_mimo_fwd(
                     k_shared[cs*R + r, n] = T.cos(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] - T.sin(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
                     k_shared[cs*R + r, N//2 + n] = T.sin(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] + T.cos(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
 
-                if i == nchunks - 1 and return_final_state:
-                    seq_boundary = T.min(chunk_start + chunk_size, S) - chunk_start
-                    for csr, n in T.Parallel(fused_chunk_size, N):
-                        if csr >= (seq_boundary - 1) * R and csr < seq_boundary * R:  # Only copy the last chunk's R rows to FINAL_K
-                            FINAL_K[i_b, csr % R, i_h, n] = k_shared[csr, n]
+                if return_final_state and i == full_nchunks - 1:
+                    seq_boundary = seq_end - chunk_start
+                    if NS > 1:
+                        for csr, n in T.Parallel(fused_chunk_size, N):
+                            if csr >= (seq_boundary - 1) * R and csr < seq_boundary * R:  # Only copy the last chunk's R rows to FINAL_K
+                                FINAL_K[i_ns, csr % R, i_h, n] = k_shared[csr, n]
+                    else:
+                        for csr, n in T.Parallel(fused_chunk_size, N):
+                            if csr >= (seq_boundary - 1) * R and csr < seq_boundary * R:  # Only copy the last chunk's R rows to FINAL_K
+                                FINAL_K[i_b, csr % R, i_h, n] = k_shared[csr, n]
 
                 k_trap_scaled_frag = T.alloc_fragment([fused_chunk_size, N], dtype)
                 T.copy(k_shared, k_trap_scaled_frag)
@@ -295,7 +393,7 @@ def mamba_mimo_fwd(
                     qk_intrachunk_masked_frag[csr_i, csr_j] = T.if_then_else(
                                                 csr_i//R > csr_j//R, # NOTE: we do indeed want to exclude the diagonal
                                                 qk_intrachunk_frag[csr_i, csr_j] 
-                                                * T.exp(SEGSUM[i_b, i_h, i, csr_i//R, csr_j//R]),
+                                                * T.exp(SEGSUM[i_b, i_h, start_chunk_ind+i, csr_i//R, csr_j//R]),
                                                 0.0
                                             )
 
@@ -360,7 +458,12 @@ def mamba_mimo_fwd(
                     for r in T.serial(R):
                         for cs, p in T.Parallel(chunk_size, P):
                             o_frag[cs, p] += lqk_PsiV_reshaped_shared[cs, r, p]
-                    T.copy(o_frag, O[i_b, chunk_start:chunk_start+chunk_size, i_h, :])
+                    if i == (full_nchunks - 1) and tail_len > 0:
+                        for cs, p in T.Parallel(chunk_size, P):
+                            if cs < tail_len:
+                                O[i_b, chunk_start+cs, i_h, p] = o_frag[cs, p]
+                    else:
+                        T.copy(o_frag, O[i_b, chunk_start:chunk_start+chunk_size, i_h, :])
                 else:
                     if hasZ:
                         z_frag = T.alloc_fragment([chunk_size, P], dtype)
@@ -381,7 +484,12 @@ def mamba_mimo_fwd(
                         # T.copy(lqk_PsiV_reshaped_frag, lqk_PsiV_reshaped_shared)
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             lqk_PsiV_reshaped_shared[cs, r, p] = o_mimo_accum_frag[cs* R + r, p]
-                    T.copy(lqk_PsiV_reshaped_shared, O[i_b, chunk_start:chunk_start+chunk_size, :, i_h, :])
+                    if i == (full_nchunks - 1) and tail_len > 0:
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            if cs < tail_len:
+                                O[i_b, chunk_start+cs, r, i_h, p] = lqk_PsiV_reshaped_shared[cs, r, p]
+                    else:
+                        T.copy(lqk_PsiV_reshaped_shared, O[i_b, chunk_start:chunk_start+chunk_size, :, i_h, :])
 
                 # --- Recurrent State Update ---
                 # DA_CS_REV scales per-step K contributions for state accumulation.
@@ -395,51 +503,107 @@ def mamba_mimo_fwd(
 
                 # DA_CS(last) applies the chunk-level decay to the carried state.
                 da_cs_sum = T.alloc_var(T.float32)
-                if tail_len > 0 and i == nchunks - 1:
-                    T.copy(DA_CS[i_b, i_h, S - 1], da_cs_sum)
-                    if return_final_state:
-                        for csr, n in T.Parallel(fused_chunk_size, N):
-                            k_state_frag[csr, n] = T.if_then_else(csr < tail_len * R, k_state_frag[csr, n], 0.0)
+                if return_final_state and i == (full_nchunks - 1) and tail_len > 0:
+                    T.copy(DA_CS[i_b, i_h, seq_end - 1], da_cs_sum)
+                    for csr, n in T.Parallel(fused_chunk_size, N):
+                        k_state_frag[csr, n] = T.if_then_else(csr < tail_len * R, k_state_frag[csr, n], 0.0)
                 else:
                     T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum)
+                
                 for n, p in T.Parallel(N, P):
                     states_frag[n, p] *= T.exp(da_cs_sum)
                 T.gemm(k_state_frag, PsiV_shared, states_frag, transpose_A=True, clear_accum=False)
             
             # --- Save Last State (if applicable) ---
             if return_final_state:
-                T.copy(states_frag, FINAL_STATE[i_b, i_h, :, :])
+                if NS > 1:
+                    T.copy(states_frag, FINAL_STATE[i_ns, i_h, :, :])
+                else:
+                    T.copy(states_frag, FINAL_STATE[i_b, i_h, :, :])
                 
 
     return mamba_mimo_fwd_kernel
 
 
-def mamba_mimo_forward(q, k, v, 
-                       q_bias, k_bias, 
-                       mimo_v, mimo_o, 
-                       z, D, 
-                       mimo_z, 
-                       angles, 
+def mamba_mimo_forward_varlen(q, k, v, 
+                       q_bias, k_bias,
+                       mimo_v, mimo_o,
+                       z, D,
+                       mimo_z,
+                       angles,
                        dA_cs,
                        dA_cs_rev,
                        dt,
                        trap,
                        segsum,
-                       chunk_size, rotary_dim_divisor, dtype, 
+                       chunk_size, rotary_dim_divisor, dtype,
+                       cu_seqlens=None,
                        return_state=False,
-                       threads=128, 
+                       threads=128,
                        num_stages=0):
+    """
+    Varlen wrapper around ``mamba_mimo_fwd``.
+
+    Dispatches to the varlen kernel when ``cu_seqlens`` is provided;
+    otherwise behaves identically to the non-varlen version in
+    ``mamba3_mimo_fwd.py``.
+
+    Args:
+        q, k, v:       Packed activations, shapes ``[B, S, R, G, N]`` /
+                       ``[B, S, H, P]``.
+        q_bias, k_bias: Per-head per-R biases, shape ``[H, R, N]``.
+        mimo_v:        Psi (MIMO X) projection, shape ``[H, R, P]``.
+        mimo_o:        Phi (MIMO O) projection, shape ``[H, R, P]``, or
+                       None to disable output reduction.
+        z:             Optional gating tensor, shape ``[B, S, H, P]``.
+        D:             Optional skip-connection vector, shape ``[H]``.
+        mimo_z:        Optional Zeta (MIMO Z) projection, shape ``[H, R, P]``.
+        angles:        Rotary angles, shape ``[B, S, H, N // rotary_dim_divisor]``.
+        dA_cs:         Forward cumsum of discretised A, shape ``[B, H, S]``.
+        dA_cs_rev:     Reverse cumsum of discretised A, shape ``[B, H, S]``.
+        dt:            Discretised time step, shape ``[B, H, S]``.
+        trap:          Pre-sigmoid trapezoidal modulator, shape ``[B, H, S]``.
+        segsum:        Per-chunk lower-triangular log-decay matrix, shape
+                       ``[B, H, max_nchunks, C, C]``.
+        chunk_size:    Tokens per chunk (C).
+        rotary_dim_divisor: Divisor for the rotary embedding head dimension.
+        dtype:         Compute dtype (torch.dtype or string).
+        cu_seqlens:    Optional int32 tensor of shape ``[NS+1]`` with
+                       per-sequence token offsets.  None → dense mode.
+        return_state:  If True, also return the final recurrent state and K.
+        threads:       Number of GPU threads per thread-block.
+        num_stages:    Software-pipeline stages (0 = auto).
+
+    Returns:
+        (o, h, k_final) where:
+            o        — output activations, shape ``[B, S, H, P]`` (reduceO)
+                       or ``[B, S, R, H, P]``.
+            h        — final hidden state per sequence, shape
+                       ``[NS, H, N, P]`` when NS > 1, else ``[B, H, N, P]``,
+                       or None if return_state is False.
+            k_final  — final K per sequence, shape ``[NS, R, H, N]`` when
+                       NS > 1, else ``[B, R, H, N]``, or None if
+                       return_state is False.
+    """
     B, S, R, G, N = q.shape
     H, P = v.shape[-2], v.shape[-1]
     if isinstance(dtype, torch.dtype):
         tl_dtype = str(dtype).replace("torch.", "")
     else:
         tl_dtype = dtype
+
+    if cu_seqlens is not None:
+        # assert B == 1, "cu_seqlens support not implemented for B > 1"
+        NS = cu_seqlens.shape[0] - 1
+    else:
+        NS = 1
+
     reduceO = mimo_o is not None
     kernel = mamba_mimo_fwd(B, S, H, G, N, P, R, 
                                        z is not None, 
                                        D is not None, 
                                        reduceO,
+                                       NS=NS if cu_seqlens is not None else 1,
                                        return_final_state=return_state,
                                        chunk_size=chunk_size, 
                                        rotary_dim_divisor=rotary_dim_divisor, 
@@ -457,8 +621,12 @@ def mamba_mimo_forward(q, k, v,
     D_arg = D if D is not None else torch.empty((H,), device=q.device, dtype=torch.float32)
     mimo_z_arg = mimo_z if mimo_z is not None else torch.empty((H, R, P), device=q.device, dtype=torch.float32)
 
-    h = torch.empty((B, H, N, P), device='cuda', dtype=torch.float32) if return_state else None
-    k_final = torch.empty((B, R, H, N), device='cuda', dtype=dtype) if return_state else None
+    if cu_seqlens is not None:
+        h = torch.empty((NS, H, N, P), device='cuda', dtype=torch.float32) if return_state else None
+        k_final = torch.empty((NS, R, H, N), device='cuda', dtype=dtype) if return_state else None
+    else:
+        h = torch.empty((B, H, N, P), device='cuda', dtype=torch.float32) if return_state else None
+        k_final = torch.empty((B, R, H, N), device='cuda', dtype=dtype) if return_state else None
 
     kernel( q,
             k,
@@ -472,6 +640,7 @@ def mamba_mimo_forward(q, k, v,
             dt,
             trap,
             segsum,
+            cu_seqlens,
             h,
             k_final
             )

--- a/mamba_ssm/ops/triton/mamba3/mamba3_mimo_utils.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_mimo_utils.py
@@ -1,12 +1,48 @@
 """
-Fused Triton kernels for Mamba3 backward pass ddt computation.
+Triton kernels for Mamba3 backward-pass dA/dt/trap computations.
 
-This module implements fused kernels that combine three separate backward operations:
-1. bwd_segsum_ddt_from_dSSdA - Complex 2D segsum operation
-2. bwd_ddt_from_ddA_cs_rev - Forward exclusive cumsum operation
-3. bwd_ddt_from_ddA_cs - Reverse cumsum operation
+This module is self-contained: it provides both dense (fixed-length) and varlen
+(variable-length sequences packed into a single tensor) versions of every kernel.
+Varlen variants follow the same naming convention as their dense counterparts but
+carry a ``_varlen`` suffix.
 
-The fusion reduces memory traffic and kernel launch overhead.
+Kernel groups
+-------------
+1. bwd_dadt_cumsum_fused  – Fused reverse-cumsum + forward-exclusive-cumsum that
+                             back-propagates through the per-chunk cumulative-sum
+                             terms ddA_cs and ddA_cs_rev into ddt.
+2. bwd_segsum_dadt        – Accumulates the 2-D inter-token segsum contribution of
+                             dSSdA into ddt, one [C×C] chunk block at a time.
+3. bwd_dtrap_ddt          – Back-propagates through the trapezoidal-rule gamma
+                             parameterisation to produce ddt and d(trap_presigmoid).
+4. dacs_segsum            – Forward helper: computes the per-chunk prefix sums
+                             da_cs, da_cs_rev, and the lower-triangular segsum
+                             matrix from the raw decay increments da.
+
+Public API
+----------
+Dense wrappers (fixed-length sequences):
+    bwd_dadt_fused_triton(dSSdA, SSdA, ddA_cs, ddA_cs_rev, dA_cs, dA_cs_rev, chunk_size)
+    bwd_dtrap_ddt_triton(trap, dt, dfactor, dgamma_diag, chunk_size)
+    compute_dacs_segsum_triton(da, chunk_size)
+
+Varlen wrappers (variable-length sequences packed end-to-end):
+    bwd_dadt_fused_triton_varlen(dSSdA, SSdA, ddA_cs, ddA_cs_rev, dA_cs, dA_cs_rev, chunk_size, cu_seqlens)
+    bwd_dtrap_ddt_triton_varlen(trap, dt, dfactor, dgamma_diag, chunk_size, cu_seqlens)
+    compute_dacs_segsum_triton_varlen(da, chunk_size, cu_seqlens)
+
+Varlen chunk layout
+-------------------
+For a packed tensor of total length S containing NS sequences, the global chunk
+index for the first chunk of sequence i is::
+
+    global_chunk_start_i = (cu_seqlens[i] // chunk_size) + i
+
+giving nchunks_global = (S // chunk_size) + NS total chunk slots.  The additive
+NS term reserves one extra slot per sequence to hold its (possibly partial) final
+chunk without overwriting the next sequence's slots.  Two int32 mapping tensors
+(state_seq_mapping, state_chunk_in_seq) route each kernel program to the correct
+position in the packed tensor; see _build_varlen_chunk_mapping for details.
 """
 
 import torch
@@ -15,13 +51,12 @@ import triton.language as tl
 import math
 from typing import Optional, Tuple
 
-# Constants
-LOG2 = math.log(2.0)
-NEG_LOG2E = -math.log2(math.e)
 
 
 # ============================================================================
-# Kernel 1: Fused Cumsum Operations (forward exclusive + reverse)
+# Kernel group 1 (dense): fused reverse-cumsum + forward-exclusive-cumsum
+#   bwd_dadt_cumsum_fused_kernel        – dense (fixed-length)
+#   bwd_dadt_cumsum_fused_kernel_varlen – varlen (see bottom of file)
 # ============================================================================
 
 @triton.autotune(
@@ -48,49 +83,39 @@ def bwd_dadt_cumsum_fused_kernel(
     S: tl.constexpr,
     CHUNK_SIZE: tl.constexpr,
 ):
-    """
-    Fused kernel that computes contributions from:
-    - bwd_ddt_from_ddA_cs: reverse cumsum operation
-    - bwd_ddt_from_ddA_cs_rev: forward exclusive cumsum operation
+    """Compute ddt contributions from ddA_cs (reverse-cumsum) and ddA_cs_rev
+    (forward-exclusive-cumsum) within each chunk.
 
-    Each program handles one chunk for one (batch, head) pair.
-    Grid: (B, H, nchunks)
+    Each program handles one CHUNK_SIZE-length slice of the sequence for one
+    (batch, head) pair.  Grid: (B, H, nchunks).
+
+    dA_cs / dA_cs_rev are the forward cumulative sums of the decay increments
+    used as exponent arguments (clipped to ≤ 0 for numerical stability).
+    ddA_cs / ddA_cs_rev are the upstream gradients w.r.t. those cumsums.
     """
-    # Get program indices
     pid_batch = tl.program_id(0)
     pid_head = tl.program_id(1)
     pid_chunk = tl.program_id(2)
 
-    # Calculate chunk boundaries
     chunk_start = pid_chunk * CHUNK_SIZE
     offs_seq = chunk_start + tl.arange(0, CHUNK_SIZE)
     mask = offs_seq < S
 
-    # Compute base offset for this (batch, head) pair
     base_offset = pid_batch * stride_batch + pid_head * stride_head
 
-    # Load chunk data for all four input tensors
-    ddA_cs = tl.load(ddA_cs_ptr + base_offset + offs_seq * stride_seq, mask=mask, other=0.0)
+    ddA_cs     = tl.load(ddA_cs_ptr     + base_offset + offs_seq * stride_seq, mask=mask, other=0.0)
     ddA_cs_rev = tl.load(ddA_cs_rev_ptr + base_offset + offs_seq * stride_seq, mask=mask, other=0.0)
-    dA_cs = tl.load(dA_cs_ptr + base_offset + offs_seq * stride_seq, mask=mask, other=0.0)
-    dA_cs_rev = tl.load(dA_cs_rev_ptr + base_offset + offs_seq * stride_seq, mask=mask, other=0.0)
+    dA_cs      = tl.load(dA_cs_ptr      + base_offset + offs_seq * stride_seq, mask=mask, other=0.0)
+    dA_cs_rev  = tl.load(dA_cs_rev_ptr  + base_offset + offs_seq * stride_seq, mask=mask, other=0.0)
 
-    # ========================================================================
-    # Operation 1: bwd_ddt_from_ddA_cs (reverse cumsum)
-    # ========================================================================
-    # Scale by log(2) * exp2(dA_cs)
-    # Use literal constants instead of globals
-    scaled_ddA_cs =  tl.exp(dA_cs) * ddA_cs  # LOG2
-    # Apply reverse cumsum within chunk
+    # Reverse-cumsum contribution from ddA_cs.
+    scaled_ddA_cs = tl.exp(dA_cs) * ddA_cs
     ddt_cs = tl.cumsum(scaled_ddA_cs, axis=0, reverse=True)
 
-    # ========================================================================
-    # Operation 2: bwd_ddt_from_ddA_cs_rev (forward exclusive cumsum)
-    # ========================================================================
-    # Scale by log(2) * exp2(dA_cs_rev)
-    # Use literal constants instead of globals
-    scaled_ddA_cs_rev = tl.exp(dA_cs_rev) * ddA_cs_rev  # LOG2
-    # Apply forward cumsum within chunk (inclusive)
+    # Forward-exclusive-cumsum contribution from ddA_cs_rev.
+    # Compute inclusive cumsum first, then shift right by one position so that
+    # output[i] = sum(scaled_ddA_cs_rev[0 : i])  (exclusive).
+    scaled_ddA_cs_rev = tl.exp(dA_cs_rev) * ddA_cs_rev
     ddt_cs_rev_inclusive = tl.cumsum(scaled_ddA_cs_rev, axis=0)
 
     # Roll one to the right:
@@ -99,25 +124,14 @@ def bwd_dadt_cumsum_fused_kernel(
     S = (i == j + 1)                      # strictly lower diagonal (one below main)
     ddt_cs_rev_exclusive = tl.sum(tl.where(S, ddt_cs_rev_inclusive, 0), axis=1)
 
-    # # Convert to exclusive cumsum
-    # # Exclusive cumsum: output[i] = sum(input[0:i])
-    # # Inclusive cumsum: cumsum[i] = sum(input[0:i+1])
-    # # Therefore: exclusive[i] = inclusive[i] - input[i]
-    # # Which is: exclusive[i] = cumsum[i] - scaled_ddA_cs_rev[i]
-    # ddt_cs_rev_shifted = ddt_cs_rev_inclusive - scaled_ddA_cs_rev
-
-    # ========================================================================
-    # Combine contributions and apply final scaling
-    # ========================================================================
-    # Use literal constant instead of global
-    ddt_total = ddt_cs + ddt_cs_rev_exclusive 
-
-    # Store result
+    ddt_total = ddt_cs + ddt_cs_rev_exclusive
     tl.store(ddt_out_ptr + base_offset + offs_seq * stride_seq, ddt_total, mask=mask)
 
 
 # ============================================================================
-# Kernel 2: Segsum Operation with 2D Matrix Processing
+# Kernel group 2 (dense): 2-D segsum accumulation into ddt
+#   bwd_segsum_dadt_kernel        – dense (fixed-length)
+#   bwd_segsum_dadt_kernel_varlen – varlen (see bottom of file)
 # ============================================================================
 
 @triton.autotune(
@@ -154,34 +168,28 @@ def bwd_segsum_dadt_kernel(
     C: tl.constexpr,
     CHUNK_SIZE: tl.constexpr,
 ):
-    """
-    Kernel for bwd_segsum_ddt_from_dSSdA operation.
-    Matches the reference implementation:
-    1. Permute dSSdA last two dims
-    2. Compute seg = dA_cs[i] - dA_cs[j]
-    3. Scale by log(2) * exp2(seg)
-    4. Reverse cumsum along dim -2 (column-wise for each row)
-    5. Apply lower triangular mask (i > j)
-    6. Sum along dim -1 (sum over j for each i)
+    """Accumulate the inter-token segsum contribution of dSSdA into ddt.
 
-    Each program handles one chunk for one (batch, head) pair.
-    Grid: (B, H, nchunks)
+    For each [C×C] chunk block the operation is:
+        1. Load dSSdA[chunk] (stored transposed as seq_k × seq_q).
+        2. Element-wise multiply by exp(SSdA[chunk]), where SSdA[i,j] =
+           dA_cs[i] - dA_cs[j] is the log-decay from token j to token i.
+        3. Reverse-cumsum along axis 0 (accumulate contributions from later
+           query positions back toward earlier key positions).
+        4. Zero the upper triangle (i ≤ j) so only causal pairs contribute.
+        5. Row-sum and atomically add into ddt_out[chunk_start : chunk_start+C].
+
+    Grid: (B, H, nchunks).
     """
-    # Get program indices
     pid_batch = tl.program_id(0)
     pid_head = tl.program_id(1)
     pid_chunk = tl.program_id(2)
 
-    # Calculate chunk boundaries
     chunk_start = pid_chunk * CHUNK_SIZE
     offs_c = tl.arange(0, CHUNK_SIZE)
     offs_seq = chunk_start + offs_c
 
-    # Load dA_cs for this chunk [C]
-    # dA_cs_offset = pid_batch * stride_dA_batch + pid_head * stride_dA_head
-    # dA_cs_chunk = tl.load(dA_cs_ptr + dA_cs_offset + offs_seq * stride_dA_seq)
-
-    # Base offset for dSSdA matrix [nchunks, C, C]
+    # dSSdA is stored transposed (seq_k × seq_q), so row/col strides are swapped.
     dSSdA_offset = dSSdA_ptr + (pid_batch * stride_dSSdA_batch +
                     pid_head * stride_dSSdA_head +
                     pid_chunk * stride_dSSdA_chunk)
@@ -192,9 +200,9 @@ def bwd_segsum_dadt_kernel(
                     pid_head * stride_ddt_head +
                     offs_seq * stride_ddt_seq)
 
-    # NOTE: dSSdA is actually the transpose corresponding to seq_k \time seq_q
+    # dSSdA is stored as (seq_k × seq_q); swap row/col strides to transpose on load.
     dSSdA_block = tl.load(dSSdA_offset + offs_c[:, None]*stride_dSSdA_col + offs_c[None, :]*stride_dSSdA_row)
-    SSdA_block = tl.load(SSdA_offset + offs_c[:, None]*stride_SSdA_row + offs_c[None, :]*stride_SSdA_col)
+    SSdA_block  = tl.load(SSdA_offset  + offs_c[:, None]*stride_SSdA_row  + offs_c[None, :]*stride_SSdA_col)
 
     dSSdA_block = dSSdA_block * tl.exp(SSdA_block)
     dSSdA_block = tl.cumsum(dSSdA_block, axis=0, reverse=True)
@@ -210,7 +218,9 @@ def bwd_segsum_dadt_kernel(
 
 
 # ============================================================================
-# Kernel 3:  backwards from gamma terms to trap 
+# Kernel group 3 (dense): backward through trapezoidal-rule gamma → ddt, dtrap
+#   bwd_dtrap_ddt_kernel        – dense (fixed-length)
+#   bwd_dtrap_ddt_kernel_varlen – varlen (see bottom of file)
 # ============================================================================
 
 @triton.autotune(
@@ -235,12 +245,23 @@ def bwd_dtrap_ddt_kernel(
     SEQLEN: tl.constexpr,
     CHUNK_SIZE: tl.constexpr,
 ):
-    # Get program indices
+    """Back-propagate through the trapezoidal-rule gamma parameterisation.
+
+    The forward pass computes:
+        gamma[t]  = sigmoid(trap[t]) * dt[t]           (current-token weight)
+        sgamma[t] = sigmoid(trap[t+1]) * dt[t+1]       (next-token weight, shifted)
+        factor[t] = gamma[t] + sgamma[t]
+
+    This kernel computes ddt and d(trap_presigmoid) given dfactor (= d(factor))
+    and dgamma_diag (= d(gamma) from the diagonal path) by unrolling the chain
+    rule and applying a right-shift for the cross-token sgamma contribution.
+
+    Grid: (B, H, nchunks).  Each program writes one contiguous CHUNK_SIZE slice.
+    """
     pid_batch = tl.program_id(0)
     pid_head = tl.program_id(1)
     pid_chunk = tl.program_id(2)
 
-    # Calculate chunk boundaries
     chunk_start = pid_chunk * CHUNK_SIZE
     offs_c = tl.arange(0, CHUNK_SIZE)
     offs_seq = chunk_start + offs_c
@@ -275,26 +296,22 @@ def bwd_dtrap_ddt_kernel(
         mask=offs_seq < SEQLEN, other=0.0
     )
 
-    # dgamma and dsgamma for current positions
-    dgamma_block = dfactor_block + dgamma_diag_input_block
-    dsgamma_block = dfactor_block #+ dsgamma_input_block
+    dgamma_block  = dfactor_block + dgamma_diag_input_block
+    dsgamma_block = dfactor_block
 
-    # dsdt and dstrap for current positions (using shifted strap/sdt)
-    dsdt_block = tl.sigmoid(-strap_block.to(tl.float32)) * dsgamma_block
+    # Gradients w.r.t. the shifted (next-token) trap/dt values.
+    dsdt_block  = tl.sigmoid(-strap_block.to(tl.float32)) * dsgamma_block
     dstrap_block = -sdt_block * dsgamma_block
 
-    # Compute dsdt/dstrap at previous position for cross-chunk shift
-    prev_seq = chunk_start - 1
+    # Fetch the last token of the previous chunk to fill position 0 of this chunk
+    # after the right-shift (cross-chunk boundary contribution).
+    prev_seq  = chunk_start - 1
     prev_mask = prev_seq >= 0
-    prev_dgamma = tl.load(
+    prev_dgamma  = tl.load(
         dfactor_ptr + dfactor_offset + prev_seq * stride_dfactor_seq,
         mask=prev_mask, other=0.0
     )
-    # prev_dsgamma_input = tl.load(
-    #     dsgamma_ptr + dsgamma_offset + prev_seq * stride_dsgamma_seq,
-    #     mask=prev_mask, other=0.0
-    # )
-    prev_dsgamma = prev_dgamma  #+ prev_dsgamma_input
+    prev_dsgamma = prev_dgamma
     prev_strap = tl.load(
         trap_ptr + trap_offset + chunk_start * stride_trap_seq,
         mask=chunk_start < SEQLEN, other=0.0
@@ -306,7 +323,8 @@ def bwd_dtrap_ddt_kernel(
     prev_dsdt = tl.sigmoid(-prev_strap.to(tl.float32)) * prev_dsgamma
     prev_dstrap = -prev_sdt * prev_dsgamma
 
-    # Shift right by one within chunk: out[i] = in[i-1], with cross-chunk value at i=0
+    # Right-shift within chunk: shifted[i] = original[i-1].
+    # Position 0 takes its value from the previous chunk's last token.
     offs_i = tl.arange(0, CHUNK_SIZE)[:, None]
     offs_j = tl.arange(0, CHUNK_SIZE)[None, :]
     shift_mask = offs_i == (offs_j + 1)
@@ -334,7 +352,93 @@ def bwd_dtrap_ddt_kernel(
 
 
 # ============================================================================
-# Kernel 4:  compute da_cs, da_cs_rev, segsum from da
+# Kernel group 4 (varlen): compute da_cs, da_cs_rev, and segsum from da
+#   dacs_segsum_kernel        – dense (fixed-length, below)
+#   dacs_segsum_kernel_varlen – varlen (this kernel)
+# ============================================================================
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_stages=s, num_warps=w)
+        for s in [2, 3]
+        for w in [4, 8]
+    ],
+    key=["CHUNK_SIZE"],
+)
+@triton.jit
+def dacs_segsum_kernel_varlen(
+    da_ptr,
+    da_cs_ptr,
+    da_cs_rev_ptr,
+    segsum_ptr,
+    cu_seqlens_ptr,
+    state_seq_mapping_ptr,
+    state_chunk_in_seq_ptr,
+    stride_da_batch, stride_da_head, stride_da_seq,
+    stride_da_cs_batch, stride_da_cs_head, stride_da_cs_seq,
+    stride_da_cs_rev_batch, stride_da_cs_rev_head, stride_da_cs_rev_seq,
+    stride_segsum_batch, stride_segsum_head, stride_segsum_chunk,
+    stride_segsum_row, stride_segsum_col,
+    stride_cu_seqlen, stride_state_seq_mapping, stride_state_chunk_in_seq,
+    SEQLEN,
+    NUM_SEQUENCES: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+):
+    """Varlen version of dacs_segsum_kernel.
+
+    Computes da_cs (forward prefix-sum of da, clipped to ≤ 0), da_cs_rev
+    (exclusive reverse prefix-sum, clipped to ≤ 0), and the lower-triangular
+    segsum matrix for each chunk, respecting sequence boundaries so that sums
+    do not cross from one sequence into another.
+
+    pid_chunk indexes into the global chunk array (length nchunks_global).
+    state_seq_mapping and state_chunk_in_seq decode which sequence and local
+    chunk position the program is responsible for.  Inactive (padding) slots
+    produce an all-False mask and write nothing.
+
+    Grid: (B, H, nchunks_global).
+    """
+    pid_batch = tl.program_id(0)
+    pid_head = tl.program_id(1)
+    pid_chunk = tl.program_id(2)
+
+    curr_seq_ind = tl.load(state_seq_mapping_ptr + pid_chunk * stride_state_seq_mapping)
+    local_chunk_ind = tl.load(state_chunk_in_seq_ptr + pid_chunk * stride_state_chunk_in_seq)
+    seq_start = tl.load(cu_seqlens_ptr + curr_seq_ind * stride_cu_seqlen)
+    seq_end = tl.load(cu_seqlens_ptr + (curr_seq_ind + 1) * stride_cu_seqlen)
+    offs = tl.arange(0, CHUNK_SIZE)
+    offs_seq = seq_start + local_chunk_ind * CHUNK_SIZE + offs
+    mask = (offs_seq < seq_end) & (offs_seq < SEQLEN)
+
+    base_da = pid_batch * stride_da_batch + pid_head * stride_da_head
+    da_chunk = tl.load(da_ptr + base_da + offs_seq * stride_da_seq, mask=mask, other=0.0)
+
+    da_cs = tl.cumsum(da_chunk, axis=0)
+    da_cs = tl.minimum(da_cs, 0.0)
+
+    da_cs_rev_inclusive = tl.cumsum(da_chunk, axis=0, reverse=True)
+    da_cs_rev = da_cs_rev_inclusive - da_chunk
+    da_cs_rev = tl.minimum(da_cs_rev, 0.0)
+
+    base_da_cs = pid_batch * stride_da_cs_batch + pid_head * stride_da_cs_head
+    base_da_cs_rev = pid_batch * stride_da_cs_rev_batch + pid_head * stride_da_cs_rev_head
+    tl.store(da_cs_ptr + base_da_cs + offs_seq * stride_da_cs_seq, da_cs, mask=mask)
+    tl.store(da_cs_rev_ptr + base_da_cs_rev + offs_seq * stride_da_cs_rev_seq, da_cs_rev, mask=mask)
+
+    offs_i = offs[:, None]
+    offs_j = offs[None, :]
+    segsum = tl.where(offs_i > offs_j, da_chunk[:, None], 0.0)
+    segsum = tl.cumsum(segsum, axis=0)
+    segsum = tl.minimum(segsum, 0.0)
+
+    base_segsum = (pid_batch * stride_segsum_batch +
+                   pid_head * stride_segsum_head +
+                   pid_chunk * stride_segsum_chunk)
+    tl.store(segsum_ptr + base_segsum + offs_i * stride_segsum_row + offs_j * stride_segsum_col, segsum)
+
+
+# ============================================================================
+# Kernel group 4 (dense): compute da_cs, da_cs_rev, and segsum from da
 # ============================================================================
 
 @triton.autotune(
@@ -359,6 +463,14 @@ def dacs_segsum_kernel(
     SEQLEN: tl.constexpr,
     CHUNK_SIZE: tl.constexpr,
 ):
+    """Dense (fixed-length) version of dacs_segsum_kernel_varlen.
+
+    Computes da_cs, da_cs_rev, and the lower-triangular segsum matrix for each
+    contiguous chunk.  Sequences are assumed to be fixed-length and aligned to
+    chunk boundaries; no varlen mapping tensors are needed.
+
+    Grid: (B, H, nchunks).
+    """
     pid_batch = tl.program_id(0)
     pid_head = tl.program_id(1)
     pid_chunk = tl.program_id(2)
@@ -373,13 +485,13 @@ def dacs_segsum_kernel(
 
     da_cs = tl.cumsum(da_chunk, axis=0)
     da_cs = tl.minimum(da_cs, 0.0)
-    
+
     da_cs_rev = tl.cumsum(da_chunk, axis=0, reverse=True)
     # Roll one to the left:
     i = tl.arange(0, CHUNK_SIZE)[:, None]          # [N,1]
     j = tl.arange(0, CHUNK_SIZE)[None, :]          # [1,N]
-    S = (i == j - 1)                      # strictly upper diagonal (one above main)
-    da_cs_rev = tl.sum(tl.where(S, da_cs_rev, 0), axis=1)
+    S_mat = (i == j - 1)                      # strictly upper diagonal (one above main)
+    da_cs_rev = tl.sum(tl.where(S_mat, da_cs_rev, 0), axis=1)
     da_cs_rev = tl.minimum(da_cs_rev, 0.0)
 
     base_da_cs = pid_batch * stride_da_cs_batch + pid_head * stride_da_cs_head
@@ -400,8 +512,9 @@ def dacs_segsum_kernel(
                    pid_chunk * stride_segsum_chunk)
     tl.store(segsum_ptr + base_segsum + offs_i * stride_segsum_row + offs_j * stride_segsum_col, segsum)
 
+
 # ============================================================================
-# Wrapper Function
+# Public wrappers – dense (fixed-length sequences)
 # ============================================================================
 
 def bwd_dadt_fused_triton(
@@ -413,7 +526,19 @@ def bwd_dadt_fused_triton(
     dA_cs_rev: torch.Tensor,          # [B, H, S]
     chunk_size: int,
 ) -> torch.Tensor:
-    # Validate inputs
+    """Fuse the three ddt backward contributions for fixed-length sequences.
+
+    Runs bwd_dadt_cumsum_fused_kernel (cumsum terms) and bwd_segsum_dadt_kernel
+    (segsum term) back-to-back and returns their sum.  The result must be
+    multiplied by NEG_LOG2E = -log2(e) ≈ -1.4427 by the caller to obtain the
+    final ddt in log2-decay space.
+
+    S must be a multiple of chunk_size.
+
+    Returns
+    -------
+    dadt_out : float32 tensor of shape [B, H, S]
+    """
     B, H, S = ddA_cs.shape
     nchunks = S // chunk_size
     assert S % chunk_size == 0, f"Sequence length {S} must be divisible by chunk_size {chunk_size}"
@@ -448,12 +573,19 @@ def bwd_dadt_fused_triton(
     return dadt_out
 
 def bwd_dtrap_ddt_triton(
-    trap: torch.Tensor,      # [B, H, S]
-    dt: torch.Tensor,        # [B, H, S]
-    dfactor: torch.Tensor,   # [B, H, S]
-    dgamma_diag: torch.Tensor,   # [B, H, S]
-    chunk_size: int, # NOTE: the chunk_size does not have to be the same as the other kernels
+    trap: torch.Tensor,           # [B, H, S]  – trap_presigmoid values
+    dt: torch.Tensor,             # [B, H, S]
+    dfactor: torch.Tensor,        # [B, H, S]  – upstream gradient of factor
+    dgamma_diag: torch.Tensor,    # [B, H, S]  – upstream gradient of gamma (diagonal)
+    chunk_size: int,              # may differ from the chunk_size used by bwd_dadt_fused_triton
 ):
+    """Back-propagate through the trapezoidal gamma parameterisation (dense).
+
+    Returns
+    -------
+    ddt   : tensor same shape and dtype as dt
+    dtrap : tensor same shape and dtype as trap  (gradient w.r.t. trap_presigmoid)
+    """
     B, H, S = dt.shape
     nchunks = S // chunk_size
 
@@ -475,10 +607,99 @@ def bwd_dtrap_ddt_triton(
     )
     return ddt, dtrap
 
+def compute_dacs_segsum_triton_varlen(
+    da: torch.Tensor,              # [B, H, S]
+    chunk_size: int,
+    cu_seqlens: torch.Tensor = None,   # [NS+1], int32
+):
+    """Compute da_cs, da_cs_rev, and segsum for variable-length packed sequences.
+
+    Falls back to compute_dacs_segsum_triton (dense) when cu_seqlens is None.
+
+    Parameters
+    ----------
+    da           : decay increments, shape [B, H, S].
+    chunk_size   : tokens per chunk (must be a power of two).
+    cu_seqlens   : cumulative sequence lengths, shape [NS+1], starting at 0.
+
+    Returns
+    -------
+    da_cs        : forward inclusive prefix-sum of da, clipped to ≤ 0. [B, H, S]
+    da_cs_rev    : exclusive reverse prefix-sum of da, clipped to ≤ 0. [B, H, S]
+    segsum       : lower-triangular intra-chunk segsum. [B, H, nchunks_global, C, C]
+                   nchunks_global = (S // chunk_size) + num_sequences.
+    """
+    if cu_seqlens is None:
+        return compute_dacs_segsum_triton(da, chunk_size)
+
+    B, H, S = da.shape
+    assert cu_seqlens.ndim == 1, f"cu_seqlens must be 1D, got shape {tuple(cu_seqlens.shape)}"
+    num_sequences = max(int(cu_seqlens.numel()) - 1, 0)
+    if num_sequences == 0:
+        return compute_dacs_segsum_triton(da, chunk_size)
+
+    # Global chunk count: each sequence contributes ceil(len/chunk_size) chunks,
+    # which equals (len // chunk_size) + 1 under the "always +1" convention used
+    # throughout this module.  Summing over all sequences gives:
+    #     nchunks = (S // chunk_size) + num_sequences
+    nchunks = (S // chunk_size) + num_sequences
+
+    da_cs = torch.empty_like(da)
+    da_cs_rev = torch.empty_like(da)
+    segsum = torch.zeros(B, H, nchunks, chunk_size, chunk_size, device=da.device, dtype=da.dtype)
+
+    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunks_per_seq = (seq_lens // chunk_size) + 1
+
+    # Build mapping tensors: both have length nchunks_global.
+    # Inactive (padding) slots are given a sentinel local-chunk index that
+    # places chunk_start >= seq_end, making the kernel mask all-False.
+    state_seq_mapping  = torch.zeros(nchunks, dtype=torch.int32, device=da.device)
+    state_chunk_in_seq = torch.zeros(nchunks, dtype=torch.int32, device=da.device)
+    default_seq_len = int(seq_lens[0].item()) if num_sequences > 0 else 0
+    default_inactive_local_chunk = (default_seq_len + chunk_size - 1) // chunk_size
+    state_chunk_in_seq.fill_(default_inactive_local_chunk)
+
+    for i in range(num_sequences):
+        start = int(cu_seqlens[i].item())
+        n = int(chunks_per_seq[i].item())
+        chunk_start = (start // chunk_size) + i
+        chunk_end = chunk_start + n
+        assert chunk_end <= nchunks, (
+            f"Chunk mapping overflow for seq {i}: [{chunk_start}, {chunk_end}) vs nchunks={nchunks}"
+        )
+        state_seq_mapping[chunk_start:chunk_end] = i
+        state_chunk_in_seq[chunk_start:chunk_end] = torch.arange(n, dtype=torch.int32, device=da.device)
+
+    grid = (B, H, nchunks)
+    dacs_segsum_kernel_varlen[grid](
+        da, da_cs, da_cs_rev, segsum, cu_seqlens, state_seq_mapping, state_chunk_in_seq,
+        da.stride(0), da.stride(1), da.stride(2),
+        da_cs.stride(0), da_cs.stride(1), da_cs.stride(2),
+        da_cs_rev.stride(0), da_cs_rev.stride(1), da_cs_rev.stride(2),
+        segsum.stride(0), segsum.stride(1), segsum.stride(2),
+        segsum.stride(3), segsum.stride(4),
+        cu_seqlens.stride(0), state_seq_mapping.stride(0), state_chunk_in_seq.stride(0),
+        S,
+        num_sequences,
+        chunk_size,
+    )
+
+    return da_cs, da_cs_rev, segsum
+
+
 def compute_dacs_segsum_triton(
-    da: torch.Tensor,  # (B, H, S)
+    da: torch.Tensor,  # [B, H, S]
     chunk_size: int,
 ):
+    """Compute da_cs, da_cs_rev, and segsum for fixed-length sequences.
+
+    Returns
+    -------
+    da_cs    : forward inclusive prefix-sum of da, clipped to ≤ 0. [B, H, S]
+    da_cs_rev: exclusive reverse prefix-sum of da, clipped to ≤ 0. [B, H, S]
+    segsum   : lower-triangular intra-chunk segsum. [B, H, nchunks, C, C]
+    """
     B, H, S = da.shape
     nchunks = (S + chunk_size - 1) // chunk_size
 
@@ -502,15 +723,26 @@ def compute_dacs_segsum_triton(
 
 
 # ============================================================================
-# Reference Implementations (for testing)
+# Reference implementations (pure PyTorch, used for correctness tests)
+# Dense versions: bwd_segsum_ddt_from_dSSdA_ref, bwd_ddt_from_ddA_cs_rev_ref,
+#                 bwd_ddt_from_ddA_cs_ref, compute_dtrap_ddt_ref,
+#                 compute_dacs_segsum_ref
+# Varlen versions: bwd_dadt_fused_varlen_ref, compute_dtrap_ddt_varlen_ref,
+#                  compute_dacs_segsum_ref_varlen
 # ============================================================================
 
 def bwd_segsum_ddt_from_dSSdA_ref(
-    dSSdA: torch.Tensor,
-    dA_cs: torch.Tensor,
+    dSSdA: torch.Tensor,   # [B, H, nchunks, C, C]
+    dA_cs: torch.Tensor,   # [B, H, S]
     chunk_size: int,
-):
-    """Reference implementation of bwd_segsum_ddt_from_dSSdA."""
+) -> torch.Tensor:         # [B, H, S]
+    """Dense reference for the segsum contribution to ddt.
+
+    Computes the row-sum of exp(dA_cs[i]-dA_cs[j]) * dSSdA[j,i] for i > j
+    within each chunk, then applies a reverse cumsum so that each token i
+    aggregates contributions from all later tokens j > i in the chunk.
+    Result is scaled by -log2(e) to match the log2-decay convention.
+    """
     B, H, nchunks, C, C_ = dSSdA.shape
     assert C == chunk_size == C_
     dA_cs_chunk = dA_cs.view(B, H, nchunks, C)
@@ -526,11 +758,15 @@ def bwd_segsum_ddt_from_dSSdA_ref(
 
 
 def bwd_ddt_from_ddA_cs_rev_ref(
-    ddA_cs_rev: torch.Tensor,
-    dA_cs_rev: torch.Tensor,
+    ddA_cs_rev: torch.Tensor,  # [B, H, S]
+    dA_cs_rev: torch.Tensor,   # [B, H, S]
     chunk_size: int,
-):
-    """Reference implementation of bwd_ddt_from_ddA_cs_rev."""
+) -> torch.Tensor:             # [B, H, S]
+    """Dense reference for the forward-exclusive-cumsum contribution to ddt.
+
+    Propagates ddA_cs_rev through exp(dA_cs_rev) and a forward exclusive
+    cumsum within each chunk.  Result is scaled by -log2(e).
+    """
     B, H, S = ddA_cs_rev.shape
     nchunks = S // chunk_size
     ddA_cs_rev = torch.exp(dA_cs_rev) * ddA_cs_rev
@@ -543,11 +779,15 @@ def bwd_ddt_from_ddA_cs_rev_ref(
 
  
 def bwd_ddt_from_ddA_cs_ref(
-    ddA_cs: torch.Tensor,
-    dA_cs: torch.Tensor,
+    ddA_cs: torch.Tensor,  # [B, H, S]
+    dA_cs: torch.Tensor,   # [B, H, S]
     chunk_size: int,
-):
-    """Reference implementation of bwd_ddt_from_ddA_cs."""
+) -> torch.Tensor:         # [B, H, S]
+    """Dense reference for the reverse-cumsum contribution to ddt.
+
+    Propagates ddA_cs through exp(dA_cs) and a reverse cumsum within each
+    chunk.  Result is scaled by -log2(e).
+    """
     B, H, S = ddA_cs.shape
     nchunks = S // chunk_size
     ddA_cs =  torch.exp(dA_cs) * ddA_cs
@@ -557,19 +797,24 @@ def bwd_ddt_from_ddA_cs_ref(
     ddt = ddA * (-math.log2(math.e))
     return ddt.reshape(B, H, nchunks*chunk_size)
 
-def compute_dtrap_ddt_ref(dfactor: torch.Tensor,
-                          dgamma_diag_input: torch.Tensor,
-                          trap_presigmoid,
-                          dt,
-                          ) -> Tuple[torch.Tensor, torch.Tensor]:
-    trap = torch.nn.functional.sigmoid(trap_presigmoid)
-    strap = torch.nn.functional.pad(trap[:, :, 1:], (0, 1), value=0.0)
-    sdt = torch.nn.functional.pad(dt[:, :, 1:], (0, 1), value=0.0)
-    dgamma = dfactor.detach().clone() + dgamma_diag_input.detach().clone()
-    dsgamma = dfactor.detach().clone() # + dsgamma_input.detach().clone()
-    dsdt = (1 - strap) * dsgamma
+def compute_dtrap_ddt_ref(
+    dfactor: torch.Tensor,          # [B, H, S]
+    dgamma_diag_input: torch.Tensor, # [B, H, S]
+    trap_presigmoid: torch.Tensor,  # [B, H, S]
+    dt: torch.Tensor,               # [B, H, S]
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Dense reference for bwd_dtrap_ddt_triton.
+
+    Returns (ddt, dtrap_presigmoid), both shaped [B, H, S].
+    """
+    trap   = torch.nn.functional.sigmoid(trap_presigmoid)
+    strap  = torch.nn.functional.pad(trap[:, :, 1:], (0, 1), value=0.0)
+    sdt    = torch.nn.functional.pad(dt[:, :, 1:],   (0, 1), value=0.0)
+    dgamma  = dfactor.detach().clone() + dgamma_diag_input.detach().clone()
+    dsgamma = dfactor.detach().clone()
+    dsdt   = (1 - strap) * dsgamma
     dstrap = -sdt * dsgamma
-    # shift rightward:
+    # Right-shift by one: gradient from sgamma[t] lands on position t-1.
     ddt = torch.nn.functional.pad(dsdt[:, :, :-1], (1, 0), value=0.0)
     dtrap = torch.nn.functional.pad(dstrap[:, :, :-1], (1, 0), value=0.0)
     # Add the dgamma path:
@@ -579,18 +824,23 @@ def compute_dtrap_ddt_ref(dfactor: torch.Tensor,
     ddt += dgamma*trap
     return ddt, dtrap
 
-def compute_dacs_segsum_ref(da: torch.Tensor, # (B, H, S)
-                        chunk_size: int,
-                        ):
+def compute_dacs_segsum_ref(
+    da: torch.Tensor,  # [B, H, S]
+    chunk_size: int,
+):
+    """Dense reference for compute_dacs_segsum_triton.
+
+    Requires S to be a multiple of chunk_size.  Returns (da_cs, da_cs_rev, segsum).
+    """
+    from einops import repeat
     B, H, S = da.shape
     nchunks = S // chunk_size
 
     da_reshaped = da.view(B, H, nchunks, chunk_size)
     da_cs = torch.cumsum(da_reshaped, dim=-1)
     da_cs_sum = torch.sum(da_reshaped, dim=-1)
-    da_cs_rev = da_cs_sum[..., None] - da_cs #torch.flip(torch.cumsum(torch.flip(da_reshaped, dims=[-1]), dim=-1), dims=[-1])
+    da_cs_rev = da_cs_sum[..., None] - da_cs
 
-    from einops import repeat
     segsum = repeat(da_reshaped, "... d -> ... d e", e=chunk_size)
     mask = torch.tril(torch.ones(chunk_size, chunk_size, device=da_cs.device, dtype=bool), diagonal=-1)
     segsum = segsum.masked_fill(~mask, 0)
@@ -599,14 +849,571 @@ def compute_dacs_segsum_ref(da: torch.Tensor, # (B, H, S)
     return da_cs.view(B, H, S), da_cs_rev.view(B, H, S), segsum
 
 
+def compute_dacs_segsum_ref_varlen(
+    da: torch.Tensor,              # [B, H, S]
+    chunk_size: int,
+    cu_seqlens: torch.Tensor,      # [NS+1]
+    num_sequences: int,
+):
+    """Varlen reference for compute_dacs_segsum_triton_varlen.
+
+    Calls compute_dacs_segsum_ref as a subroutine per sequence, zero-padding
+    each sequence to the nearest chunk_size multiple.  Uses the same global
+    chunk layout as _build_varlen_chunk_mapping so the segsum output is directly
+    comparable to the Triton kernel output.
+    """
+    from einops import repeat
+
+    B, H, S = da.shape
+    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunks_per_seq = (seq_lens // chunk_size) + 1
+    nchunks_global = (S // chunk_size) + num_sequences
+
+    da_cs = torch.empty(B, H, S, device=da.device, dtype=da.dtype)
+    da_cs_rev = torch.empty(B, H, S, device=da.device, dtype=da.dtype)
+    segsum = torch.zeros(B, H, nchunks_global, chunk_size, chunk_size, device=da.device, dtype=da.dtype)
+
+    for i in range(num_sequences):
+        start = int(cu_seqlens[i].item())
+        end = int(cu_seqlens[i + 1].item())
+        curr_seqlen = end - start
+        curr_nchunks = int(chunks_per_seq[i].item())
+        curr_padded_len = curr_nchunks * chunk_size
+        # Global chunk slot for sequence i (matches _build_varlen_chunk_mapping)
+        global_chunk_start = (start // chunk_size) + i
+
+        da_padded = torch.zeros(B, H, curr_padded_len, device=da.device, dtype=da.dtype)
+        if curr_seqlen > 0:
+            da_padded[:, :, :curr_seqlen] = da[:, :, start:end]
+
+        # Inline of compute_dacs_segsum_ref (dense, non-varlen).
+        da_reshaped = da_padded.view(B, H, curr_nchunks, chunk_size)
+        da_cs_seq = torch.cumsum(da_reshaped, dim=-1)
+        da_cs_sum = torch.sum(da_reshaped, dim=-1)
+        da_cs_rev_seq = da_cs_sum[..., None] - da_cs_seq
+        segsum_seq = repeat(da_reshaped, "... d -> ... d e", e=chunk_size)
+        tril_mask = torch.tril(torch.ones(chunk_size, chunk_size, device=da.device, dtype=torch.bool), diagonal=-1)
+        segsum_seq = segsum_seq.masked_fill(~tril_mask, 0)
+        segsum_seq = torch.cumsum(segsum_seq, dim=-2)
+
+        if curr_seqlen > 0:
+            da_cs    [:, :, start:end] = da_cs_seq    .view(B, H, curr_padded_len)[:, :, :curr_seqlen]
+            da_cs_rev[:, :, start:end] = da_cs_rev_seq.view(B, H, curr_padded_len)[:, :, :curr_seqlen]
+        segsum[:, :, global_chunk_start:global_chunk_start + curr_nchunks, :, :] = segsum_seq
+
+    return da_cs, da_cs_rev, segsum
+
+
+def bwd_dadt_fused_varlen_ref(
+    dSSdA: torch.Tensor,       # [B, H, nchunks_global, C, C]
+    ddA_cs: torch.Tensor,      # [B, H, S]
+    ddA_cs_rev: torch.Tensor,  # [B, H, S]
+    dA_cs: torch.Tensor,       # [B, H, S]
+    dA_cs_rev: torch.Tensor,   # [B, H, S]
+    chunk_size: int,
+    cu_seqlens: torch.Tensor,  # [NS+1]
+) -> torch.Tensor:
+    """Varlen reference for bwd_dadt_fused_triton_varlen.
+
+    Calls the non-varlen reference functions as subroutines, one sequence at a time.
+    Each sequence is zero-padded to the nearest chunk_size multiple before the call,
+    and only the valid (non-padded) positions are written to the output.
+    """
+    B, H, S = ddA_cs.shape
+    num_sequences = int(cu_seqlens.numel()) - 1
+    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunks_per_seq = (seq_lens // chunk_size) + 1
+
+    dadt_out = torch.zeros(B, H, S, device=ddA_cs.device, dtype=torch.float32)
+
+    for i in range(num_sequences):
+        start = int(cu_seqlens[i].item())
+        end = int(cu_seqlens[i + 1].item())
+        curr_seqlen = end - start
+        if curr_seqlen == 0:
+            continue
+        curr_nchunks = int(chunks_per_seq[i].item())
+        curr_padded_len = curr_nchunks * chunk_size
+        # Global chunk slot for the first chunk of this sequence (matches _build_varlen_chunk_mapping)
+        global_chunk_start = (start // chunk_size) + i
+
+        def _pad(x):
+            padded = torch.zeros(B, H, curr_padded_len, device=x.device, dtype=x.dtype)
+            padded[:, :, :curr_seqlen] = x[:, :, start:end]
+            return padded
+
+        ddA_cs_seq    = _pad(ddA_cs)
+        ddA_cs_rev_seq = _pad(ddA_cs_rev)
+        dA_cs_seq     = _pad(dA_cs)
+        dA_cs_rev_seq  = _pad(dA_cs_rev)
+        dSSdA_seq = dSSdA[:, :, global_chunk_start:global_chunk_start + curr_nchunks, :, :]
+
+        ddt1 = bwd_segsum_ddt_from_dSSdA_ref(dSSdA_seq, dA_cs_seq, chunk_size)
+        ddt2 = bwd_ddt_from_ddA_cs_rev_ref(ddA_cs_rev_seq, dA_cs_rev_seq, chunk_size)
+        ddt3 = bwd_ddt_from_ddA_cs_ref(ddA_cs_seq, dA_cs_seq, chunk_size)
+        dadt_out[:, :, start:end] = (ddt1 + ddt2 + ddt3)[:, :, :curr_seqlen]
+
+    return dadt_out
+
+
+def compute_dtrap_ddt_varlen_ref(
+    dfactor: torch.Tensor,          # [B, H, S]
+    dgamma_diag_input: torch.Tensor, # [B, H, S]
+    trap_presigmoid: torch.Tensor,  # [B, H, S]
+    dt: torch.Tensor,               # [B, H, S]
+    chunk_size: int,
+    cu_seqlens: torch.Tensor,       # [NS+1]
+) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Varlen reference for bwd_dtrap_ddt_triton_varlen.
+
+    Calls compute_dtrap_ddt_ref as subroutine per sequence, zero-padding each
+    sequence to a chunk_size multiple and zeroing the cross-sequence boundary
+    shift (first position of each sequence gets zero incoming gradient, matching
+    the varlen kernel's is_first_chunk_in_seq guard).
+    """
+    B, H, S = dt.shape
+    num_sequences = int(cu_seqlens.numel()) - 1
+    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunks_per_seq = (seq_lens // chunk_size) + 1
+
+    ddt_out   = torch.zeros(B, H, S, device=dt.device, dtype=dt.dtype)
+    dtrap_out = torch.zeros(B, H, S, device=dt.device, dtype=dt.dtype)
+
+    for i in range(num_sequences):
+        start = int(cu_seqlens[i].item())
+        end = int(cu_seqlens[i + 1].item())
+        curr_seqlen = end - start
+        if curr_seqlen == 0:
+            continue
+        curr_nchunks = int(chunks_per_seq[i].item())
+        curr_padded_len = curr_nchunks * chunk_size
+
+        def _pad(x):
+            padded = torch.zeros(B, H, curr_padded_len, device=x.device, dtype=x.dtype)
+            padded[:, :, :curr_seqlen] = x[:, :, start:end]
+            return padded
+
+        ddt_seq, dtrap_seq = compute_dtrap_ddt_ref(
+            _pad(dfactor), _pad(dgamma_diag_input), _pad(trap_presigmoid), _pad(dt)
+        )
+        ddt_out  [:, :, start:end] = ddt_seq  [:, :, :curr_seqlen]
+        dtrap_out[:, :, start:end] = dtrap_seq[:, :, :curr_seqlen]
+
+    return ddt_out, dtrap_out
+
+
 # ============================================================================
-# Testing Functions
+# Public wrappers – varlen (variable-length sequences packed end-to-end)
+# Kernel groups 1-3 varlen implementations.  Group 4 varlen kernel is above.
+# ============================================================================
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_stages=s, num_warps=w)
+        for s in [1, 2, 3]
+        for w in [4, 8]
+    ],
+    key=["CHUNK_SIZE"],
+    restore_value=["ddt_out_ptr"],
+)
+@triton.jit
+def bwd_dadt_cumsum_fused_kernel_varlen(
+    ddA_cs_ptr,         # [B, H, S]
+    ddA_cs_rev_ptr,     # [B, H, S]
+    dA_cs_ptr,          # [B, H, S]
+    dA_cs_rev_ptr,      # [B, H, S]
+    ddt_out_ptr,        # [B, H, S] - output (accumulate)
+    cu_seqlens_ptr,     # [NS+1]
+    state_seq_mapping_ptr,    # [nchunks_global]
+    state_chunk_in_seq_ptr,   # [nchunks_global]
+    stride_batch,
+    stride_head,
+    stride_seq,
+    stride_cu,
+    stride_ssm,
+    stride_scis,
+    S: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+):
+    """Varlen version of bwd_dadt_cumsum_fused_kernel.
+    Grid: (B, H, nchunks_global).  Each program handles one global chunk slot.
+    """
+    pid_batch = tl.program_id(0)
+    pid_head  = tl.program_id(1)
+    pid_chunk = tl.program_id(2)
+
+    # Decode global chunk → sequence start and local chunk index.
+    curr_seq_ind    = tl.load(state_seq_mapping_ptr  + pid_chunk * stride_ssm)
+    local_chunk_ind = tl.load(state_chunk_in_seq_ptr + pid_chunk * stride_scis)
+    seq_start = tl.load(cu_seqlens_ptr + curr_seq_ind       * stride_cu)
+    seq_end   = tl.load(cu_seqlens_ptr + (curr_seq_ind + 1) * stride_cu)
+
+    chunk_start = seq_start + local_chunk_ind * CHUNK_SIZE
+    offs        = tl.arange(0, CHUNK_SIZE)
+    offs_seq    = chunk_start + offs
+    mask        = (offs_seq < seq_end) & (offs_seq < S)
+
+    base = pid_batch * stride_batch + pid_head * stride_head
+
+    ddA_cs     = tl.load(ddA_cs_ptr     + base + offs_seq * stride_seq, mask=mask, other=0.0)
+    ddA_cs_rev = tl.load(ddA_cs_rev_ptr + base + offs_seq * stride_seq, mask=mask, other=0.0)
+    dA_cs      = tl.load(dA_cs_ptr      + base + offs_seq * stride_seq, mask=mask, other=0.0)
+    dA_cs_rev  = tl.load(dA_cs_rev_ptr  + base + offs_seq * stride_seq, mask=mask, other=0.0)
+
+    # Reverse cumsum contribution from ddA_cs
+    scaled_ddA_cs = tl.exp(dA_cs) * ddA_cs
+    ddt_cs = tl.cumsum(scaled_ddA_cs, axis=0, reverse=True)
+
+    # Forward exclusive cumsum contribution from ddA_cs_rev
+    scaled_ddA_cs_rev = tl.exp(dA_cs_rev) * ddA_cs_rev
+    ddt_cs_rev_inclusive = tl.cumsum(scaled_ddA_cs_rev, axis=0)
+    i = tl.arange(0, CHUNK_SIZE)[:, None]
+    j = tl.arange(0, CHUNK_SIZE)[None, :]
+    S_mat = (i == j + 1)
+    ddt_cs_rev_exclusive = tl.sum(tl.where(S_mat, ddt_cs_rev_inclusive, 0), axis=1)
+
+    ddt_total = ddt_cs + ddt_cs_rev_exclusive
+    tl.store(ddt_out_ptr + base + offs_seq * stride_seq, ddt_total, mask=mask)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_stages=s, num_warps=w)
+        for s in [2, 3]
+        for w in [4, 8]
+    ],
+    key=["CHUNK_SIZE"],
+    restore_value=["ddt_out_ptr"],
+)
+@triton.jit
+def bwd_segsum_dadt_kernel_varlen(
+    dSSdA_ptr,          # [B, H, nchunks_global, C, C]
+    SSdA_cs_ptr,        # [B, H, nchunks_global, C, C]
+    ddt_out_ptr,        # [B, H, S] - accumulated output
+    cu_seqlens_ptr,     # [NS+1]
+    state_seq_mapping_ptr,    # [nchunks_global]
+    state_chunk_in_seq_ptr,   # [nchunks_global]
+    stride_dSSdA_batch, stride_dSSdA_head, stride_dSSdA_chunk,
+    stride_dSSdA_row,   stride_dSSdA_col,
+    stride_SSdA_batch,  stride_SSdA_head,  stride_SSdA_chunk,
+    stride_SSdA_row,    stride_SSdA_col,
+    stride_ddt_batch,   stride_ddt_head,   stride_ddt_seq,
+    stride_cu, stride_ssm, stride_scis,
+    S: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+):
+    """Varlen version of bwd_segsum_dadt_kernel.
+    Grid: (B, H, nchunks_global).
+    """
+    pid_batch = tl.program_id(0)
+    pid_head  = tl.program_id(1)
+    pid_chunk = tl.program_id(2)
+
+    curr_seq_ind    = tl.load(state_seq_mapping_ptr  + pid_chunk * stride_ssm)
+    local_chunk_ind = tl.load(state_chunk_in_seq_ptr + pid_chunk * stride_scis)
+    seq_start = tl.load(cu_seqlens_ptr + curr_seq_ind       * stride_cu)
+    seq_end   = tl.load(cu_seqlens_ptr + (curr_seq_ind + 1) * stride_cu)
+
+    chunk_start = seq_start + local_chunk_ind * CHUNK_SIZE
+    offs_c   = tl.arange(0, CHUNK_SIZE)
+    offs_seq = chunk_start + offs_c
+    mask_seq = (offs_seq < seq_end) & (offs_seq < S)
+
+    dSSdA_off = (pid_batch * stride_dSSdA_batch + pid_head * stride_dSSdA_head +
+                 pid_chunk * stride_dSSdA_chunk)
+    SSdA_off  = (pid_batch * stride_SSdA_batch  + pid_head * stride_SSdA_head  +
+                 pid_chunk * stride_SSdA_chunk)
+    ddt_ptrs = ddt_out_ptr + (pid_batch * stride_ddt_batch +
+                               pid_head  * stride_ddt_head  +
+                               offs_seq  * stride_ddt_seq)
+
+    # NOTE: dSSdA stored as (seq_k x seq_q) – transpose indices match non-varlen version.
+    dSSdA_block = tl.load(dSSdA_off + dSSdA_ptr +
+                          offs_c[:, None] * stride_dSSdA_col +
+                          offs_c[None, :] * stride_dSSdA_row)
+    SSdA_block  = tl.load(SSdA_off  + SSdA_cs_ptr  +
+                           offs_c[:, None] * stride_SSdA_row +
+                           offs_c[None, :] * stride_SSdA_col)
+
+    dSSdA_block = dSSdA_block * tl.exp(SSdA_block)
+    dSSdA_block = tl.cumsum(dSSdA_block, axis=0, reverse=True)
+
+    offs_i = tl.arange(0, CHUNK_SIZE)[:, None]
+    offs_j = tl.arange(0, CHUNK_SIZE)[None, :]
+    SS_mask = offs_i > offs_j
+    dSSdA   = tl.where(SS_mask, dSSdA_block, 0.0)
+
+    ddt_chunk = tl.load(ddt_ptrs, mask=mask_seq, other=0.0)
+    ddt_chunk += tl.sum(dSSdA, axis=1)
+    tl.store(ddt_ptrs, ddt_chunk, mask=mask_seq)
+
+
+@triton.autotune(
+    configs=[
+        triton.Config({}, num_stages=s, num_warps=w)
+        for s in [2, 3]
+        for w in [4, 8]
+    ],
+    key=["CHUNK_SIZE"],
+)
+@triton.jit
+def bwd_dtrap_ddt_kernel_varlen(
+    trap_ptr, dt_ptr, dfactor_ptr, dgamma_diag_ptr,
+    ddt_ptr, dtrap_ptr,
+    cu_seqlens_ptr,
+    state_seq_mapping_ptr,
+    state_chunk_in_seq_ptr,
+    stride_trap_batch, stride_trap_head, stride_trap_seq,
+    stride_dt_batch,   stride_dt_head,   stride_dt_seq,
+    stride_dfactor_batch, stride_dfactor_head, stride_dfactor_seq,
+    stride_dgamma_batch,  stride_dgamma_head,  stride_dgamma_seq,
+    stride_ddt_batch,  stride_ddt_head,  stride_ddt_seq,
+    stride_dtrap_batch, stride_dtrap_head, stride_dtrap_seq,
+    stride_cu, stride_ssm, stride_scis,
+    S: tl.constexpr,
+    CHUNK_SIZE: tl.constexpr,
+):
+    """Varlen version of bwd_dtrap_ddt_kernel.
+    Grid: (B, H, nchunks_global).
+    """
+    pid_batch = tl.program_id(0)
+    pid_head  = tl.program_id(1)
+    pid_chunk = tl.program_id(2)
+
+    curr_seq_ind    = tl.load(state_seq_mapping_ptr  + pid_chunk * stride_ssm)
+    local_chunk_ind = tl.load(state_chunk_in_seq_ptr + pid_chunk * stride_scis)
+    seq_start = tl.load(cu_seqlens_ptr + curr_seq_ind       * stride_cu)
+    seq_end   = tl.load(cu_seqlens_ptr + (curr_seq_ind + 1) * stride_cu)
+    is_first_chunk_in_seq = (local_chunk_ind == 0)
+
+    chunk_start = seq_start + local_chunk_ind * CHUNK_SIZE
+    offs_c   = tl.arange(0, CHUNK_SIZE)
+    offs_seq = chunk_start + offs_c
+    mask_seq = (offs_seq < seq_end) & (offs_seq < S)
+
+    trap_off = pid_batch * stride_trap_batch + pid_head * stride_trap_head
+    dt_off   = pid_batch * stride_dt_batch   + pid_head * stride_dt_head
+    dfactor_off  = pid_batch * stride_dfactor_batch  + pid_head * stride_dfactor_head
+    dgamma_off   = pid_batch * stride_dgamma_batch   + pid_head * stride_dgamma_head
+
+    # Shifted (next-token) trap and dt – zero out at seq boundary.
+    shift_mask = (offs_seq + 1 < seq_end) & (offs_seq + 1 < S)
+    strap_block = tl.load(trap_ptr + trap_off + (offs_seq + 1) * stride_trap_seq,
+                          mask=shift_mask, other=0.0)
+    sdt_block   = tl.load(dt_ptr   + dt_off   + (offs_seq + 1) * stride_dt_seq,
+                          mask=shift_mask, other=0.0)
+    trap_block  = tl.load(trap_ptr + trap_off + offs_seq * stride_trap_seq,
+                          mask=mask_seq, other=0.0)
+    dt_block    = tl.load(dt_ptr   + dt_off   + offs_seq * stride_dt_seq,
+                          mask=mask_seq, other=0.0)
+    dfactor_block     = tl.load(dfactor_ptr  + dfactor_off  + offs_seq * stride_dfactor_seq,
+                                mask=mask_seq, other=0.0)
+    dgamma_diag_block = tl.load(dgamma_diag_ptr + dgamma_off + offs_seq * stride_dgamma_seq,
+                                mask=mask_seq, other=0.0)
+
+    dgamma_block  = dfactor_block + dgamma_diag_block
+    dsgamma_block = dfactor_block
+
+    dsdt_block  = tl.sigmoid(-strap_block.to(tl.float32)) * dsgamma_block
+    dstrap_block = -sdt_block * dsgamma_block
+
+    # Cross-chunk: the first position of this chunk gets its shifted gradient from
+    # the previous chunk's last position – UNLESS this is the first chunk of a sequence.
+    prev_seq_valid = chunk_start > 0 and not is_first_chunk_in_seq
+    prev_dgamma = tl.load(
+        dfactor_ptr + dfactor_off + (chunk_start - 1) * stride_dfactor_seq,
+        mask=prev_seq_valid, other=0.0,
+    )
+    prev_dsgamma = prev_dgamma
+    prev_strap = tl.load(trap_ptr + trap_off + chunk_start * stride_trap_seq,
+                         mask=(chunk_start < S) and not is_first_chunk_in_seq, other=0.0)
+    prev_sdt   = tl.load(dt_ptr   + dt_off   + chunk_start * stride_dt_seq,
+                         mask=(chunk_start < S) and not is_first_chunk_in_seq, other=0.0)
+    prev_dsdt  = tl.sigmoid(-prev_strap.to(tl.float32)) * prev_dsgamma
+    prev_dstrap = -prev_sdt * prev_dsgamma
+
+    offs_i = tl.arange(0, CHUNK_SIZE)[:, None]
+    offs_j = tl.arange(0, CHUNK_SIZE)[None, :]
+    shift_mask_mat = offs_i == (offs_j + 1)
+    dsdt_shift  = tl.sum(tl.where(shift_mask_mat, dsdt_block [None, :], 0.0), axis=1)
+    dstrap_shift = tl.sum(tl.where(shift_mask_mat, dstrap_block[None, :], 0.0), axis=1)
+
+    offs = tl.arange(0, CHUNK_SIZE)
+    dsdt_shift  = tl.where(offs == 0, prev_dsdt,  dsdt_shift)
+    dstrap_shift = tl.where(offs == 0, prev_dstrap, dstrap_shift)
+
+    ddt_out  = dsdt_shift + dgamma_block * tl.sigmoid(trap_block.to(tl.float32))
+    dtrap_out = dstrap_shift + dgamma_block * dt_block
+    dtrap_out *= tl.sigmoid(trap_block.to(tl.float32)) * tl.sigmoid(-trap_block.to(tl.float32))
+
+    ddt_ptrs  = ddt_ptr  + (pid_batch * stride_ddt_batch  + pid_head * stride_ddt_head  + offs_seq * stride_ddt_seq)
+    dtrap_ptrs = dtrap_ptr + (pid_batch * stride_dtrap_batch + pid_head * stride_dtrap_head + offs_seq * stride_dtrap_seq)
+    tl.store(ddt_ptrs,  ddt_out,  mask=mask_seq)
+    tl.store(dtrap_ptrs, dtrap_out, mask=mask_seq)
+
+
+def _build_varlen_chunk_mapping(cu_seqlens: torch.Tensor, chunk_size: int):
+    """Build the three varlen indexing primitives consumed by every varlen kernel.
+
+    Because sequences have different lengths, chunks do not cross sequence
+    boundaries — the last chunk of each sequence may be shorter than
+    chunk_size.  All chunks across all sequences are laid out in a single flat
+    "global" array of length nchunks_global, and the two mapping arrays let
+    each kernel thread locate the sequence and position it belongs to.
+
+    Returns
+    -------
+    nchunks_global : int
+        Total number of chunk slots across all sequences:
+            nchunks_global = (S // chunk_size) + num_sequences
+        The additive num_sequences term accounts for the partial last chunk of
+        each sequence.  Kernel grids are launched with nchunks_global programs
+        along the chunk dimension.
+
+    state_seq_mapping : int32 tensor, shape [nchunks_global]
+        Maps each global chunk index to the sequence it belongs to.
+        state_seq_mapping[pid_chunk] == i  means chunk pid_chunk is part of
+        sequence i.  Inactive (padding) slots are left at 0 (zero-init), so
+        they appear to belong to sequence 0.
+
+    state_chunk_in_seq : int32 tensor, shape [nchunks_global]
+        Maps each global chunk index to its 0-based position within its
+        sequence.  Active slots hold values in [0, chunks_per_seq[i]).
+        Inactive slots are filled with the sentinel ceil(seq_lens[0] /
+        chunk_size), which is co-designed with the zero-initialisation of
+        state_seq_mapping: an inactive slot "belongs" to sequence 0, and the
+        offset is large enough that chunk_start = cu_seqlens[0] + offset *
+        chunk_size >= cu_seqlens[1], placing every element beyond seq_end and
+        making the kernel's mask all-False (a no-op).
+    """
+    num_sequences = int(cu_seqlens.numel()) - 1
+    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunks_per_seq = (seq_lens // chunk_size) + 1  # same convention as compute_dacs_segsum_triton
+    S = int(cu_seqlens[-1].item())
+    nchunks_global = (S // chunk_size) + num_sequences
+
+    state_seq_mapping  = torch.zeros(nchunks_global, dtype=torch.int32, device=cu_seqlens.device)
+    state_chunk_in_seq = torch.zeros(nchunks_global, dtype=torch.int32, device=cu_seqlens.device)
+    # Fill with out-of-range sentinel so inactive slots are masked out.
+    default_seq_len = int(seq_lens[0].item()) if num_sequences > 0 else 0
+    state_chunk_in_seq.fill_((default_seq_len + chunk_size - 1) // chunk_size)
+
+    for i in range(num_sequences):
+        start = int(cu_seqlens[i].item())
+        n     = int(chunks_per_seq[i].item())
+        chunk_start = (start // chunk_size) + i
+        state_seq_mapping [chunk_start:chunk_start + n] = i
+        state_chunk_in_seq[chunk_start:chunk_start + n] = torch.arange(n, dtype=torch.int32,
+                                                                         device=cu_seqlens.device)
+    return nchunks_global, state_seq_mapping, state_chunk_in_seq
+
+
+def bwd_dadt_fused_triton_varlen(
+    dSSdA: torch.Tensor,       # [B, H, nchunks_global, C, C]
+    SSdA: torch.Tensor,        # [B, H, nchunks_global, C, C]
+    ddA_cs: torch.Tensor,      # [B, H, S]
+    ddA_cs_rev: torch.Tensor,  # [B, H, S]
+    dA_cs: torch.Tensor,       # [B, H, S]
+    dA_cs_rev: torch.Tensor,   # [B, H, S]
+    chunk_size: int,
+    cu_seqlens: torch.Tensor,  # [NS+1]
+) -> torch.Tensor:
+    """Varlen version of bwd_dadt_fused_triton.
+
+    dSSdA and SSdA use the global chunk layout defined by _build_varlen_chunk_mapping;
+    nchunks_global = (S // chunk_size) + num_sequences.  The result must be
+    multiplied by NEG_LOG2E = -log2(e) ≈ -1.4427 by the caller.
+
+    Returns float32 tensor of shape [B, H, S].
+    """
+    B, H, S = ddA_cs.shape
+    nchunks_global, state_seq_mapping, state_chunk_in_seq = _build_varlen_chunk_mapping(
+        cu_seqlens, chunk_size
+    )
+    assert dSSdA.shape == (B, H, nchunks_global, chunk_size, chunk_size), \
+        f"dSSdA shape mismatch: got {dSSdA.shape}, expected {(B, H, nchunks_global, chunk_size, chunk_size)}"
+
+    dadt_out = torch.zeros(B, H, S, device=ddA_cs.device, dtype=torch.float32)
+    grid = (B, H, nchunks_global)
+
+    bwd_dadt_cumsum_fused_kernel_varlen[grid](
+        ddA_cs, ddA_cs_rev, dA_cs, dA_cs_rev, dadt_out,
+        cu_seqlens, state_seq_mapping, state_chunk_in_seq,
+        ddA_cs.stride(0), ddA_cs.stride(1), ddA_cs.stride(2),
+        cu_seqlens.stride(0),
+        state_seq_mapping.stride(0),
+        state_chunk_in_seq.stride(0),
+        S=S,
+        CHUNK_SIZE=chunk_size,
+    )
+
+    bwd_segsum_dadt_kernel_varlen[grid](
+        dSSdA, SSdA, dadt_out,
+        cu_seqlens, state_seq_mapping, state_chunk_in_seq,
+        dSSdA.stride(0), dSSdA.stride(1), dSSdA.stride(2),
+        dSSdA.stride(3), dSSdA.stride(4),
+        SSdA.stride(0),  SSdA.stride(1),  SSdA.stride(2),
+        SSdA.stride(3),  SSdA.stride(4),
+        dadt_out.stride(0), dadt_out.stride(1), dadt_out.stride(2),
+        cu_seqlens.stride(0),
+        state_seq_mapping.stride(0),
+        state_chunk_in_seq.stride(0),
+        S=S,
+        CHUNK_SIZE=chunk_size,
+    )
+    return dadt_out
+
+
+def bwd_dtrap_ddt_triton_varlen(
+    trap: torch.Tensor,           # [B, H, S]  – trap_presigmoid values
+    dt: torch.Tensor,             # [B, H, S]
+    dfactor: torch.Tensor,        # [B, H, S]
+    dgamma_diag: torch.Tensor,    # [B, H, S]
+    chunk_size: int,
+    cu_seqlens: torch.Tensor,     # [NS+1]
+):
+    """Varlen version of bwd_dtrap_ddt_triton.
+
+    Cross-sequence boundary shifts are suppressed: the first chunk of each
+    sequence receives zero incoming gradient from the shifted sgamma path,
+    matching the is_first_chunk_in_seq guard in bwd_dtrap_ddt_kernel_varlen.
+
+    Returns (ddt, dtrap_presigmoid), both shaped [B, H, S].
+    """
+    B, H, S = dt.shape
+    nchunks_global, state_seq_mapping, state_chunk_in_seq = _build_varlen_chunk_mapping(
+        cu_seqlens, chunk_size
+    )
+    ddt   = torch.zeros_like(dt)
+    dtrap = torch.zeros_like(trap)
+    grid  = (B, H, nchunks_global)
+
+    bwd_dtrap_ddt_kernel_varlen[grid](
+        trap, dt, dfactor, dgamma_diag, ddt, dtrap,
+        cu_seqlens, state_seq_mapping, state_chunk_in_seq,
+        trap.stride(0),    trap.stride(1),    trap.stride(2),
+        dt.stride(0),      dt.stride(1),      dt.stride(2),
+        dfactor.stride(0), dfactor.stride(1), dfactor.stride(2),
+        dgamma_diag.stride(0), dgamma_diag.stride(1), dgamma_diag.stride(2),
+        ddt.stride(0),   ddt.stride(1),   ddt.stride(2),
+        dtrap.stride(0), dtrap.stride(1), dtrap.stride(2),
+        cu_seqlens.stride(0),
+        state_seq_mapping.stride(0),
+        state_chunk_in_seq.stride(0),
+        S=S,
+        CHUNK_SIZE=chunk_size,
+    )
+    return ddt, dtrap
+
+
+# ============================================================================
+# Correctness tests (run via __main__)
 # ============================================================================
 
 def test_bwd_ddt_fused_correctness():
-    """Test the fused kernel against reference implementation."""
+    """Test bwd_dadt_fused_triton (dense) against the reference implementations."""
     print("=" * 70)
-    print("Test: basic_correctness")
+    print("Test: bwd_ddt_fused_correctness (dense)")
     print("=" * 70)
 
     B, H, S = 16, 32, 2048
@@ -649,11 +1456,11 @@ def test_bwd_ddt_fused_correctness():
     return passed
 
 def test_dtrap_ddt_correctness():
-    """Test the fused kernel against reference implementation."""
+    """Test bwd_dtrap_ddt_triton (dense) against compute_dtrap_ddt_ref."""
     import torch.nn.functional as F
 
     print("=" * 70)
-    print("Test: basic_correctness")
+    print("Test: dtrap_ddt_correctness (dense)")
     print("=" * 70)
 
     B, H, S = 16, 32, 2048
@@ -693,7 +1500,60 @@ def test_dtrap_ddt_correctness():
 
     return passed
 
+def test_dacs_segsum_correctness_varlen():
+    import torch.nn.functional as F
+    B, H = 1, 8
+    chunk_size = 16
+    test_cases = [
+        ("single_non_multiple", [37]),
+        ("single_exact_multiple", [32]),
+        ("mixed_with_zero_len", [0, 7, 32, 19, 0, 16]),
+    ]
+
+    all_passed = True
+    for name, seq_lengths in test_cases:
+        S = sum(seq_lengths)
+        if S == 0:
+            continue
+        da = -F.softplus(-3.0 + torch.randn(B, H, S, device='cuda', dtype=torch.float))
+        cu_seqlens = torch.tensor(
+            [0] + list(torch.cumsum(torch.tensor(seq_lengths), dim=0).tolist()),
+            device='cuda',
+            dtype=torch.int32,
+        )
+        num_sequences = len(seq_lengths)
+
+        da_cs_ref, da_cs_rev_ref, segsum_ref = compute_dacs_segsum_ref_varlen(
+            da, chunk_size, cu_seqlens, num_sequences
+        )
+        da_cs_triton, da_cs_rev_triton, segsum_triton = compute_dacs_segsum_triton_varlen(
+            da, chunk_size, cu_seqlens
+        )
+
+        max_diff_cs = (da_cs_ref - da_cs_triton).abs().max().item()
+        mean_diff_cs = (da_cs_ref - da_cs_triton).abs().mean().item()
+        max_diff_cs_rev = (da_cs_rev_ref - da_cs_rev_triton).abs().max().item()
+        mean_diff_cs_rev = (da_cs_rev_ref - da_cs_rev_triton).abs().mean().item()
+        max_diff_segsum = (segsum_ref - segsum_triton).abs().max().item()
+        mean_diff_segsum = (segsum_ref - segsum_triton).abs().mean().item()
+
+        print(f"[{name}]")
+        print(f"  da_cs max difference:     {max_diff_cs:.2e}")
+        print(f"  da_cs mean difference:    {mean_diff_cs:.2e}")
+        print(f"  da_cs_rev max difference: {max_diff_cs_rev:.2e}")
+        print(f"  da_cs_rev mean difference:{mean_diff_cs_rev:.2e}")
+        print(f"  segsum max difference:    {max_diff_segsum:.2e}")
+        print(f"  segsum mean difference:   {mean_diff_segsum:.2e}")
+        passed = max(max_diff_cs, max_diff_cs_rev, max_diff_segsum) < 1e-4
+        print(f"  Status: {'PASS' if passed else 'FAIL'}")
+        print()
+        all_passed = all_passed and passed
+
+    return all_passed
+
+
 def test_dacs_segsum_correctness():
+    """Test the dense dacs+segsum Triton kernel against the dense reference."""
     import torch.nn.functional as F
     B, H, S = 16, 32, 2048
     chunk_size = 16
@@ -709,6 +1569,9 @@ def test_dacs_segsum_correctness():
     max_diff_segsum = (segsum_ref - segsum_triton).abs().max().item()
     mean_diff_segsum = (segsum_ref - segsum_triton).abs().mean().item()
 
+    print("=" * 70)
+    print("Test: dacs_segsum_correctness")
+    print("=" * 70)
     print(f"  da_cs max difference:     {max_diff_cs:.2e}")
     print(f"  da_cs mean difference:    {mean_diff_cs:.2e}")
     print(f"  da_cs_rev max difference: {max_diff_cs_rev:.2e}")
@@ -722,8 +1585,120 @@ def test_dacs_segsum_correctness():
     return passed
 
 
+def test_bwd_dadt_fused_varlen_correctness():
+    """Test bwd_dadt_fused_triton_varlen against varlen reference."""
+    print("=" * 70)
+    print("Test: bwd_dadt_fused_varlen_correctness")
+    print("=" * 70)
+
+    import torch.nn.functional as F
+    B, H, chunk_size = 1, 8, 16
+    # Three sequences of lengths 37, 32, 28; total S = 97
+    seq_lengths = [37, 32, 28]
+    S = sum(seq_lengths)
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(seq_lengths), dim=0).tolist()),
+        device='cuda', dtype=torch.int32,
+    )
+    num_sequences = len(seq_lengths)
+    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    chunks_per_seq = (seq_lens // chunk_size) + 1
+    nchunks_global = (S // chunk_size) + num_sequences
+    C = chunk_size
+
+    torch.manual_seed(42)
+    dSSdA    = torch.randn(B, H, nchunks_global, C, C, device='cuda', dtype=torch.float32)
+    ddA_cs   = torch.randn(B, H, S, device='cuda', dtype=torch.float32)
+    ddA_cs_rev = torch.randn(B, H, S, device='cuda', dtype=torch.float32)
+    dA_cs    = torch.randn(B, H, S, device='cuda', dtype=torch.float32) * 0.1
+    dA_cs_rev = torch.randn(B, H, S, device='cuda', dtype=torch.float32) * 0.1
+
+    # Build SSdA in the varlen global chunk layout.
+    # For each sequence i, the global chunk slots start at (cu_seqlens[i] // chunk_size) + i.
+    SSdA = torch.zeros(B, H, nchunks_global, C, C, device='cuda', dtype=torch.float32)
+    for i in range(num_sequences):
+        start = int(cu_seqlens[i].item())
+        end   = int(cu_seqlens[i + 1].item())
+        curr_seqlen  = end - start
+        curr_nchunks = int(chunks_per_seq[i].item())
+        curr_padded_len = curr_nchunks * chunk_size
+        global_chunk_start = (start // chunk_size) + i
+
+        dA_cs_padded = torch.zeros(B, H, curr_padded_len, device='cuda', dtype=torch.float32)
+        if curr_seqlen > 0:
+            dA_cs_padded[:, :, :curr_seqlen] = dA_cs[:, :, start:end]
+        dA_cs_seq = dA_cs_padded.view(B, H, curr_nchunks, C)
+        SSdA[:, :, global_chunk_start:global_chunk_start + curr_nchunks, :, :] = (
+            dA_cs_seq[:, :, :, :, None] - dA_cs_seq[:, :, :, None, :]
+        )
+
+    # Varlen reference
+    ddt_ref = bwd_dadt_fused_varlen_ref(
+        dSSdA, ddA_cs, ddA_cs_rev, dA_cs, dA_cs_rev, chunk_size, cu_seqlens
+    )
+
+    # Varlen Triton kernel (result scaled by -log2(e) to match reference sign convention)
+    ddt_triton = bwd_dadt_fused_triton_varlen(
+        dSSdA, SSdA, ddA_cs, ddA_cs_rev, dA_cs, dA_cs_rev, chunk_size, cu_seqlens
+    ) * -1.4426950408889634
+
+    max_diff  = (ddt_ref - ddt_triton).abs().max().item()
+    mean_diff = (ddt_ref - ddt_triton).abs().mean().item()
+    print(f"  Max difference:  {max_diff:.2e}")
+    print(f"  Mean difference: {mean_diff:.2e}")
+    passed = max_diff < 1e-4
+    print(f"  Status: {'PASS' if passed else 'FAIL'}")
+    print()
+    return passed
+
+
+def test_dtrap_ddt_varlen_correctness():
+    """Test bwd_dtrap_ddt_triton_varlen against varlen reference."""
+    print("=" * 70)
+    print("Test: dtrap_ddt_varlen_correctness")
+    print("=" * 70)
+
+    import torch.nn.functional as F
+    B, H, chunk_size = 1, 8, 16
+    seq_lengths = [37, 32, 28]
+    S = sum(seq_lengths)
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(seq_lengths), dim=0).tolist()),
+        device='cuda', dtype=torch.int32,
+    )
+
+    torch.manual_seed(42)
+    trap        = torch.rand(B, H, S, device='cuda', dtype=torch.float16)
+    dt          = F.softplus(-3.0 + torch.randn(B, H, S, device='cuda', dtype=torch.float32))
+    dfactor     = torch.randn(B, H, S, device='cuda', dtype=torch.float32) * 0.1
+    dgamma_diag = torch.randn(B, H, S, device='cuda', dtype=torch.float32) * 0.1
+
+    # Varlen reference
+    ddt_ref, dtrap_ref = compute_dtrap_ddt_varlen_ref(
+        dfactor, dgamma_diag, trap, dt, chunk_size, cu_seqlens
+    )
+
+    # Varlen Triton kernel
+    ddt_triton, dtrap_triton = bwd_dtrap_ddt_triton_varlen(
+        trap, dt, dfactor, dgamma_diag, chunk_size, cu_seqlens
+    )
+
+    max_diff_ddt   = (ddt_ref   - ddt_triton  ).abs().max().item()
+    mean_diff_ddt  = (ddt_ref   - ddt_triton  ).abs().mean().item()
+    max_diff_dtrap = (dtrap_ref - dtrap_triton).abs().max().item()
+    mean_diff_dtrap = (dtrap_ref - dtrap_triton).abs().mean().item()
+    print(f"  ddt  max difference:  {max_diff_ddt:.2e}")
+    print(f"  ddt  mean difference: {mean_diff_ddt:.2e}")
+    print(f"  dtrap max difference:  {max_diff_dtrap:.2e}")
+    print(f"  dtrap mean difference: {mean_diff_dtrap:.2e}")
+    passed = max(max_diff_ddt, max_diff_dtrap) < 1e-3
+    print(f"  Status: {'PASS' if passed else 'FAIL'}")
+    print()
+    return passed
+
+
 # ============================================================================
-# Benchmarking Functions
+# Benchmarks (run individually as needed)
 # ============================================================================
 
 def benchmark_bwd_ddt():
@@ -870,10 +1845,14 @@ def benchmark_dtrap_ddt():
 # Main execution
 # ============================================================================
 if __name__ == "__main__":
+    # Non-varlen (dense) tests
     test_bwd_ddt_fused_correctness()
-    # benchmark_bwd_ddt()
     test_dtrap_ddt_correctness()
+    test_dacs_segsum_correctness()
+    # benchmark_bwd_ddt()
     # benchmark_dtrap_ddt()
     # benchmark_dacs_segsum()
-    test_dacs_segsum_correctness()
-    # benchmark_dacs_segsum()
+    # Varlen tests
+    test_dacs_segsum_correctness_varlen()
+    test_bwd_dadt_fused_varlen_correctness()
+    test_dtrap_ddt_varlen_correctness()

--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
@@ -387,6 +387,17 @@ def mamba3_siso_combined(
     all_states_absent = (Input_SSM_State is None) and (Input_K_State is None) and (Input_V_State is None) and (Input_Angle_State is None)
     assert all_states_present or all_states_absent, "Input states must be provided together or all be None."
 
+    # Typecast all derived tensors to bf16.
+    # ADT, DT should be in fp32 for stability
+    # Q_bias, K_bias, D should be in fp32 as they are model parameters
+    Q = Q.to(torch.bfloat16)
+    K = K.to(torch.bfloat16)
+    V = V.to(torch.bfloat16)
+    Trap = Trap.to(torch.bfloat16)
+    Angles = Angles.to(torch.bfloat16)
+    if Z is not None:
+        Z = Z.to(torch.bfloat16)
+
     return _Mamba3Function.apply(
         Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, D, Z,
         Input_Angle_State, Input_SSM_State, Input_K_State, Input_V_State, cu_seqlens, chunk_size, return_final_states

--- a/tests/ops/tilelang/test_mamba3_mimo.py
+++ b/tests/ops/tilelang/test_mamba3_mimo.py
@@ -5,12 +5,21 @@ Copyright (c) 2026, Dao AI Lab, Goombalab
 
 
 Usage:
+pytest -q -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py
+
+# Focus on specific test subsets with -k:
 pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k bwd
 pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k fwd
 pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k smoke
 pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k chunk_ref_matches_step_ref
 
-Remove the -s flag for less verbose output.
+# Varlen-specific tests:
+pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k varlen
+pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k "fwd_varlen"
+pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k "bwd_varlen"
+pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k "smoke_forward_backward_varlen"
+
+# (Remove the -s flag for less verbose output).
 """
 
 import sys
@@ -474,10 +483,53 @@ def mamba3_MIMO_chunk_ref(
     dtype: torch.dtype = torch.float32,
     rotate_pairwise: bool = False,
     contract_mimo_out: bool = True,
+    cu_seqlens: Optional[Tensor] = None,
 ) -> tuple[Tensor, Optional[Tensor], Optional[Tensor]]:
     # Local copy of the reference program so tests remain valid even if module-level
     # debug/reference helpers are removed from shipped kernels.
     from einops import rearrange, repeat
+
+    # --- Varlen path: loop per-sequence, delegate to the single-sequence path ---
+    if cu_seqlens is not None:
+        NS = cu_seqlens.shape[0] - 1
+        out_parts = []
+        for i in range(NS):
+            start = int(cu_seqlens[i].item())
+            end = int(cu_seqlens[i + 1].item())
+            seq_len = end - start
+            out_i, _, _ = mamba3_MIMO_chunk_ref(
+                q[:, start:end], k[:, start:end], v[:, start:end],
+                q_bias, k_bias, mimo_v, mimo_o,
+                z[:, start:end] if z is not None else None, mimo_z,
+                angles[:, start:end],
+                dA_cs[:, :, start:end], dA_cs_rev[:, :, start:end],
+                dt[:, :, start:end], trap[:, :, start:end],
+                D,
+                chunk_size=chunk_size,
+                rotary_dim_divisor=rotary_dim_divisor,
+                return_final_state=False, dtype=dtype,
+                rotate_pairwise=rotate_pairwise,
+                contract_mimo_out=contract_mimo_out,
+                cu_seqlens=None,
+            )
+            out_parts.append(out_i[:, :seq_len])
+        return torch.cat(out_parts, dim=1), None, None
+
+    # --- Single-sequence path ---
+    # Pad to the next multiple of chunk_size so the chunked rearranges are valid
+    # for sequences whose length is not a multiple of chunk_size.
+    orig_seqlen = q.shape[1]
+    pad_len = (chunk_size - orig_seqlen % chunk_size) % chunk_size
+    if pad_len > 0:
+        q         = _pad_zeros(q,         pad_len, dim=1)
+        k         = _pad_zeros(k,         pad_len, dim=1)
+        v         = _pad_zeros(v,         pad_len, dim=1)
+        angles    = _pad_zeros(angles,    pad_len, dim=1)
+        z         = _pad_zeros(z,         pad_len, dim=1)
+        dA_cs     = _pad_zeros(dA_cs,     pad_len, dim=2)
+        dA_cs_rev = _pad_zeros(dA_cs_rev, pad_len, dim=2)
+        dt        = _pad_zeros(dt,        pad_len, dim=2)
+        trap      = _pad_zeros(trap,      pad_len, dim=2)
 
     nchunks = q.shape[1] // chunk_size
     q, k, v = q.to(dtype), k.to(dtype), v.to(dtype)
@@ -630,9 +682,11 @@ def mamba3_MIMO_chunk_ref(
     if contract_mimo_out:
         assert mimo_o is not None
         o = torch.einsum("bhncrd,hrd->bhncd", o, mimo_o)
-        return rearrange(o, "b h n c d -> b (n c) h d"), final_state, final_k
+        out = rearrange(o, "b h n c d -> b (n c) h d")
+        return out[:, :orig_seqlen], final_state, final_k
 
-    return rearrange(o, "b h n c r d -> b (n c) r h d"), final_state, final_k
+    out = rearrange(o, "b h n c r d -> b (n c) r h d")
+    return out[:, :orig_seqlen], final_state, final_k
 
 
 def run_ref_backward_fp32(
@@ -1250,3 +1304,627 @@ def test_mamba_mimo_smoke_forward_backward(mods: SimpleNamespace) -> None:
         grad = inputs[name].grad
         assert grad is not None, f"Missing gradient for {name}"
         assert torch.isfinite(grad).all(), f"Non-finite gradient detected for {name}"
+
+
+def test_mamba_mimo_smoke_forward_backward_varlen(mods: SimpleNamespace) -> None:
+    """Smoke test for the varlen forward+backward path through ``mamba3_mimo``.
+
+    Packs three sequences of non-uniform lengths (none a multiple of chunk_size)
+    into a single batch=1 tensor and checks that forward succeeds with the
+    correct output shape and all 14 leaf gradients are populated and finite.
+    """
+    import math
+    chunk_size = 16
+    mimo_rank = 4
+    nheads_qk = FIXED_G
+    nheads = FIXED_H
+    headdim_qk = 128
+    headdim_v = 64
+    rotary_dim_divisor = FIXED_ROTARY_DIM_DIVISOR
+
+    seqlens = [2 * chunk_size - 1, 3 * chunk_size + 5, 4 * chunk_size - 3]
+    s_total = sum(seqlens)
+    cu_seqlens = torch.tensor(
+        [0] + list(torch.cumsum(torch.tensor(seqlens, dtype=torch.int32), dim=0).tolist()),
+        device="cuda", dtype=torch.int32,
+    )
+
+    torch.manual_seed(42)
+    torch.cuda.manual_seed_all(42)
+
+    Q = torch.randn(
+        (1, s_total, mimo_rank, nheads_qk, headdim_qk), device="cuda",
+        dtype=FIXED_DTYPE, requires_grad=True,
+    )
+    K = torch.randn_like(Q, requires_grad=True)
+    V = torch.randn(
+        (1, s_total, nheads, headdim_v), device="cuda",
+        dtype=FIXED_DTYPE, requires_grad=True,
+    )
+    DT = F.softplus(
+        -3.0 + torch.randn(1, nheads, s_total, device="cuda", dtype=torch.float)
+    ).detach().requires_grad_(True)
+    ADT = (-DT.detach() * math.log2(math.e)).clone().detach().requires_grad_(True)
+    Trap = (
+        torch.rand((1, nheads, s_total), device="cuda", dtype=FIXED_DTYPE) * 0.5
+    ).detach().requires_grad_(True)
+    Q_bias = torch.randn(
+        (nheads, mimo_rank, headdim_qk), device="cuda",
+        dtype=torch.float32, requires_grad=True,
+    )
+    K_bias = torch.randn_like(Q_bias, requires_grad=True)
+    MIMO_V = (
+        torch.randn((nheads, mimo_rank, headdim_v), device="cuda", dtype=torch.float32) / mimo_rank
+    ).detach().requires_grad_(True)
+    MIMO_Z = (torch.randn_like(MIMO_V) / mimo_rank).detach().requires_grad_(True)
+    MIMO_Out = (torch.randn_like(MIMO_V) / mimo_rank).detach().requires_grad_(True)
+    Angles = torch.rand(
+        (1, s_total, nheads, headdim_qk // rotary_dim_divisor), device="cuda",
+        dtype=torch.float32, requires_grad=True,
+    )
+    D = torch.randn((nheads,), device="cuda", dtype=torch.float32, requires_grad=True)
+    Z = torch.randn(
+        (1, s_total, nheads, headdim_v), device="cuda",
+        dtype=FIXED_DTYPE, requires_grad=True,
+    )
+
+    out = mods.top.mamba3_mimo(
+        Q, K, V, ADT, DT, Trap,
+        Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out,
+        Angles, D, Z,
+        chunk_size=chunk_size,
+        rotary_dim_divisor=rotary_dim_divisor,
+        dtype=FIXED_DTYPE,
+        cu_seqlens=cu_seqlens,
+    )
+    assert out.shape == (1, s_total, nheads, headdim_v), \
+        f"unexpected output shape {out.shape}"
+
+    out.float().sum().backward()
+
+    leaf_tensors = {
+        "Q": Q, "K": K, "V": V, "ADT": ADT, "DT": DT, "Trap": Trap,
+        "Q_bias": Q_bias, "K_bias": K_bias,
+        "MIMO_V": MIMO_V, "MIMO_Z": MIMO_Z, "MIMO_Out": MIMO_Out,
+        "Angles": Angles, "D": D, "Z": Z,
+    }
+    for name, tensor in leaf_tensors.items():
+        assert tensor.grad is not None, f"Missing gradient for {name}"
+        assert torch.isfinite(tensor.grad).all(), f"Non-finite gradient for {name}"
+
+
+# ---------------------------------------------------------------------------
+# Varlen fixtures and helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="module")
+def mods_varlen() -> SimpleNamespace:
+    _require_cuda_and_kernel_deps()
+    import mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_fwd_varlen as fwd_varlen
+    import mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_bwd_varlen as bwd_varlen
+    import mamba_ssm.ops.triton.mamba3.mamba3_mimo_utils as utils_varlen
+
+    return SimpleNamespace(
+        fwd_varlen=fwd_varlen,
+        bwd_varlen=bwd_varlen,
+        utils_varlen=utils_varlen,
+    )
+
+
+def _varlen_seqlens(chunk_size: int) -> list:
+    """Non-uniform sequence lengths for varlen tests.
+
+    Returns four lengths [2C-1, 5C-3, 3C, 4C-1] so that adjacent sequences
+    differ, no two are the same, and three of the four are NOT multiples of
+    chunk_size — exercising the tail-chunk boundary logic in the kernel.
+    """
+    return [2 * chunk_size - 1, 5 * chunk_size - 3, 3 * chunk_size, 4 * chunk_size - 1]
+
+
+def _pad_zeros(t: Optional[Tensor], pad_len: int, dim: int) -> Optional[Tensor]:
+    """Append ``pad_len`` zero-slices along ``dim``.  Returns ``t`` if pad_len==0."""
+    if t is None or pad_len == 0:
+        return t
+    shape = list(t.shape)
+    shape[dim] = pad_len
+    return torch.cat([t, torch.zeros(shape, device=t.device, dtype=t.dtype)], dim=dim)
+
+
+def build_inputs_varlen(
+    *,
+    mods_varlen: SimpleNamespace,
+    n: int,
+    p: int,
+    r: int,
+    chunk_size: int,
+    seqlens: list,
+    seed: int,
+    b: int = 1,
+    h: int = FIXED_H,
+    g: int = FIXED_G,
+    dtype: torch.dtype = FIXED_DTYPE,
+    has_z: bool = True,
+    has_d: bool = True,
+    rotary_dim_divisor: int = FIXED_ROTARY_DIM_DIVISOR,
+) -> dict:
+    """Build packed varlen inputs for NS non-uniform sequences.
+
+    Sequence lengths need not be multiples of ``chunk_size``; the reference
+    functions pad per-sequence inputs internally.
+    ``b=1`` is required (standard varlen packing convention).
+    """
+    assert b == 1, "varlen kernel requires b=1 for packed sequences"
+    torch.manual_seed(seed)
+    torch.cuda.manual_seed_all(seed)
+
+    NS = len(seqlens)
+    s_total = sum(seqlens)
+    cu_seqlens = torch.tensor(
+        [0] + list(
+            torch.cumsum(torch.tensor(seqlens, dtype=torch.int32), dim=0).tolist()
+        ),
+        device="cuda",
+        dtype=torch.int32,
+    )
+
+    q = torch.randn((b, s_total, r, g, n), device="cuda", dtype=dtype)
+    k = torch.randn((b, s_total, r, g, n), device="cuda", dtype=dtype)
+    v = torch.randn((b, s_total, h, p), device="cuda", dtype=dtype)
+
+    q_bias = torch.randn((h, r, n), device="cuda", dtype=torch.float32)
+    k_bias = torch.randn((h, r, n), device="cuda", dtype=torch.float32)
+    mimo_v = torch.randn((h, r, p), device="cuda", dtype=torch.float32) / r
+    mimo_o = torch.randn((h, r, p), device="cuda", dtype=torch.float32) / r
+
+    z = torch.randn_like(v) if has_z else None
+    mimo_z = torch.randn_like(mimo_v) if has_z else None
+    d = torch.randn((h,), device="cuda", dtype=torch.float32) if has_d else None
+
+    angles = torch.rand(
+        (b, s_total, h, n // rotary_dim_divisor), device="cuda", dtype=torch.float32
+    )
+    dt = F.softplus(-3.0 + torch.randn((b, h, s_total), device="cuda", dtype=torch.float32))
+    a = torch.rand((b, h, s_total), device="cuda", dtype=torch.float32)
+    dA = (-dt * a).detach()
+
+    # Varlen cumsum / segsum: per-sequence prefix sums respecting sequence boundaries.
+    dA_cs, dA_cs_rev, segsum = mods_varlen.utils_varlen.compute_dacs_segsum_triton_varlen(
+        dA, chunk_size, cu_seqlens,
+    )
+    trap = torch.rand((b, h, s_total), device="cuda", dtype=dtype)
+    dout = torch.randn_like(v)
+
+    return {
+        "q": q, "k": k, "v": v,
+        "q_bias": q_bias, "k_bias": k_bias,
+        "mimo_v": mimo_v, "mimo_o": mimo_o,
+        "z": z, "mimo_z": mimo_z, "D": d,
+        "angles": angles, "dt": dt,
+        "dA": dA,
+        "dA_cs": dA_cs, "dA_cs_rev": dA_cs_rev,
+        "segsum": segsum, "trap": trap, "dout": dout,
+        "cu_seqlens": cu_seqlens, "seqlens": seqlens,
+        "chunk_size": chunk_size,
+        "rotary_dim_divisor": rotary_dim_divisor,
+    }
+
+
+def run_ref_backward_fp32_varlen(
+    inputs: dict,
+    *,
+    contract_mimo_out: bool = True,
+    grad_output: Optional[Tensor] = None,
+) -> dict:
+    """Per-sequence fp32 autograd reference for the varlen backward pass.
+
+    Runs ``mamba3_MIMO_chunk_ref`` on each packed sequence, collects
+    autograd gradients, and accumulates them into packed tensors that match
+    the layout returned by ``tilelang_bwd_combined_varlen``.
+    """
+    cu_seqlens = inputs["cu_seqlens"]
+    NS = cu_seqlens.shape[0] - 1
+    chunk_size = inputs["chunk_size"]
+    ref_dtype = torch.float32
+
+    q_base = inputs["q"].detach().to(ref_dtype)
+    k_base = inputs["k"].detach().to(ref_dtype)
+    v_base = inputs["v"].detach().to(ref_dtype)
+    q_bias_base = inputs["q_bias"].detach().to(ref_dtype)
+    k_bias_base = inputs["k_bias"].detach().to(ref_dtype)
+    mimo_v_base = inputs["mimo_v"].detach().to(ref_dtype)
+    mimo_o_base = (
+        inputs["mimo_o"].detach().to(ref_dtype) if contract_mimo_out else None
+    )
+    z_base = (
+        inputs["z"].detach().to(ref_dtype) if inputs["z"] is not None else None
+    )
+    mimo_z_base = (
+        inputs["mimo_z"].detach().to(ref_dtype)
+        if inputs["mimo_z"] is not None
+        else None
+    )
+    d_base = inputs["D"].detach().to(ref_dtype)
+    angles_base = inputs["angles"].detach().to(ref_dtype)
+    dt_base = inputs["dt"].detach().to(ref_dtype)
+    trap_base = inputs["trap"].detach().to(ref_dtype)
+    dA_cs_base = inputs["dA_cs"].detach().to(ref_dtype)
+    dA_cs_rev_base = inputs["dA_cs_rev"].detach().to(ref_dtype)
+    if grad_output is None:
+        grad_output = inputs["dout"]
+    dout = grad_output.to(ref_dtype)
+
+    # Gradient accumulators (packed layout)
+    dq = torch.zeros_like(q_base)
+    dk = torch.zeros_like(k_base)
+    dv = torch.zeros_like(v_base)
+    dq_bias = torch.zeros_like(q_bias_base)
+    dk_bias = torch.zeros_like(k_bias_base)
+    dmimo_v = torch.zeros_like(mimo_v_base)
+    dmimo_o = torch.zeros_like(mimo_o_base) if contract_mimo_out else None
+    dz = torch.zeros_like(v_base) if z_base is not None else None
+    dmimo_z = torch.zeros_like(mimo_z_base) if mimo_z_base is not None else None
+    dD = torch.zeros_like(d_base)
+    dangles = torch.zeros_like(angles_base)
+    ddA_cs = torch.zeros_like(dA_cs_base)
+    ddA_cs_rev = torch.zeros_like(dA_cs_rev_base)
+    ddt = torch.zeros_like(dt_base)
+    dtrap_acc = torch.zeros_like(trap_base)
+
+    for i in range(NS):
+        start = int(cu_seqlens[i].item())
+        end = int(cu_seqlens[i + 1].item())
+        seq_len = end - start
+
+        # --- Leaf tensors: only the VALID slice is differentiable ---
+        # mamba3_MIMO_chunk_ref handles padding internally and returns outputs
+        # already sliced back to seq_len, so no explicit _pad_zeros needed here.
+        q_i_leaf   = q_base[:, start:end].detach().requires_grad_()
+        k_i_leaf   = k_base[:, start:end].detach().requires_grad_()
+        v_i_leaf   = v_base[:, start:end].detach().requires_grad_()
+        qb_i       = q_bias_base.clone().requires_grad_()
+        kb_i       = k_bias_base.clone().requires_grad_()
+        mv_i       = mimo_v_base.clone().requires_grad_()
+        mo_i       = mimo_o_base.clone().requires_grad_() if contract_mimo_out else None
+        z_i_leaf   = (
+            z_base[:, start:end].detach().requires_grad_()
+            if z_base is not None else None
+        )
+        mz_i       = (
+            mimo_z_base.clone().requires_grad_() if mimo_z_base is not None else None
+        )
+        d_i        = d_base.clone().requires_grad_()
+        ang_i_leaf = angles_base[:, start:end].detach().requires_grad_()
+        dA_cs_i_leaf     = dA_cs_base[:, :, start:end].detach().requires_grad_()
+        dA_cs_rev_i_leaf = dA_cs_rev_base[:, :, start:end].detach().requires_grad_()
+        dt_i_leaf   = dt_base[:, :, start:end].detach().requires_grad_()
+        trap_i_leaf = trap_base[:, :, start:end].detach().requires_grad_()
+
+        out_i, _, _ = mamba3_MIMO_chunk_ref(
+            q_i_leaf, k_i_leaf, v_i_leaf, qb_i, kb_i, mv_i, mo_i,
+            z_i_leaf, mz_i,
+            ang_i_leaf, dA_cs_i_leaf, dA_cs_rev_i_leaf, dt_i_leaf, trap_i_leaf, d_i,
+            chunk_size=chunk_size,
+            rotary_dim_divisor=inputs["rotary_dim_divisor"],
+            dtype=ref_dtype,
+            contract_mimo_out=contract_mimo_out,
+        )
+        # out_i is already [:, :seq_len] — mamba3_MIMO_chunk_ref slices internally.
+
+        grad_input_items = [
+            ("q", q_i_leaf), ("k", k_i_leaf), ("v", v_i_leaf),
+            ("q_bias", qb_i), ("k_bias", kb_i),
+            ("mimo_v", mv_i), ("angles", ang_i_leaf),
+            ("dA_cs", dA_cs_i_leaf), ("dA_cs_rev", dA_cs_rev_i_leaf),
+            ("dt", dt_i_leaf), ("trap", trap_i_leaf), ("dD", d_i),
+        ]
+        if z_i_leaf is not None:
+            grad_input_items.append(("z", z_i_leaf))
+        if mz_i is not None:
+            grad_input_items.append(("mimo_z", mz_i))
+        if contract_mimo_out:
+            grad_input_items.append(("mimo_o", mo_i))
+
+        grads = torch.autograd.grad(
+            outputs=out_i,
+            inputs=tuple(t for _, t in grad_input_items),
+            grad_outputs=dout[:, start:end],
+            retain_graph=False,
+            allow_unused=True,
+        )
+        gmap = {name: g for (name, _), g in zip(grad_input_items, grads)}
+
+        dq[:, start:end] += gmap["q"]
+        dk[:, start:end] += gmap["k"]
+        dv[:, start:end] += gmap["v"]
+        dq_bias += gmap["q_bias"]
+        dk_bias += gmap["k_bias"]
+        dmimo_v += gmap["mimo_v"]
+        dangles[:, start:end] += gmap["angles"]
+        ddA_cs[:, :, start:end] += gmap["dA_cs"]
+        ddA_cs_rev[:, :, start:end] += gmap["dA_cs_rev"]
+        ddt[:, :, start:end] += gmap["dt"]
+        dtrap_acc[:, :, start:end] += gmap["trap"]
+        dD += gmap["dD"]
+        if dz is not None and "z" in gmap:
+            dz[:, start:end] += gmap["z"]
+        if dmimo_z is not None and "mimo_z" in gmap:
+            dmimo_z += gmap["mimo_z"]
+        if dmimo_o is not None and "mimo_o" in gmap:
+            dmimo_o += gmap["mimo_o"]
+
+    # Convert per-sequence ddA_cs / ddA_cs_rev -> ddA using the same formula
+    # as grads_to_dA, applied independently to each sequence.
+    # grads_to_dA requires seq_len % chunk_size == 0, so pad non-multiples.
+    ddA = torch.zeros_like(dA_cs_base)
+    for i in range(NS):
+        start = int(cu_seqlens[i].item())
+        end = int(cu_seqlens[i + 1].item())
+        seq_len = end - start
+        pad_len = (chunk_size - seq_len % chunk_size) % chunk_size
+        ddA_cs_i     = _pad_zeros(ddA_cs[:, :, start:end],     pad_len, dim=2)
+        ddA_cs_rev_i = _pad_zeros(ddA_cs_rev[:, :, start:end], pad_len, dim=2)
+        ddA[:, :, start:end] = grads_to_dA(ddA_cs_i, ddA_cs_rev_i, chunk_size)[:, :, :seq_len]
+
+    return {
+        "dq": dq, "dk": dk, "dv": dv,
+        "dA": ddA,
+        "ddt": ddt, "dtrap": dtrap_acc,
+        "dq_bias": dq_bias, "dk_bias": dk_bias,
+        "dmimo_v": dmimo_v, "dmimo_o": dmimo_o,
+        "dmimo_z": dmimo_z, "dangles": dangles,
+        "dD": dD, "dz": dz,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Varlen case grid
+# ---------------------------------------------------------------------------
+
+VARLEN_CASE_GRID = [
+    pytest.param(16, 64, 4, 8, 128, id="N16_P64_R4_C8_BB128"),
+    pytest.param(32, 64, 4, 16, 256, id="N32_P64_R4_C16_BB256"),
+    pytest.param(64, 64, 4, 16, 256, id="N64_P64_R4_C16_BB256"),
+    pytest.param(128, 64, 4, 16, 256, id="N128_P64_R4_C16_BB256"),
+    pytest.param(128, 64, 2, 32, 256, id="N128_P64_R2_C32_BB256"),
+    pytest.param(128, 64, 1, 64, 256, id="N128_P64_R1_C64_BB256"),
+]
+
+
+# ---------------------------------------------------------------------------
+# Varlen forward tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", VARLEN_CASE_GRID)
+def test_fwd_varlen_relative_error_lt_10pct(
+    mods_varlen: SimpleNamespace,
+    n: int, p: int, r: int, chunk_size: int, bb_threads: int,
+) -> None:
+    del bb_threads
+    seqlens = _varlen_seqlens(chunk_size)
+    inputs = build_inputs_varlen(
+        mods_varlen=mods_varlen,
+        n=n, p=p, r=r, chunk_size=chunk_size, seqlens=seqlens,
+        seed=9001 + n + p + r + chunk_size,
+    )
+
+    out_tilelang, _, _ = mods_varlen.fwd_varlen.mamba_mimo_forward_varlen(
+        inputs["q"], inputs["k"], inputs["v"],
+        inputs["q_bias"], inputs["k_bias"],
+        inputs["mimo_v"], inputs["mimo_o"],
+        inputs["z"], inputs["D"], inputs["mimo_z"],
+        inputs["angles"],
+        inputs["dA_cs"], inputs["dA_cs_rev"],
+        inputs["dt"], inputs["trap"], inputs["segsum"],
+        chunk_size=chunk_size,
+        rotary_dim_divisor=inputs["rotary_dim_divisor"],
+        dtype=FIXED_DTYPE,
+        cu_seqlens=inputs["cu_seqlens"],
+    )
+
+    out_ref_fp32, _, _ = mamba3_MIMO_chunk_ref(
+        inputs["q"].clone(), inputs["k"].clone(), inputs["v"].clone(),
+        inputs["q_bias"].clone(), inputs["k_bias"].clone(),
+        inputs["mimo_v"].clone(), inputs["mimo_o"].clone(),
+        inputs["z"].clone() if inputs["z"] is not None else None,
+        inputs["mimo_z"].clone() if inputs["mimo_z"] is not None else None,
+        inputs["angles"].clone(),
+        inputs["dA_cs"].clone(), inputs["dA_cs_rev"].clone(),
+        inputs["dt"].clone(), inputs["trap"].clone(),
+        inputs["D"].clone() if inputs["D"] is not None else None,
+        chunk_size=chunk_size,
+        rotary_dim_divisor=inputs["rotary_dim_divisor"],
+        dtype=torch.float32,
+        cu_seqlens=inputs["cu_seqlens"],
+    )
+
+    assert_stable_rel(
+        out_tilelang, out_ref_fp32,
+        label="fwd_varlen",
+        cfg=f"N={n}, P={p}, R={r}, chunk={chunk_size}, seqlens={seqlens}",
+    )
+
+
+@pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", VARLEN_CASE_GRID)
+def test_fwd_varlen_prereduce_relative_error_lt_10pct(
+    mods_varlen: SimpleNamespace,
+    n: int, p: int, r: int, chunk_size: int, bb_threads: int,
+) -> None:
+    """Varlen forward pass in prereduce mode (mimo_o=None, output shape [B,S,R,H,P])."""
+    del bb_threads
+    seqlens = _varlen_seqlens(chunk_size)
+    inputs = build_inputs_varlen(
+        mods_varlen=mods_varlen,
+        n=n, p=p, r=r, chunk_size=chunk_size, seqlens=seqlens,
+        seed=9003 + n + p + r + chunk_size,
+        has_z=False,
+    )
+
+    out_tilelang, _, _ = mods_varlen.fwd_varlen.mamba_mimo_forward_varlen(
+        inputs["q"], inputs["k"], inputs["v"],
+        inputs["q_bias"], inputs["k_bias"],
+        inputs["mimo_v"], None,
+        inputs["z"], inputs["D"], inputs["mimo_z"],
+        inputs["angles"],
+        inputs["dA_cs"], inputs["dA_cs_rev"],
+        inputs["dt"], inputs["trap"], inputs["segsum"],
+        chunk_size=chunk_size,
+        rotary_dim_divisor=inputs["rotary_dim_divisor"],
+        dtype=FIXED_DTYPE,
+        cu_seqlens=inputs["cu_seqlens"],
+    )
+
+    out_ref_fp32, _, _ = mamba3_MIMO_chunk_ref(
+        inputs["q"].clone(), inputs["k"].clone(), inputs["v"].clone(),
+        inputs["q_bias"].clone(), inputs["k_bias"].clone(),
+        inputs["mimo_v"].clone(), None,
+        None, None,
+        inputs["angles"].clone(),
+        inputs["dA_cs"].clone(), inputs["dA_cs_rev"].clone(),
+        inputs["dt"].clone(), inputs["trap"].clone(),
+        inputs["D"].clone() if inputs["D"] is not None else None,
+        chunk_size=chunk_size,
+        rotary_dim_divisor=inputs["rotary_dim_divisor"],
+        dtype=torch.float32,
+        contract_mimo_out=False,
+        cu_seqlens=inputs["cu_seqlens"],
+    )
+
+    assert_stable_rel(
+        out_tilelang, out_ref_fp32,
+        label="fwd_varlen_prereduce",
+        cfg=f"N={n}, P={p}, R={r}, chunk={chunk_size}, seqlens={seqlens}",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Varlen backward tests
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", VARLEN_CASE_GRID)
+def test_bwd_varlen_relative_errors_lt_10pct(
+    mods_varlen: SimpleNamespace,
+    n: int, p: int, r: int, chunk_size: int, bb_threads: int,
+) -> None:
+    seqlens = _varlen_seqlens(chunk_size)
+    inputs = build_inputs_varlen(
+        mods_varlen=mods_varlen,
+        n=n, p=p, r=r, chunk_size=chunk_size, seqlens=seqlens,
+        seed=9002 + n + p + r + chunk_size,
+    )
+
+    ref_grads = run_ref_backward_fp32_varlen(inputs)
+
+    (
+        dq, dk, dv, dA, ddt, dtrap,
+        dq_bias, dk_bias,
+        dmimo_v, dmimo_z, dmimo_o,
+        dangles, dD, dz,
+    ) = mods_varlen.bwd_varlen.mamba_mimo_bwd_combined_varlen(
+        inputs["dout"],
+        inputs["q"], inputs["k"], inputs["v"],
+        inputs["q_bias"], inputs["k_bias"],
+        inputs["mimo_v"], inputs["mimo_o"],
+        inputs["z"], inputs["mimo_z"],
+        inputs["angles"],
+        inputs["dA_cs"], inputs["dA_cs_rev"],
+        inputs["dt"], inputs["trap"],
+        inputs["D"], inputs["segsum"],
+        chunk_size, inputs["rotary_dim_divisor"],
+        FIXED_DTYPE,
+        cu_seqlens=inputs["cu_seqlens"],
+        bb_threads=bb_threads,
+    )
+
+    comparisons = {
+        "dq": (dq, ref_grads["dq"]),
+        "dk": (dk, ref_grads["dk"]),
+        "dv": (dv, ref_grads["dv"]),
+        "dA": (dA, ref_grads["dA"]),
+        "ddt": (ddt, ref_grads["ddt"]),
+        "dtrap": (dtrap, ref_grads["dtrap"]),
+        "dq_bias": (dq_bias, ref_grads["dq_bias"]),
+        "dk_bias": (dk_bias, ref_grads["dk_bias"]),
+        "dmimo_v": (dmimo_v, ref_grads["dmimo_v"]),
+        "dmimo_z": (dmimo_z, ref_grads["dmimo_z"]),
+        "dmimo_o": (dmimo_o, ref_grads["dmimo_o"]),
+        "dangles": (dangles, ref_grads["dangles"]),
+        "dD": (dD, ref_grads["dD"]),
+        "dz": (dz, ref_grads["dz"]),
+    }
+
+    cfg = f"N={n}, P={p}, R={r}, chunk={chunk_size}, seqlens={seqlens}, bb_threads={bb_threads}"
+    for name, (ours, ref) in comparisons.items():
+        if ours is None and ref is None:
+            continue
+        assert_stable_rel(ours, ref, label=f"bwd_varlen_{name}", cfg=cfg)
+
+
+@pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", VARLEN_CASE_GRID)
+def test_bwd_varlen_prereduce_relative_errors_lt_10pct(
+    mods_varlen: SimpleNamespace,
+    n: int, p: int, r: int, chunk_size: int, bb_threads: int,
+) -> None:
+    """Varlen backward in prereduce mode (mimo_o=None)."""
+    seqlens = _varlen_seqlens(chunk_size)
+    inputs = build_inputs_varlen(
+        mods_varlen=mods_varlen,
+        n=n, p=p, r=r, chunk_size=chunk_size, seqlens=seqlens,
+        seed=9004 + n + p + r + chunk_size,
+        has_z=False,
+    )
+    b, s_total, h_dim, p_dim = inputs["v"].shape
+    dout_prereduce = torch.randn(
+        (b, s_total, r, h_dim, p_dim), device="cuda", dtype=FIXED_DTYPE
+    )
+
+    ref_grads = run_ref_backward_fp32_varlen(
+        inputs,
+        contract_mimo_out=False,
+        grad_output=dout_prereduce,
+    )
+
+    (
+        dq, dk, dv, dA, ddt, dtrap,
+        dq_bias, dk_bias,
+        dmimo_v, dmimo_z, dmimo_o,
+        dangles, dD, dz,
+    ) = mods_varlen.bwd_varlen.mamba_mimo_bwd_combined_varlen(
+        dout_prereduce,
+        inputs["q"], inputs["k"], inputs["v"],
+        inputs["q_bias"], inputs["k_bias"],
+        inputs["mimo_v"], None,
+        None, None,
+        inputs["angles"],
+        inputs["dA_cs"], inputs["dA_cs_rev"],
+        inputs["dt"], inputs["trap"],
+        inputs["D"], inputs["segsum"],
+        chunk_size, inputs["rotary_dim_divisor"],
+        FIXED_DTYPE,
+        cu_seqlens=inputs["cu_seqlens"],
+        bb_threads=bb_threads,
+    )
+
+    assert dmimo_o is None
+    assert dmimo_z is None
+    assert dz is None
+
+    comparisons = {
+        "dq": (dq, ref_grads["dq"]),
+        "dk": (dk, ref_grads["dk"]),
+        "dv": (dv, ref_grads["dv"]),
+        "dA": (dA, ref_grads["dA"]),
+        "ddt": (ddt, ref_grads["ddt"]),
+        "dtrap": (dtrap, ref_grads["dtrap"]),
+        "dq_bias": (dq_bias, ref_grads["dq_bias"]),
+        "dk_bias": (dk_bias, ref_grads["dk_bias"]),
+        "dmimo_v": (dmimo_v, ref_grads["dmimo_v"]),
+        "dangles": (dangles, ref_grads["dangles"]),
+        "dD": (dD, ref_grads["dD"]),
+    }
+
+    cfg = (
+        f"N={n}, P={p}, R={r}, chunk={chunk_size}, "
+        f"seqlens={seqlens}, bb_threads={bb_threads}"
+    )
+    for name, (ours, ref) in comparisons.items():
+        assert_stable_rel(ours, ref, label=f"bwd_varlen_prereduce_{name}", cfg=cfg)


### PR DESCRIPTION
Add variable-length (varlen) support for Mamba-3 MIMO.

Mamba-3 SISO already supports varlen, and this change extends the same capability to MIMO, enabling consistent handling of variable-length inputs across both variants.