### PR TITLE
Fix Mamba2.step() mishandling D when D_has_hdim=True

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -316,7 +316,8 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
             dBx = torch.einsum("bh,bn,bhp->bhpn", dt, B, x)
             ssm_state.copy_(ssm_state * rearrange(dA, "b h -> b h 1 1") + dBx)
             y = torch.einsum("bhpn,bn->bhp", ssm_state.to(dtype), C)
-            y = y + rearrange(self.D.to(dtype), "h -> h 1") * x
+            D = rearrange(self.D.to(dtype), "(h p) -> h p", p=self.headdim) if self.D_has_hdim else rearrange(self.D.to(dtype), "h -> h 1")
+            y = y + D * x
             y = rearrange(y, "b h p -> b (h p)")
             if not self.rmsnorm:
                 y = y * self.act(z)  # (B D)
@@ -324,7 +325,7 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
             A = repeat(A, "h -> h p n", p=self.headdim, n=self.d_state).to(dtype=torch.float32)
             dt = repeat(dt, "b h -> b h p", p=self.headdim)
             dt_bias = repeat(self.dt_bias, "h -> h p", p=self.headdim)
-            D = repeat(self.D, "h -> h p", p=self.headdim)
+            D = rearrange(self.D, "(h p) -> h p", p=self.headdim) if self.D_has_hdim else repeat(self.D, "h -> h p", p=self.headdim)
             B = rearrange(B, "b (g n) -> b g n", g=self.ngroups)
             C = rearrange(C, "b (g n) -> b g n", g=self.ngroups)
             x_reshaped = rearrange(x, "b (h p) -> b h p", p=self.headdim)


### PR DESCRIPTION
Closes #887 and #888.

## Bug

`Mamba2.step()` treats `self.D` as having shape `(nheads,)` in both its inference code paths, but when the module is constructed with `D_has_hdim=True` its shape is `(d_ssm,) = (nheads * headdim,)`. As a result, `step()` is inconsistent with `forward()`, which already branches on `D_has_hdim` at the `mamba_split_conv1d_scan_combined` and `mamba_chunk_scan_combined` call sites.

Concretely:

- `selective_state_update is None` path (mamba2.py L319):
  ```python
  y = y + rearrange(self.D.to(dtype), \"h -> h 1\") * x
  ```
  With `D_has_hdim=True`, `self.D` is `(nheads*headdim,)`, so this produces a tensor of shape `(nheads*headdim, 1)` which cannot broadcast against `x` of shape `(batch, nheads, headdim)`.
- `selective_state_update` path (mamba2.py L327):
  ```python
  D = repeat(self.D, \"h -> h p\", p=self.headdim)
  ```
  With `D_has_hdim=True` this builds a `(nheads*headdim, headdim)` tensor, but `selective_state_update` expects `D` of shape `(nheads, headdim)` per its docstring in `mamba_ssm/ops/triton/selective_state_update.py`.

## Root cause

`step()` was written under the assumption that `self.D` is always per-head (shape `(nheads,)`). The `D_has_hdim=True` option, which makes `self.D` per-(head, headdim), was wired into `forward()` but not into either of `step()`'s branches.

## Fix

Branch on `self.D_has_hdim` and reshape `self.D` via `rearrange(\"(h p) -> h p\", p=self.headdim)` in both locations, matching the convention used in `forward()`. When `D_has_hdim=False` behavior is unchanged (`rearrange(\"h -> h 1\")` for the elementwise multiply branch, `repeat(\"h -> h p\")` for the kernel branch).

## Why the fix is correct

- `D_has_hdim=True` case:
  - Elementwise branch: `rearrange(self.D, \"(h p) -> h p\", p=headdim)` produces `(nheads, headdim)`, which broadcasts against `x` of shape `(batch, nheads, headdim)` — exactly the per-`(head, hdim)` `D * x` term intended in the forward equations.
  - Kernel branch: `selective_state_update` documents `D: (dim,) or (nheads, dim)`; `rearrange(\"(h p) -> h p\")` yields the `(nheads, headdim)` form directly, with no incorrect duplication.
- `D_has_hdim=False` case: the `else` arms keep the original `rearrange(\"h -> h 1\")` and `repeat(\"h -> h p\")` calls, so behavior is byte-identical to `main` for all existing users.
- The change mirrors the same `D_has_hdim` check that `forward()` already uses at the `mamba_split_conv1d_scan_combined` and `mamba_chunk_scan_combined` calls, keeping `forward()` and `step()` in agreement.