### PR TITLE
Pass group_size to RMSNormGated in Mamba2Simple for ngroups > 1

### DIFF
--- a/mamba_ssm/modules/mamba2_simple.py
+++ b/mamba_ssm/modules/mamba2_simple.py
@@ -117,7 +117,8 @@ class Mamba2Simple(nn.Module):
 
         # Extra normalization layer right before output projection
         assert RMSNormGated is not None
-        self.norm = RMSNormGated(self.d_inner, eps=1e-5, norm_before_gate=False, **factory_kwargs)
+        self.norm = RMSNormGated(self.d_inner, eps=1e-5, norm_before_gate=False,
+                                 group_size=self.d_inner // ngroups, **factory_kwargs)
 
         self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=bias, **factory_kwargs)
 


### PR DESCRIPTION
## Bug

`Mamba2Simple` threads `ngroups` through the rest of the block — `d_in_proj` includes `2 * ngroups * d_state`, the conv dim is `d_inner + 2 * ngroups * d_state`, and `B`/`C` are rearranged with `g=self.ngroups` — but the final `RMSNormGated` is built without `group_size`:

https://github.com/state-spaces/mamba/blob/main/mamba_ssm/modules/mamba2_simple.py#L120

\`\`\`python
self.norm = RMSNormGated(self.d_inner, eps=1e-5, norm_before_gate=False, **factory_kwargs)
\`\`\`

`RMSNormGated` treats `group_size=None` as \"one group covering the whole hidden_size\" (see `mamba_ssm/ops/triton/layernorm_gated.py` line 418-419), so with `ngroups > 1` the gated RMSNorm collapses all heads into a single normalization group, rather than normalizing each group independently.

The non-simple Mamba2 handles this correctly in `mamba2.py`:

\`\`\`python
self.norm = RMSNormGated(self.d_ssm, eps=1e-5, norm_before_gate=self.norm_before_gate,
                         group_size=self.d_ssm // ngroups, **factory_kwargs)
\`\`\`

## Fix

Mirror the `mamba2.py` pattern and pass `group_size=self.d_inner // ngroups`. With the default `ngroups=1` this evaluates to `d_inner`, which is equivalent to `group_size=None`, so the default configuration is unchanged. Users who construct `Mamba2Simple(..., ngroups=g)` with `g > 1` now get group-wise normalization consistent with `Mamba2`.