### PR TITLE
Fix Mamba2.step() D handling when D_has_hdim=True

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -316,7 +316,10 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
             dBx = torch.einsum("bh,bn,bhp->bhpn", dt, B, x)
             ssm_state.copy_(ssm_state * rearrange(dA, "b h -> b h 1 1") + dBx)
             y = torch.einsum("bhpn,bn->bhp", ssm_state.to(dtype), C)
-            y = y + rearrange(self.D.to(dtype), "h -> h 1") * x
+            if self.D_has_hdim:
+                y = y + rearrange(self.D.to(dtype), "(h p) -> h p", p=self.headdim) * x
+            else:
+                y = y + rearrange(self.D.to(dtype), "h -> h 1") * x
             y = rearrange(y, "b h p -> b (h p)")
             if not self.rmsnorm:
                 y = y * self.act(z)  # (B D)
@@ -324,7 +327,10 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
             A = repeat(A, "h -> h p n", p=self.headdim, n=self.d_state).to(dtype=torch.float32)
             dt = repeat(dt, "b h -> b h p", p=self.headdim)
             dt_bias = repeat(self.dt_bias, "h -> h p", p=self.headdim)
-            D = repeat(self.D, "h -> h p", p=self.headdim)
+            if self.D_has_hdim:
+                D = rearrange(self.D, "(h p) -> h p", p=self.headdim)
+            else:
+                D = repeat(self.D, "h -> h p", p=self.headdim)
             B = rearrange(B, "b (g n) -> b g n", g=self.ngroups)
             C = rearrange(C, "b (g n) -> b g n", g=self.ngroups)
             x_reshaped = rearrange(x, "b (h p) -> b h p", p=self.headdim)


### PR DESCRIPTION
## Summary
- When `D_has_hdim=True`, `self.D` has shape `(d_ssm,)` = `(nheads * headdim,)`, but `step()` was treating it as shape `(nheads,)` in both the fallback path and the `selective_state_update` path.
- Added conditional reshaping (`rearrange(self.D, "(h p) -> h p", p=self.headdim)`) to both code paths in `step()`, consistent with how `forward()` already handles `D_has_hdim=True`.

## Details
In `step()`, there are two code paths that use `self.D`:

1. **Fallback path** (when `selective_state_update is None`): was doing `rearrange(self.D, "h -> h 1")` which assumes D has shape `(nheads,)`. Now conditionally uses `rearrange(self.D, "(h p) -> h p", p=self.headdim)` when `D_has_hdim=True`.

2. **`selective_state_update` path**: was doing `repeat(self.D, "h -> h p", p=self.headdim)` which also assumes D has shape `(nheads,)`. Now conditionally uses `rearrange` instead of `repeat` when `D_has_hdim=True`.

Both `forward()` code paths (lines 191 and 251) already handled this correctly via:
```python
D=rearrange(self.D, "(h p) -> h p", p=self.headdim) if self.D_has_hdim else self.D
```

Fixes #887

## Test plan
- [ ] Instantiate `Mamba2` with `D_has_hdim=True` and verify `step()` produces correct output matching `forward()` for single-token inputs
- [ ] Verify shapes are consistent: `self.D` shape `(d_ssm,)` is reshaped to `(nheads, headdim)` before use in both step paths
- [ ] Verify no regression when `D_has_hdim=False` (default behavior unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)