### PR TITLE
Remove duplicate dA assignment in mamba_chunk_scan

### DIFF
--- a/mamba_ssm/ops/triton/ssd_combined.py
+++ b/mamba_ssm/ops/triton/ssd_combined.py
@@ -668,7 +668,6 @@ def mamba_chunk_scan(x, dt, A, B, C, chunk_size, D=None, z=None, dt_bias=None, d
     if dt_softplus:
         dt = F.softplus(dt)
     dA = dt * rearrange(A, "h -> h 1 1")
-    dA = dt * rearrange(A, "h -> h 1 1")
     dA_cumsum = torch.cumsum(dA, dim=-1)
     # 1. Compute the state for each chunk
     states = chunk_state(B, x, dt, dA_cumsum, states_in_fp32=True)


### PR DESCRIPTION
## Bug

\`mamba_chunk_scan\` in \`mamba_ssm/ops/triton/ssd_combined.py\` computes \`dA\` twice in a row with the identical expression:

\`\`\`python
dA = dt * rearrange(A, \"h -> h 1 1\")
dA = dt * rearrange(A, \"h -> h 1 1\")
dA_cumsum = torch.cumsum(dA, dim=-1)
\`\`\`

## Root cause

The sibling reference in the same file (\`ssd_chunk_scan_combined_ref\`) performs the same computation once:

\`\`\`python
dA = dt * rearrange(A, \"h -> h 1 1\")
dA_cumsum = torch.cumsum(dA, dim=-1)
\`\`\`

and so does the kernel-backed \`_chunk_cumsum_fwd\` used in \`_mamba_chunk_scan_combined_fwd\`. The duplicate has been in place since the initial Mamba-2 release (60dadf2) and looks like a copy-paste leftover. It is functionally a no-op (the second line overwrites \`dA\` with an identical tensor) but the shadowed line is a trap for future edits — changing only one of the two copies would silently diverge.

## Fix

Drop the redundant assignment so the function matches \`ssd_chunk_scan_combined_ref\` and the rest of the module.