### PR TITLE
Set `batch`, `seqlen`, `ngroups`, and `nheads` as dynamic arguments for MIMO kernels.

### DIFF
--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
@@ -1202,15 +1202,22 @@ def mamba_mimo_bwd_combined(
         dtype_str = str(dtype).replace("torch.", "")
     else:
         dtype_str = dtype
-    bwd_fwd_kernel = mamba_mimo_bwd_fwd(B, S, H, G, N, P, R, 
-                                             z is not None,
-                                             D is not None,
-                                             reduceO,
-                                             chunk_size, 
-                                             rotary_dim_divisor,
-                                             dtype_str,
-                                             bf_threads,
-                                             bf_num_stages)
+    bwd_fwd_kernel = mamba_mimo_bwd_fwd(
+        T.dynamic("B"),
+        T.dynamic("S"), 
+        T.dynamic("H"), 
+        T.dynamic("G"), 
+        N, P, R, 
+        z is not None,
+        D is not None,
+        reduceO,
+        chunk_size, 
+        rotary_dim_divisor,
+        dtype_str,
+        bf_threads,
+        bf_num_stages
+    )
+
     bwd_fwd_kernel(
                     dout,
                     q, 
@@ -1253,15 +1260,21 @@ def mamba_mimo_bwd_combined(
     ddA_cs = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
     
     
-    bwd_bwd_kernel = mamba_mimo_bwd_bwd(B, S, H, G, N, P, R, 
-                                             z is not None,
-                                             D is not None,
-                                             reduceO,
-                                             chunk_size, 
-                                             rotary_dim_divisor,
-                                             dtype_str,
-                                             bb_threads,
-                                             bb_num_stages)
+    bwd_bwd_kernel = mamba_mimo_bwd_bwd(
+        T.dynamic("B"),
+        T.dynamic("S"), 
+        T.dynamic("H"), 
+        T.dynamic("G"), 
+        N, P, R, 
+        z is not None,
+        D is not None,
+        reduceO,
+        chunk_size, 
+        rotary_dim_divisor,
+        dtype_str,
+        bb_threads,
+        bb_num_stages)
+
     bwd_bwd_kernel(
             dout,
             q, 

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
@@ -71,6 +71,7 @@ def mamba_mimo_bwd_fwd(
     hasD,
     reduceO,
     NS: int = 1,
+    isVarlen: bool = True,
     chunk_size: int = 16,
     rotary_dim_divisor: int = 4,
     dtype: str = 'float16',
@@ -210,7 +211,7 @@ def mamba_mimo_bwd_fwd(
             seq_end = T.alloc_var(T.int32)
             full_nchunks = T.alloc_var(T.int32)
             tail_len = T.alloc_var(T.int32)
-            if NS > 1:
+            if isVarlen:
                 start_seq_ind = CU_SEQLENS[i_ns]
                 start_chunk_ind = (start_seq_ind // chunk_size) + i_ns
                 seq_len = CU_SEQLENS[i_ns + 1] - CU_SEQLENS[i_ns]
@@ -553,6 +554,7 @@ def mamba_mimo_bwd_bwd(
     hasD,
     reduceO,
     NS: int = 1,
+    isVarlen: bool = False,
     chunk_size: int = 16,
     rotary_dim_divisor: int = 4,
     dtype: str = 'float16',
@@ -720,7 +722,7 @@ def mamba_mimo_bwd_bwd(
             seq_end = T.alloc_var(T.int32)
             full_nchunks = T.alloc_var(T.int32)
             tail_len = T.alloc_var(T.int32)
-            if NS > 1:
+            if isVarlen:
                 start_seq_ind = CU_SEQLENS[i_ns]
                 start_chunk_ind = (start_seq_ind // chunk_size) + i_ns
                 seq_len = CU_SEQLENS[i_ns + 1] - CU_SEQLENS[i_ns]
@@ -1323,7 +1325,7 @@ def mamba_mimo_bwd_combined_varlen(
         T.dynamic("G"), 
         N, P, R,
         z is not None, D is not None, reduceO,
-        T.dynamic("NS"), chunk_size, rotary_dim_divisor, dtype_str,
+        T.dynamic("NS"), cu_seqlens is not None, chunk_size, rotary_dim_divisor, dtype_str,
         bf_threads, bf_num_stages)
 
     bwd_fwd_kernel(
@@ -1356,7 +1358,7 @@ def mamba_mimo_bwd_combined_varlen(
         T.dynamic("G"),
         N, P, R,
         z is not None, D is not None, reduceO,
-        T.dynamic("NS"), chunk_size, rotary_dim_divisor, dtype_str,
+        T.dynamic("NS"), cu_seqlens is not None, chunk_size, rotary_dim_divisor, dtype_str,
         bb_threads, bb_num_stages)
 
     bwd_bwd_kernel(

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
@@ -1317,10 +1317,15 @@ def mamba_mimo_bwd_combined_varlen(
     qk_dot = torch.zeros([B, H, S, R, R], dtype=q.dtype, device=q.device)
 
     bwd_fwd_kernel = mamba_mimo_bwd_fwd(
-        B, S, H, G, N, P, R,
+        T.dynamic("B"),
+        T.dynamic("S"), 
+        T.dynamic("H"), 
+        T.dynamic("G"), 
+        N, P, R,
         z is not None, D is not None, reduceO,
-        NS, chunk_size, rotary_dim_divisor, dtype_str,
+        T.dynamic("NS"), chunk_size, rotary_dim_divisor, dtype_str,
         bf_threads, bf_num_stages)
+
     bwd_fwd_kernel(
         dout, q, k, v, q_bias, k_bias, mimo_v, mimo_o,
         dmimo_o, states,
@@ -1345,10 +1350,15 @@ def mamba_mimo_bwd_combined_varlen(
     ddA_cs = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
 
     bwd_bwd_kernel = mamba_mimo_bwd_bwd(
-        B, S, H, G, N, P, R,
+        T.dynamic("B"),
+        T.dynamic("S"), 
+        T.dynamic("H"), 
+        T.dynamic("G"),
+        N, P, R,
         z is not None, D is not None, reduceO,
-        NS, chunk_size, rotary_dim_divisor, dtype_str,
+        T.dynamic("NS"), chunk_size, rotary_dim_divisor, dtype_str,
         bb_threads, bb_num_stages)
+
     bwd_bwd_kernel(
         dout, q, k, v, q_bias, k_bias, mimo_v, mimo_o,
         dk_tilelang.view(B, S * R, H, N),

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd.py
@@ -436,16 +436,20 @@ def mamba_mimo_forward(q, k, v,
     else:
         tl_dtype = dtype
     reduceO = mimo_o is not None
-    kernel = mamba_mimo_fwd(B, S, H, G, N, P, R, 
-                                       z is not None, 
-                                       D is not None, 
-                                       reduceO,
-                                       return_final_state=return_state,
-                                       chunk_size=chunk_size, 
-                                       rotary_dim_divisor=rotary_dim_divisor, 
-                                       dtype=tl_dtype, 
-                                       threads=threads, 
-                                       num_stages=num_stages)
+    kernel = mamba_mimo_fwd(T.dynamic("B"),
+                            T.dynamic("S"), 
+                            T.dynamic("H"), 
+                            T.dynamic("G"), 
+                            N, P, R, 
+                            z is not None, 
+                            D is not None, 
+                            reduceO,
+                            return_final_state=return_state,
+                            chunk_size=chunk_size, 
+                            rotary_dim_divisor=rotary_dim_divisor, 
+                            dtype=tl_dtype, 
+                            threads=threads, 
+                            num_stages=num_stages)
     # print(kernel.get_kernel_source()) # NOTE: prints compiled CUDA code
     if reduceO:
         o = torch.empty((B, S, H, P), device='cuda', dtype=dtype)

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
@@ -599,17 +599,21 @@ def mamba_mimo_forward_varlen(q, k, v,
         NS = 1
 
     reduceO = mimo_o is not None
-    kernel = mamba_mimo_fwd(B, S, H, G, N, P, R, 
-                                       z is not None, 
-                                       D is not None, 
-                                       reduceO,
-                                       NS=NS if cu_seqlens is not None else 1,
-                                       return_final_state=return_state,
-                                       chunk_size=chunk_size, 
-                                       rotary_dim_divisor=rotary_dim_divisor, 
-                                       dtype=tl_dtype, 
-                                       threads=threads, 
-                                       num_stages=num_stages)
+    kernel = mamba_mimo_fwd(T.dynamic("B"),
+                            T.dynamic("S"), 
+                            T.dynamic("H"), 
+                            T.dynamic("G"),
+                            N, P, R, 
+                            z is not None, 
+                            D is not None, 
+                            reduceO,
+                            NS=T.dynamic("NS"), 
+                            return_final_state=return_state,
+                            chunk_size=chunk_size, 
+                            rotary_dim_divisor=rotary_dim_divisor, 
+                            dtype=tl_dtype,
+                            threads=threads,
+                            num_stages=num_stages)
     # print(kernel.get_kernel_source()) # NOTE: prints compiled CUDA code
     if reduceO:
         o = torch.empty((B, S, H, P), device='cuda', dtype=dtype)

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
@@ -68,6 +68,7 @@ def mamba_mimo_fwd(
     hasD,
     reduceO,
     NS: int = 1,
+    isVarlen: bool = True,
     return_final_state=False,
     chunk_size: int = 16,
     rotary_dim_divisor = 4,
@@ -98,7 +99,7 @@ def mamba_mimo_fwd(
     # Block sizes for K and V dimensions - use full dimensions (no tiling)
     # assert S % chunk_size == 0, "Sequence length must be divisible by chunk_size"
 
-    if NS > 1:
+    if isVarlen:
         max_nchunks = (S//chunk_size) + NS
         Final_State_shape = (NS, H, N, P)
         Final_K_shape = (NS, R, H, N)
@@ -239,7 +240,7 @@ def mamba_mimo_fwd(
             seq_end = T.alloc_var(T.int32)
             full_nchunks = T.alloc_var(T.int32)
             tail_len = T.alloc_var(T.int32)
-            if NS > 1:
+            if isVarlen:
                 start_seq_ind = CU_SEQLENS[i_ns]
                 start_chunk_ind = (start_seq_ind // chunk_size) + i_ns
                 seq_len = CU_SEQLENS[i_ns + 1] - CU_SEQLENS[i_ns]
@@ -367,7 +368,7 @@ def mamba_mimo_fwd(
 
                 if return_final_state and i == full_nchunks - 1:
                     seq_boundary = seq_end - chunk_start
-                    if NS > 1:
+                    if isVarlen:
                         for csr, n in T.Parallel(fused_chunk_size, N):
                             if csr >= (seq_boundary - 1) * R and csr < seq_boundary * R:  # Only copy the last chunk's R rows to FINAL_K
                                 FINAL_K[i_ns, csr % R, i_h, n] = k_shared[csr, n]
@@ -516,7 +517,7 @@ def mamba_mimo_fwd(
             
             # --- Save Last State (if applicable) ---
             if return_final_state:
-                if NS > 1:
+                if isVarlen:
                     T.copy(states_frag, FINAL_STATE[i_ns, i_h, :, :])
                 else:
                     T.copy(states_frag, FINAL_STATE[i_b, i_h, :, :])
@@ -607,7 +608,8 @@ def mamba_mimo_forward_varlen(q, k, v,
                             z is not None, 
                             D is not None, 
                             reduceO,
-                            NS=T.dynamic("NS"), 
+                            NS=T.dynamic("NS"),
+                            isVarlen=cu_seqlens is not None,
                             return_final_state=return_state,
                             chunk_size=chunk_size, 
                             rotary_dim_divisor=rotary_dim_divisor, 


### PR DESCRIPTION
To avoid recompiling MIMO kernels when `batch`, `seqlen`, `ngroups`, or `nheads` changes, pass them as `T.dynamic` input arguments during kernel compilation. 