### PR TITLE
Fix unreachable code and resource leak in hf.py

### DIFF
--- a/mamba_ssm/utils/hf.py
+++ b/mamba_ssm/utils/hf.py
@@ -8,14 +8,15 @@ from transformers.utils.hub import cached_file
 
 def load_config_hf(model_name):
     resolved_archive_file = cached_file(model_name, CONFIG_NAME, _raise_exceptions_for_missing_entries=False)
-    return json.load(open(resolved_archive_file))
+    with open(resolved_archive_file) as f:
+        return json.load(f)
 
 
 def load_state_dict_hf(model_name, device=None, dtype=None):
     # If not fp32, then we don't want to load directly to the GPU
     mapped_device = "cpu" if dtype not in [torch.float32, None] else device
     resolved_archive_file = cached_file(model_name, WEIGHTS_NAME, _raise_exceptions_for_missing_entries=False)
-    return torch.load(resolved_archive_file, map_location=mapped_device)
+    state_dict = torch.load(resolved_archive_file, map_location=mapped_device)
     # Convert dtype before moving to GPU to save memory
     if dtype is not None:
         state_dict = {k: v.to(dtype=dtype) for k, v in state_dict.items()}


### PR DESCRIPTION
## Summary

- **Fix unreachable code in `load_state_dict_hf`**: The function had a premature `return` on the `torch.load(...)` line (line 18), which made the subsequent dtype conversion and device mapping code (lines 20-23) completely unreachable. This means when loading a model with a non-fp32 dtype, the state dict was never converted to the requested dtype or moved to the target device -- it silently returned fp32 weights on CPU instead. Fixed by assigning the `torch.load` result to `state_dict` and returning after conversion.
- **Fix resource leak in `load_config_hf`**: The file handle from `open()` was passed directly to `json.load()` without being closed. Changed to use a `with` statement to ensure proper cleanup.

## Test plan

- [ ] Verify `load_state_dict_hf` correctly converts dtype when `dtype` is not `torch.float32`
- [ ] Verify `load_state_dict_hf` correctly maps state dict to the specified device
- [ ] Verify `load_config_hf` still correctly loads config files