### PR TITLE
Fix typo in distributed_utils.py and remove unused variables

### DIFF
--- a/mamba_ssm/distributed/distributed_utils.py
+++ b/mamba_ssm/distributed/distributed_utils.py
@@ -105,10 +105,10 @@ all_reduce = AllReduceFunc.apply
 def sync_shared_params(model: torch.nn.Module, process_group: ProcessGroup):
     # We want to iterate over parameters with _shared_params=True in the same order,
     # as different ranks might have different number of parameters (e.g., only rank 0 has bias).
-    pamams_shared = {
+    params_shared = {
         name: p for name, p in model.named_parameters() if getattr(p, "_shared_params", False)
     }
-    for _, p in sorted(pamams_shared.items()):
+    for _, p in sorted(params_shared.items()):
         with torch.no_grad():
             # Broadcast needs src to be global rank, not group rank
             torch.distributed.broadcast(

--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -357,7 +357,6 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
     def _get_states_from_cache(self, inference_params, batch_size, initialize_states=False):
         assert self.layer_idx is not None
         if self.layer_idx not in inference_params.key_value_memory_dict:
-            batch_shape = (batch_size,)
             conv_state = torch.zeros(
                 batch_size,
                 self.d_conv,

--- a/mamba_ssm/modules/mamba_simple.py
+++ b/mamba_ssm/modules/mamba_simple.py
@@ -268,7 +268,6 @@ class Mamba(nn.Module):
     def _get_states_from_cache(self, inference_params, batch_size, initialize_states=False):
         assert self.layer_idx is not None
         if self.layer_idx not in inference_params.key_value_memory_dict:
-            batch_shape = (batch_size,)
             conv_state = torch.zeros(
                 batch_size,
                 self.d_model * self.expand,


### PR DESCRIPTION
## Summary

- **Fix typo in `distributed_utils.py`**: `pamams_shared` -> `params_shared` in `sync_shared_params()`. The variable name was misspelled but functionally correct since it was only used locally; this fix improves readability.
- **Remove unused `batch_shape` variable**: In both `mamba_simple.py` and `mamba2.py`, `_get_states_from_cache` assigned `batch_shape = (batch_size,)` but never used it. Removed the dead assignment.

## Test plan

- [ ] Verify `sync_shared_params` still works correctly for distributed training
- [ ] Verify `_get_states_from_cache` behaves identically in both Mamba and Mamba2 modules