### PR TITLE
Allow overriding BASE_WHEEL_URL via an environment variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ this_dir = os.path.dirname(os.path.abspath(__file__))
 
 PACKAGE_NAME = "mamba_ssm"
 
-BASE_WHEEL_URL = "https://github.com/state-spaces/mamba/releases/download/{tag_name}/{wheel_name}"
+BASE_WHEEL_URL = os.getenv("MAMBA_BASE_WHEEL_URL", "https://github.com/state-spaces/mamba/releases/download/{tag_name}/{wheel_name}")
 
 # FORCE_BUILD: Force a fresh build locally, instead of attempting to find prebuilt wheels
 # SKIP_CUDA_BUILD: Intended to allow CI to use a simple `python setup.py sdist` run to copy over raw files, without any cuda compilation


### PR DESCRIPTION
## Abstract
This is a simple patch to allow overriding `BASE_WHEEL_URL` in `setup.py` via an environment variable `MAMBA_BASE_WHEEL_URL`.

## Motivation
1. In some environments (e.g., corporate networks or air-gapped setups), direct access to GitHub Releases may be slow or unavailable. This causes installation to fail even when prebuilt wheels exist.
2. Currently, the wheel download URL is hardcoded to GitHub: `https://github.com/state-spaces/mamba/releases/download/{tag_name}/{wheel_name}`

## Related Issues

#848
#277

## Proposal

This PR simply allows overriding the base URL via an environment variable:

```python
BASE_WHEEL_URL = os.getenv(
    "MAMBA_BASE_WHEEL_URL",
    "https://github.com/state-spaces/mamba/releases/download/{tag_name}/{wheel_name}",
)
```
This preserves the existing behavior by default, while enabling users to redirect downloads
to mirrors or proxies (e.g., ghproxy, internal artifact stores, etc.).

## Example
```sh
export MAMBA_BASE_WHEEL_URL="https://<your_mirror>/state-spaces/mamba/releases/download/{tag_name}/{wheel_name}"
pip install mamba-ssm
```

## Benefits

- Fully backward compatible (no behavior change by default)
- Enables usage in restricted, internal or offline-friendly environments

## Note
- The URL format is expected to include {tag_name} and {wheel_name}
- No changes to build or release workflow
- This is tested on my machine locally with `uv`