### PR TITLE
Cache ctx.saved_tensors in Mamba3 backward to fix FSDP activation checkpointing

### DIFF
--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
@@ -165,7 +165,8 @@ class _Mamba3Function(torch.autograd.Function):
         except Exception:
             pass
         
-        if len(ctx.saved_tensors) == 0:
+        _saved = ctx.saved_tensors
+        if len(_saved) == 0:
             raise RuntimeError(
                 "Backward called but forward ran without gradient tracking. "
                 "Ensure inputs require grad or run under torch.enable_grad()."
@@ -176,7 +177,7 @@ class _Mamba3Function(torch.autograd.Function):
         (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, Angles_Cumsum,
         D_save, Z_save, Input_SSM_State_save, Input_K_State_save, Input_V_State_save,
         Out, Out_v, SSM_States, DA_CS, DA_CS_SUM, Q_rot, K_scaled, QK_dot, Scale, Gamma,
-        Final_SSM_State_save, cu_seqlens_save) = ctx.saved_tensors
+        Final_SSM_State_save, cu_seqlens_save) = _saved
         
         D = D_save if ctx.has_D else None
         Z = Z_save if ctx.has_Z else None


### PR DESCRIPTION
`_Mamba3Function.backward()` accesses `ctx.saved_tensors` twice. `torch.utils.checkpoint` registers unpack hooks that only allow a single access, so the second call raises `CheckpointError` when FSDP activation checkpointing is enabled:
 
```
torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Unpack is being triggered for a tensor that was already unpacked once. If you are calling ctx.saved_tensors in backward, make sure to do so only once. Otherwise please open an issue with details on your use case.
```
 
This PR caches `ctx.saved_tensors` in a local variable so both uses read from the same reference.