### PR TITLE
Allocate states_converted with states_dtype, not dstates_dtype

### DIFF
--- a/mamba_ssm/ops/triton/ssd_state_passing.py
+++ b/mamba_ssm/ops/triton/ssd_state_passing.py
@@ -240,7 +240,7 @@ def _state_passing_bwd(
         assert seq_idx.shape == (batch, seqlen)
     dstates = torch.empty_like(dout, dtype=dstates_dtype if dstates_dtype is not None else dout.dtype)
     if states_dtype is not None and states_dtype != states.dtype:
-        states_converted = torch.empty_like(states, dtype=dstates_dtype if dstates_dtype is not None else dout.dtype)
+        states_converted = torch.empty_like(states, dtype=states_dtype)
         assert states_converted.stride() == states.stride()
     else:
         states_converted = None


### PR DESCRIPTION
## Bug

In `_state_passing_bwd` (`mamba_ssm/ops/triton/ssd_state_passing.py`),
the `states_converted` buffer is allocated with the wrong dtype. It
receives `dstates_dtype`, the dtype meant for the gradient-of-states
output, instead of `states_dtype`, the dtype the states are supposed to
be cast to.

## Root cause

Lines 241-244:

```python
dstates = torch.empty_like(dout, dtype=dstates_dtype if dstates_dtype is not None else dout.dtype)
if states_dtype is not None and states_dtype != states.dtype:
    states_converted = torch.empty_like(states, dtype=dstates_dtype if dstates_dtype is not None else dout.dtype)
    assert states_converted.stride() == states.stride()
```

The guard on line 242 is `states_dtype is not None and states_dtype
!= states.dtype` — we enter this branch exactly when states need to be
**cast to `states_dtype`**. Yet the allocation dtype on line 243
copy-pastes the expression used for `dstates` one line above, so the
buffer ends up in `dstates_dtype` (or `dout.dtype`). The post-kernel
branch at lines 281-282 confirms the intent:

```python
if states_dtype is not None and states_dtype == states.dtype:
    states_converted = states   # no conversion needed
```

i.e. `states_converted` is the `states`-in-`states_dtype` buffer, not
the `dstates` buffer.

## Why the fix is correct

- Allocates `states_converted` in `states_dtype`, matching the guard
  that gated this branch and matching the post-kernel "no-conversion"
  assignment (`states_converted = states` when dtypes already match).
- The outer condition already ensures `states_dtype is not None`, so
  no fallback is needed.
- No other allocation or kernel argument changes; the kernel just now
  writes to a correctly-typed buffer.

## Change

`mamba_ssm/ops/triton/ssd_state_passing.py`: change the
`states_converted` allocation in `_state_passing_bwd` to use
`dtype=states_dtype`. One-line fix.