### PR TITLE
Remove unused batch_shape variable in _get_states_from_cache

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -357,7 +357,6 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
     def _get_states_from_cache(self, inference_params, batch_size, initialize_states=False):
         assert self.layer_idx is not None
         if self.layer_idx not in inference_params.key_value_memory_dict:
-            batch_shape = (batch_size,)
             conv_state = torch.zeros(
                 batch_size,
                 self.d_conv,

--- a/mamba_ssm/modules/mamba_simple.py
+++ b/mamba_ssm/modules/mamba_simple.py
@@ -268,7 +268,6 @@ class Mamba(nn.Module):
     def _get_states_from_cache(self, inference_params, batch_size, initialize_states=False):
         assert self.layer_idx is not None
         if self.layer_idx not in inference_params.key_value_memory_dict:
-            batch_shape = (batch_size,)
             conv_state = torch.zeros(
                 batch_size,
                 self.d_model * self.expand,


### PR DESCRIPTION
## Summary
- Removes the unused `batch_shape` variable from `Mamba._get_states_from_cache` in `mamba_simple.py` and `Mamba2._get_states_from_cache` in `mamba2.py`
- The variable was assigned `(batch_size,)` but never referenced, making it dead code

## Details
Both `_get_states_from_cache` methods contained:
```python
batch_shape = (batch_size,)
```
This line has no effect since `batch_shape` is not used anywhere in the function body. Removing it improves code clarity.

## Test plan
- No behavioral change; this is a dead code removal
- Existing tests should pass unchanged