### PR TITLE
Fix ssd_selective_scan passing None as delta_softplus to selective_scan_fn

### DIFF
--- a/mamba_ssm/ops/triton/ssd_combined.py
+++ b/mamba_ssm/ops/triton/ssd_combined.py
@@ -766,7 +766,7 @@ def ssd_selective_scan(x, dt, A, B, C, D=None, z=None, dt_bias=None, dt_softplus
             dt = F.softplus(dt)
         dt = dt.clamp(min=dt_limit[0], max=dt_limit[1]).to(x.dtype)
         dt_bias = None
-        dt_softplus = None
+        dt_softplus = False
     out = selective_scan_fn(x, dt, A, B, C, D=D, z=z, delta_bias=dt_bias, delta_softplus=dt_softplus)
     return rearrange(out, "b (h p) l -> b l h p", p=headdim)
 


### PR DESCRIPTION
### Bug
When `dt_limit` is non-default, `ssd_selective_scan` applies `dt_bias` and softplus to `dt` manually and clamps it, then resets `dt_bias` and `dt_softplus` so they are not re-applied inside `selective_scan_fn`. The `dt_softplus` reset uses `None` instead of `False`:

https://github.com/state-spaces/mamba/blob/316ed60/mamba_ssm/ops/triton/ssd_combined.py#L762-L770

```python
if dt_limit != (0.0, float("inf")):
    if dt_bias is not None:
        dt = dt + rearrange(dt_bias, "d -> d 1")
    if dt_softplus:
        dt = F.softplus(dt)
    dt = dt.clamp(min=dt_limit[0], max=dt_limit[1]).to(x.dtype)
    dt_bias = None
    dt_softplus = None
out = selective_scan_fn(x, dt, A, B, C, D=D, z=z, delta_bias=dt_bias, delta_softplus=dt_softplus)
```

### Root cause
`selective_scan_fn`'s `delta_softplus` parameter is a `bool` (default `False`) that is forwarded into the `selective_scan_cuda.fwd` C++ binding as a C++ `bool`. Passing Python `None` for the bool overrides the `False` default and relies on implicit `None -> bool` coercion at the pybind11 boundary, which either raises `TypeError` or silently misbehaves. In contrast, `delta_bias` is `Optional[Tensor]`, so the `dt_bias = None` reset is correct.

### Fix
Set `dt_softplus = False` to match the boolean contract of `selective_scan_fn`/`selective_scan_cuda.fwd`, mirroring the intent of the `dt_bias = None` reset on the line above. Behaviour is unchanged when `dt_limit` is the default `(0.0, float('inf'))` (the reset block does not execute).