### PR TITLE
fix: remove double RMSNorm on B/C in MambaInnerFn.backward at checkpoint_lvl=1

### DIFF
--- a/mamba_ssm/ops/selective_scan_interface.py
+++ b/mamba_ssm/ops/selective_scan_interface.py
@@ -300,20 +300,6 @@ class MambaInnerFn(torch.autograd.Function):
                 delta = rearrange(delta, "b d l -> (b l) d", l=L).contiguous()
                 delta = rms_norm_forward(delta, ctx.dt_rms_weight, None, ctx.b_c_dt_rms_eps)
                 delta = rearrange(delta, "(b l) d -> b d l", l=L).contiguous()
-            if b_rms_weight is not None:
-                # Recompute & RMSNorm B
-                B = rearrange(B, "b 1 dstate l -> (b l) dstate", l=L).contiguous()
-                B = rms_norm_forward(
-                    B, ctx.b_rms_weight, None, ctx.b_c_dt_rms_eps
-                )
-                B = rearrange(B, "(b l) dstate -> b 1 dstate l", l=L).contiguous()
-            if c_rms_weight is not None:
-                # Recompute & RMSNorm C
-                C = rearrange(C, "b 1 dstate l -> (b l) dstate", l=L).contiguous()
-                C = rms_norm_forward(
-                    C, ctx.c_rms_weight, None, ctx.b_c_dt_rms_eps
-                )
-                C = rearrange(C, "(b l) dstate -> b 1 dstate l", l=L).contiguous()
             
         # The kernel supports passing in a pre-allocated dz (e.g., in case we want to fuse the
         # backward of selective_scan_cuda with the backward of chunk).


### PR DESCRIPTION
## Bug

`MambaInnerFn.backward` applies RMSNorm to `B` and `C` a second time when `checkpoint_lvl == 1`, silently corrupting gradients.

**Forward pass** (`selective_scan_interface.py`, around line 250):
```python
if b_rms_weight is not None:
    B = rms_norm_forward(B, b_rms_weight, ...)   # B is now post-norm
if c_rms_weight is not None:
    C = rms_norm_forward(C, c_rms_weight, ...)   # C is now post-norm
```
Then `ctx.save_for_backward(..., B, C, ...)` saves **post-norm** B and C.

Only `conv1d_out` and `delta` are set to `None` before saving:
```python
if checkpoint_lvl >= 1:
    conv1d_out, delta = None, None   # will be recomputed in backward
```
B and C are **not** set to None — they are saved as already-normalized tensors.

**Backward pass** (`checkpoint_lvl == 1`):
- `delta` is correctly recomputed from scratch (was None), so re-applying dt_rms is correct.
- `B` and `C` come from `ctx.saved_tensors` already normalized. The removed blocks applied RMSNorm a second time, making the effective normalization `rms_norm(rms_norm(B))` instead of `rms_norm(B)`.

This causes incorrect gradients for any model using `b_rms_weight` or `c_rms_weight` with activation checkpointing (`checkpoint_lvl=1`), such as Mamba2 trained with `--checkpoint-activations`.

## Root cause

The `b_rms_weight` / `c_rms_weight` normalization blocks were added inside the `checkpoint_lvl == 1` recompute block by analogy with `dt_rms_weight`, but unlike `delta`, B and C are saved post-norm and never recomputed — so they must not be re-normalized.

## Fix

Remove the 14 lines that re-apply `rms_norm_forward` to B and C inside the `checkpoint_lvl == 1` block. `delta` re-normalization is unaffected and remains correct.

Fixes #885.