### PR TITLE
Fix Mamba3.step() missing squeeze for seqlen dimension

### DIFF
--- a/mamba_ssm/modules/mamba3.py
+++ b/mamba_ssm/modules/mamba3.py
@@ -308,7 +308,8 @@ class Mamba3(nn.Module):
         assert mamba3_step_fn is not None, "Cute Mamba-3 step function is not available. Please ensure you installed the necessary dependencies, such as nvidia-cutlass-dsl and quack-kernels."
 
         # in_proj
-        zxBCdt = self.in_proj(u)
+        assert u.shape[1] == 1, "Only support decoding with 1 token at a time for now"
+        zxBCdt = self.in_proj(u.squeeze(1))
         z, x, B, C, dd_dt, dd_A, trap, angles = torch.split(
             zxBCdt,
             [


### PR DESCRIPTION
## Summary

`Mamba3.forward()` passes `u` with shape `(batch, 1, d_model)` to `step()` during single-token decoding (`seqlen_offset > 0`). However, `step()` feeds `u` directly to `in_proj` without squeezing the seqlen dimension, producing 3D output. All downstream operations in `_preprocess()` expect 2D input — e.g., `rearrange(x, "b (h p) -> b h p", ...)` fails on a 3D tensor.

`Mamba2.step()` (line 280–281) handles this correctly:
```python
assert hidden_states.shape[1] == 1, "Only support decoding with 1 token at a time for now"
zxbcdt = self.in_proj(hidden_states.squeeze(1))
```

**Fix:** Add the same assert and `squeeze(1)` to `Mamba3.step()`.

## Test plan

- [x] Verified `forward()` passes 3D `u` to `step()` at line 147
- [x] Verified `Mamba2.step()` squeezes at line 281
- [x] Verified `_preprocess()` rearrange patterns require 2D input
- [ ] Mamba3 single-token decoding should now work without shape errors

🤖 Generated with [Claude Code](https://claude.ai/claude-code)