### PR TITLE
Sync quack-kernels to 0.3.4 in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
     "torch",
     "tilelang==0.1.8",
-    "quack-kernels==0.3.1",
+    "quack-kernels==0.3.4",
     "triton>=3.5.0",
     "ninja",
     "einops",


### PR DESCRIPTION
## Summary
- `pyproject.toml` pins `quack-kernels==0.3.1` while `setup.py` pins `quack-kernels==0.3.4`
- This mismatch causes PEP 517 builds (`pip install .`) to install the older version
- Sync `pyproject.toml` to match `setup.py` at `0.3.4`

## Test plan
- [x] Verified `setup.py` line 403 specifies `quack-kernels==0.3.4`
- [x] Single version bump, no other changes