### PR TITLE
Fix min_p sampling reading logits[..., 0] as max and crashing on batched inputs

### DIFF
--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -103,9 +103,9 @@ def sample(logits, top_k=1, top_p=0.0, min_p=0.0, temperature=1.0):
         else:
             if min_p > 0.0:
                 logits_top = logits.clone()
-                max_prob = logits_top[..., 0].item()
+                max_prob = logits_top.max(dim=-1, keepdim=True).values
                 min_prob = max_prob * min_p
-                modify_logits_for_min_p_filtering(logits_top, min_prob)
+                logits_top.masked_fill_(logits_top < min_prob, float("-inf"))
                 if temperature != 1.0:
                     logits_top /= temperature
                 return torch.multinomial(torch.softmax(logits_top, dim=-1), num_samples=1).squeeze(dim=-1)


### PR DESCRIPTION
## Bug

In `mamba_ssm/utils/generation.py`, the `min_p` branch of `sample()` has been broken since min-p was added in #135:

```python
if min_p > 0.0:
    logits_top = logits.clone()
    max_prob = logits_top[..., 0].item()
    min_prob = max_prob * min_p
    modify_logits_for_min_p_filtering(logits_top, min_prob)
```

Two distinct problems:

1. **Wrong token.** `logits_top[..., 0]` is the logit at vocabulary index 0 — typically the pad/BOS token — not the maximum logit. Min-p filtering is defined relative to the *most likely* token (`prob[token] >= min_p * max_prob`), so scaling by a fixed-index token's logit makes the threshold nearly meaningless: when that token is unfavoured, no filtering happens; when it happens to be dominant, the filter throws away real candidates.
2. **Crash on batch > 1.** `logits` has shape `(batch_size, vocab_size)`, so `logits_top[..., 0]` is a `(batch_size,)` tensor and `.item()` raises `"only one element tensors can be converted to Python scalars"`. Any batched decode path (e.g. `decode(..., min_p=x)` with batch > 1) is unreachable. This was previously reported in the now-closed #513.

## Root cause

`[..., 0]` should be a reduction across the vocab axis, not an index into it. The trailing `.item()` exists only to placate the scalar-threshold signature of `modify_logits_for_min_p_filtering`, which early-exits via `if min_p <= 0.0 or min_p >= 1.0` — a check that itself rejects tensor thresholds.

## Fix

Take the per-row max logit with `keepdim=True` so the threshold broadcasts back to `(batch_size, vocab_size)`, and mask inline with the same `-inf` sentinel the helper would have used:

```diff
-                max_prob = logits_top[..., 0].item()
+                max_prob = logits_top.max(dim=-1, keepdim=True).values
                 min_prob = max_prob * min_p
-                modify_logits_for_min_p_filtering(logits_top, min_prob)
+                logits_top.masked_fill_(logits_top < min_prob, float("-inf"))
```

`modify_logits_for_min_p_filtering` can't be reused here because its scalar comparison rejects a tensor threshold. The inline `masked_fill_` preserves the in-place semantics the original code relied on. The `if min_p > 0.0` entry check guarding this branch is unchanged, so the existing fast-path for `min_p = 0` is preserved.

## Change

Two one-line edits on `mamba_ssm/utils/generation.py`. No API, signature, or helper-function changes.