### PR TITLE
Fix Mamba2 RMSNorm group_size using unsharded ngroups under tensor parallelism

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -142,7 +142,7 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
         if self.rmsnorm:
             assert RMSNormGated is not None
             self.norm = RMSNormGated(self.d_ssm, eps=1e-5, norm_before_gate=self.norm_before_gate,
-                                     group_size=self.d_ssm // ngroups, **factory_kwargs)
+                                     group_size=self.d_ssm // self.ngroups, **factory_kwargs)
 
         if self.process_group is None:
             self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=bias, **factory_kwargs)


### PR DESCRIPTION
## Bug

In `Mamba2.__init__()`, line 145 computes the RMSNorm `group_size` using the raw constructor parameter `ngroups` instead of `self.ngroups`:

```python
self.norm = RMSNormGated(self.d_ssm, eps=1e-5, norm_before_gate=self.norm_before_gate,
                         group_size=self.d_ssm // ngroups, **factory_kwargs)
```

`self.d_ssm` is already sharded (`d_ssm // world_size`, line 81), but `ngroups` is the original unsharded value. `self.ngroups` is correctly sharded (`ngroups // world_size`, line 83).

When `world_size > 1`, this produces `group_size = (d_ssm/W) / ngroups` instead of the correct `(d_ssm/W) / (ngroups/W) = d_ssm/ngroups`, making the group size `W` times too small.

## Fix

Use `self.ngroups` (the sharded value) instead of `ngroups`.

🤖 Generated with [Claude Code](https://claude.ai/code)