### PR TITLE
Fix selective_state_update crashing when dt_bias or D is None

### DIFF
--- a/mamba_ssm/ops/triton/selective_state_update.py
+++ b/mamba_ssm/ops/triton/selective_state_update.py
@@ -196,7 +196,8 @@ def selective_state_update(state, x, dt, A, B, C, D=None, z=None, dt_bias=None, 
                                      ((8, 4) if dstate <= 64 else
                                       ((4, 4) if dstate <= 128 else
                                        ((4, 8))))))
-    tie_hdim = A.stride(-1) == 0 and A.stride(-2) == 0 and dt.stride(-1) == 0 and dt_bias.stride(-1) == 0
+    tie_hdim = (A.stride(-1) == 0 and A.stride(-2) == 0 and dt.stride(-1) == 0
+                and (dt_bias is None or dt_bias.stride(-1) == 0))
     with torch.cuda.device(x.device.index):
         _selective_scan_update_kernel[grid](
             state, x, dt, dt_bias, A, B, C, D, z, out, state_batch_indices,
@@ -204,11 +205,11 @@ def selective_state_update(state, x, dt, A, B, C, D=None, z=None, dt_bias=None, 
             state.stride(0), state.stride(1), state.stride(2), state.stride(3),
             x.stride(0), x.stride(1), x.stride(2),
             dt.stride(0), dt.stride(1), dt.stride(2),
-            *(dt_bias.stride(0), dt_bias.stride(1)) if dt_bias is not None else 0,
+            *((dt_bias.stride(0), dt_bias.stride(1)) if dt_bias is not None else (0, 0)),
             A.stride(0), A.stride(1), A.stride(2),
             B.stride(0), B.stride(1), B.stride(2),
             C.stride(0), C.stride(1), C.stride(2),
-            *(D.stride(0), D.stride(1)) if D is not None else 0,
+            *((D.stride(0), D.stride(1)) if D is not None else (0, 0)),
             z_strides[0], z_strides[1], z_strides[2],
             out.stride(0), out.stride(1), out.stride(2),
             dt_softplus,


### PR DESCRIPTION
## Bug

\`selective_state_update\` in \`mamba_ssm/ops/triton/selective_state_update.py\` advertises both \`D=None\` and \`dt_bias=None\` in its signature, but calling it with either one set to \`None\` raises \`TypeError\` before the kernel ever launches:

\`\`\`
TypeError: Value after * must be an iterable, not int
\`\`\`

## Root cause

The Python wrapper has two conditional-unpack expressions feeding the Triton kernel:

\`\`\`python
*(dt_bias.stride(0), dt_bias.stride(1)) if dt_bias is not None else 0,
...
*(D.stride(0), D.stride(1)) if D is not None else 0,
\`\`\`

Python parses these as

\`\`\`python
*((a, b) if cond else 0)
\`\`\`

so when the conditional is False the \`else\` branch produces the scalar \`0\`, which \`*\` then tries to unpack and fails.

Quick reproduction (just the syntax, without Triton):

\`\`\`python
def f(*args): pass
f(*(1, 2) if True else 0)    # (1, 2) — OK
f(*(1, 2) if False else 0)   # TypeError: Value after * must be an iterable, not int
\`\`\`

The two in-tree callers in \`mamba_ssm/modules/mamba_simple.py\` and \`mamba_ssm/modules/mamba2.py\` always pass non-\`None\` \`D\` and \`dt_bias\`, so the bug is latent for the standard Mamba/Mamba2 forward path. It trips as soon as anything calls \`from mamba_ssm.ops.triton.selective_state_update import selective_state_update\` and omits \`D\` or \`dt_bias\` — which is exactly the use case the public function's default-\`None\` signature advertises.

The \`tie_hdim\` line just above has the same \`dt_bias is None\` blind spot — \`dt_bias.stride(-1) == 0\` is short-circuited for the common case but becomes an \`AttributeError\` whenever \`A\` and \`dt\` also happen to have zero trailing strides (which is exactly when \`tie_hdim\` is meant to be true).

## Fix

1. Wrap the conditional expression inside each unpack with parentheses and replace \`else 0\` with \`else (0, 0)\`, so both branches yield a 2-tuple the kernel wrapper can unpack into its two stride placeholder slots (the kernel ignores those strides via the \`HAS_DT_BIAS\` / \`HAS_D\` heuristics whenever the underlying pointer is None).

2. Guard the \`tie_hdim\` check with \`dt_bias is None or dt_bias.stride(-1) == 0\` so we don't dereference a None dt_bias — a None dt_bias is trivially \"tied\" across heads because there's nothing to tie.

\`\`\`diff
-    tie_hdim = A.stride(-1) == 0 and A.stride(-2) == 0 and dt.stride(-1) == 0 and dt_bias.stride(-1) == 0
+    tie_hdim = (A.stride(-1) == 0 and A.stride(-2) == 0 and dt.stride(-1) == 0
+                and (dt_bias is None or dt_bias.stride(-1) == 0))
     with torch.cuda.device(x.device.index):
         _selective_scan_update_kernel[grid](
             ...
-            *(dt_bias.stride(0), dt_bias.stride(1)) if dt_bias is not None else 0,
+            *((dt_bias.stride(0), dt_bias.stride(1)) if dt_bias is not None else (0, 0)),
             ...
-            *(D.stride(0), D.stride(1)) if D is not None else 0,
+            *((D.stride(0), D.stride(1)) if D is not None else (0, 0)),
\`\`\`

No effect on the existing Mamba/Mamba2 forward path (both in-tree callers pass non-None \`D\` and \`dt_bias\`, so both conditionals take the \`if\` branch exactly as before). The change only affects the \`D is None\` / \`dt_bias is None\` paths, which are currently unreachable without crashing.