### PR TITLE
Fix double RMSNorm on B/C in MambaInnerFn.backward at checkpoint_lvl=1

### DIFF
--- a/mamba_ssm/ops/selective_scan_interface.py
+++ b/mamba_ssm/ops/selective_scan_interface.py
@@ -300,21 +300,10 @@ class MambaInnerFn(torch.autograd.Function):
                 delta = rearrange(delta, "b d l -> (b l) d", l=L).contiguous()
                 delta = rms_norm_forward(delta, ctx.dt_rms_weight, None, ctx.b_c_dt_rms_eps)
                 delta = rearrange(delta, "(b l) d -> b d l", l=L).contiguous()
-            if b_rms_weight is not None:
-                # Recompute & RMSNorm B
-                B = rearrange(B, "b 1 dstate l -> (b l) dstate", l=L).contiguous()
-                B = rms_norm_forward(
-                    B, ctx.b_rms_weight, None, ctx.b_c_dt_rms_eps
-                )
-                B = rearrange(B, "(b l) dstate -> b 1 dstate l", l=L).contiguous()
-            if c_rms_weight is not None:
-                # Recompute & RMSNorm C
-                C = rearrange(C, "b 1 dstate l -> (b l) dstate", l=L).contiguous()
-                C = rms_norm_forward(
-                    C, ctx.c_rms_weight, None, ctx.b_c_dt_rms_eps
-                )
-                C = rearrange(C, "(b l) dstate -> b 1 dstate l", l=L).contiguous()
-            
+            # B and C are already RMSNorm'd in the forward before save_for_backward
+            # (see the `b_rms_weight`/`c_rms_weight` branches in forward), so they must
+            # not be normalized again here at checkpoint_lvl == 1.
+
         # The kernel supports passing in a pre-allocated dz (e.g., in case we want to fuse the
         # backward of selective_scan_cuda with the backward of chunk).
         dxz = torch.empty_like(xz)  # (batch, dim, seqlen)


### PR DESCRIPTION
## Bug

In `mamba_ssm/ops/selective_scan_interface.py`, `MambaInnerFn.backward` double-normalizes `B` and `C` whenever `b_rms_weight` / `c_rms_weight` is provided and `checkpoint_lvl == 1`. The scan backward then receives wrong inputs and produces incorrect gradients.

Reported in #885.

## Root cause

In `MambaInnerFn.forward`, the `b_rms_weight` / `c_rms_weight` branches apply `rms_norm_forward` to `B` and `C` *in place* and then `ctx.save_for_backward` saves those **post-norm** tensors (while `delta` is explicitly set to `None` before saving so it truly gets recomputed from `x_dbl` in backward).

In the `checkpoint_lvl == 1` branch of `backward`, the code then loaded the (already-normalized) saved `B`/`C` and called `rms_norm_forward` on them again before `selective_scan_cuda.bwd`. That is a second RMSNorm on top of the first.

## Fix

Remove the redundant `rms_norm_forward` on `B` and `C` in backward. The saved tensors are the same post-norm `B`/`C` that the forward kernel itself consumed, so no further normalization is needed. `delta` is unaffected — it is still recomputed and (when `dt_rms_weight` is set) normalized here.

Fixes #885.