### PR TITLE
Fix load_state_dict_hf early-returning before dtype/device conversion

### DIFF
--- a/mamba_ssm/utils/hf.py
+++ b/mamba_ssm/utils/hf.py
@@ -15,7 +15,7 @@ def load_state_dict_hf(model_name, device=None, dtype=None):
     # If not fp32, then we don't want to load directly to the GPU
     mapped_device = "cpu" if dtype not in [torch.float32, None] else device
     resolved_archive_file = cached_file(model_name, WEIGHTS_NAME, _raise_exceptions_for_missing_entries=False)
-    return torch.load(resolved_archive_file, map_location=mapped_device)
+    state_dict = torch.load(resolved_archive_file, map_location=mapped_device)
     # Convert dtype before moving to GPU to save memory
     if dtype is not None:
         state_dict = {k: v.to(dtype=dtype) for k, v in state_dict.items()}


### PR DESCRIPTION
## Bug

\`mamba_ssm/utils/hf.py:load_state_dict_hf\` takes \`device\` and \`dtype\` parameters that are documented by the \`mapped_device\` comment (\"If not fp32, then we don't want to load directly to the GPU\") as a two-stage load-then-cast flow, but it returns from \`torch.load\` before any of the staging runs:

\`\`\`python
def load_state_dict_hf(model_name, device=None, dtype=None):
    # If not fp32, then we don't want to load directly to the GPU
    mapped_device = \"cpu\" if dtype not in [torch.float32, None] else device
    resolved_archive_file = cached_file(model_name, WEIGHTS_NAME, _raise_exceptions_for_missing_entries=False)
    return torch.load(resolved_archive_file, map_location=mapped_device)
    # Convert dtype before moving to GPU to save memory
    if dtype is not None:
        state_dict = {k: v.to(dtype=dtype) for k, v in state_dict.items()}
    state_dict = {k: v.to(device=device) for k, v in state_dict.items()}
    return state_dict
\`\`\`

## Root cause

The \`return\` on the \`torch.load(...)\` line makes every subsequent line dead code. So when a caller passes e.g. \`dtype=torch.float16, device=\"cuda\"\`:

- \`mapped_device\` resolves to \`\"cpu\"\` (correct — stage on CPU to save GPU memory during cast)
- Tensors are loaded on CPU
- The function returns the CPU/fp32 state dict immediately
- The \`.to(dtype=dtype)\` and \`.to(device=device)\` stages never run

The caller silently gets an un-cast, CPU-resident state dict instead of the requested dtype on the requested device.

## Why the fix is correct

Changing \`return torch.load(...)\` to \`state_dict = torch.load(...)\` restores the intended control flow: load onto \`mapped_device\`, cast dtype if requested, then move to \`device\` (a no-op when \`device is None\`). The final \`return state_dict\` already in place then returns the fully-converted dict. No new logic is introduced — the fix just makes the existing cast/move lines reachable.