### PR TITLE
Skip selective_scan_cuda build on ROCm/HIP

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -244,25 +244,29 @@ if not SKIP_CUDA_BUILD:
             ),
         }
 
-    ext_modules.append(
-        CUDAExtension(
-            name="selective_scan_cuda",
-            sources=[
-                "csrc/selective_scan/selective_scan.cpp",
-                "csrc/selective_scan/selective_scan_fwd_fp32.cu",
-                "csrc/selective_scan/selective_scan_fwd_fp16.cu",
-                "csrc/selective_scan/selective_scan_fwd_bf16.cu",
-                "csrc/selective_scan/selective_scan_bwd_fp32_real.cu",
-                "csrc/selective_scan/selective_scan_bwd_fp32_complex.cu",
-                "csrc/selective_scan/selective_scan_bwd_fp16_real.cu",
-                "csrc/selective_scan/selective_scan_bwd_fp16_complex.cu",
-                "csrc/selective_scan/selective_scan_bwd_bf16_real.cu",
-                "csrc/selective_scan/selective_scan_bwd_bf16_complex.cu",
-            ],
-            extra_compile_args=extra_compile_args,
-            include_dirs=[Path(this_dir) / "csrc" / "selective_scan"],
+    # selective_scan_cuda is a Mamba-1 CUDA extension that does not compile
+    # on ROCm/HIP.  Mamba-2 and Mamba-3 use Triton kernels instead, so this
+    # extension is not needed on HIP builds.
+    if not HIP_BUILD:
+        ext_modules.append(
+            CUDAExtension(
+                name="selective_scan_cuda",
+                sources=[
+                    "csrc/selective_scan/selective_scan.cpp",
+                    "csrc/selective_scan/selective_scan_fwd_fp32.cu",
+                    "csrc/selective_scan/selective_scan_fwd_fp16.cu",
+                    "csrc/selective_scan/selective_scan_fwd_bf16.cu",
+                    "csrc/selective_scan/selective_scan_bwd_fp32_real.cu",
+                    "csrc/selective_scan/selective_scan_bwd_fp32_complex.cu",
+                    "csrc/selective_scan/selective_scan_bwd_fp16_real.cu",
+                    "csrc/selective_scan/selective_scan_bwd_fp16_complex.cu",
+                    "csrc/selective_scan/selective_scan_bwd_bf16_real.cu",
+                    "csrc/selective_scan/selective_scan_bwd_bf16_complex.cu",
+                ],
+                extra_compile_args=extra_compile_args,
+                include_dirs=[Path(this_dir) / "csrc" / "selective_scan"],
+            )
         )
-    )
 
 
 def get_package_version():


### PR DESCRIPTION
## Summary

- Skip building the `selective_scan_cuda` CUDA extension on ROCm/HIP builds since it does not compile on HIP
- This extension is only used by Mamba-1; Mamba-2 and Mamba-3 use Triton kernels

### Problem

Installing `mamba-ssm` on ROCm currently requires the workaround:

```bash
MAMBA_SKIP_CUDA_BUILD=TRUE pip install mamba-ssm
```

Without this flag, `setup.py` tries to compile `csrc/selective_scan/*.cu` with hipcc, which fails because the CUDA kernels use APIs without HIP equivalents.

### Fix

`setup.py` already detects HIP builds via `HIP_BUILD = bool(torch.version.hip)`. This PR wraps the `selective_scan_cuda` extension in `if not HIP_BUILD:`, so ROCm installs get a pure-Python + Triton wheel automatically.

The `selective_scan_interface.py` module already handles `selective_scan_cuda = None` gracefully via `try/except`.

Tested on: AMD Radeon RX 9070 XT (gfx1201, RDNA4), ROCm 7.2.1, PyTorch 2.12.0.dev+rocm7.2

Relates to #65 (ROCm support), #914 (Mamba-3 Triton kernel fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)