### PR TITLE
Fix wrong group_size in Mamba2 RMSNormGated under tensor parallelism

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -142,7 +142,7 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
         if self.rmsnorm:
             assert RMSNormGated is not None
             self.norm = RMSNormGated(self.d_ssm, eps=1e-5, norm_before_gate=self.norm_before_gate,
-                                     group_size=self.d_ssm // ngroups, **factory_kwargs)
+                                     group_size=self.d_ssm // self.ngroups, **factory_kwargs)
 
         if self.process_group is None:
             self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=bias, **factory_kwargs)


### PR DESCRIPTION
## Summary

In `Mamba2.__init__()`, the `RMSNormGated` layer is constructed with `group_size=self.d_ssm // ngroups`, but `ngroups` here is the raw constructor parameter while `self.d_ssm` has already been divided by `world_size` (line 81). This should use `self.ngroups` (line 83), which is also divided by `world_size`.

**Bug:** Line 145 — `group_size=self.d_ssm // ngroups`  
**Root cause:** `self.d_ssm = d_ssm // world_size` but `ngroups` is undivided, so the group_size becomes `(d_ssm / world_size) / ngroups` — too small by a factor of `world_size`.  
**Correct:** `group_size=self.d_ssm // self.ngroups` = `(d_ssm / world_size) / (ngroups / world_size)` = `d_ssm / ngroups`  
**Hidden when:** `world_size == 1` (single GPU), since `ngroups == self.ngroups` in that case.

**Fix:** `ngroups` → `self.ngroups` on line 145.

## Test plan
- [x] Verified `self.d_ssm` is divided by `world_size` (line 81)
- [x] Verified `self.ngroups` is divided by `world_size` (line 83)
- [x] Confirmed raw `ngroups` is the undivided parameter
- [x] One-word change, consistent with how all other `self.*` attributes are used in this constructor