### PR TITLE
feat: ANE for Mac/iPhone support

### DIFF
--- a/mamba_ane/README.md
+++ b/mamba_ane/README.md
@@ -1,13 +1,153 @@
 # Mamba ANE
 
-Topics to cover:
+ANE-native implementation of Mamba-3 for Apple Silicon (M-series). This package provides a pure PyTorch port of Mamba-3 optimized for inference on Neural Engine accelerators via CoreML.
 
-- install the env : 
+## Quick Start
 
-    conda create -n ane_export with python3.12
+### Installation
 
-    pip install -r requirements.txt
+Create a dedicated conda environment with Python 3.12:
 
-    or direct a venv
+```bash
+conda create -n ane_export python=3.12
+conda activate ane_export
+pip install -r requirements.txt
+```
 
-- convert the model : load the weight from mamba_ssm.modules.mamba3 import Mamba3 and load it in
+Alternatively, use a virtual environment:
+
+```bash
+python3.12 -m venv ane_export
+source ane_export/bin/activate
+pip install -r requirements.txt
+```
+
+### Model Understanding
+
+For a detailed walkthrough of the Mamba-3 SISO (Single Input Single Output) architecture and how it's adapted for ANE, see:
+
+📖 **[Mamba-3 SISO Interactive Visualization](./docs/mamba3_siso_viz.html)**
+
+This HTML guide includes:
+- **7-stage pipeline visualization** showing the forward pass flow
+- **Side-by-side code comparison** between original Mamba3 (Triton kernels) and ANE-native PyTorch
+- **Tensor shape tracking** across all stages
+- **Key architectural differences** for ANE compatibility (RoPE, SSM state, attention patterns)
+- **Interactive visualizers** for understanding state flow and computation
+
+Open in any modern browser (Chrome, Safari, Firefox).
+
+## Architecture
+
+### Overview
+
+The ANE implementation replaces Triton/CUDA kernels with pure PyTorch operations compatible with Core ML's Neural Engine compute units. Key modules:
+
+- **`mamba_ane/modules/mamba3.py`** — Core Mamba-3 block with ANE-compatible SSM
+- **`mamba_ane/models/hybrid1d.py`** — StatefulMambaHybrid1D model wrapper
+
+### Design Principles
+
+1. **Pure PyTorch** — No Triton/CuteDSL; uses standard PyTorch ops
+2. **Stateful** — Maintains hidden state for streaming inference
+3. **FP32 Default** — Full precision; FP16 supported for CoreML export
+4. **Shape-Friendly** — Tensors designed for BNHD (batch, nheads, height, depth) layout
+
+## Parity Testing
+
+Numerical equivalence is verified across:
+
+### GPU → ANE Parity (FP32)
+Original Mamba-3 (CUDA) vs ANE PyTorch implementation.
+
+**Result**: ✅ **PASS**
+- Max absolute error: 6.01e-06 (tolerance: < 0.01)
+- Cosine similarity: 1.000000 (tolerance: > 0.999)
+- Consistency across 64 measurement frames
+
+See: [`tests/parity_tests/parity_report_gpu.md`](../tests/parity_tests/parity_report_gpu.md)
+
+### FP32 → FP16 Precision
+ANE FP32 model → ANE FP16 quantization.
+
+**Result**: ✅ **PASS**
+- Max absolute error: 3.05e-05 (tolerance: < 0.01)
+- Cosine similarity: 1.000000 (tolerance: > 0.999)
+
+See: [`tests/parity_tests/parity_report_gpu.md`](../tests/parity_tests/parity_report_gpu.md)
+
+### PyTorch → CoreML (CPU_AND_NE) Parity
+ANE PyTorch export (FP32) → CoreML execution on Apple Silicon (FP16)
+
+**Result**: ✅ **PASS**
+- Max absolute error: 2.10e-04 (tolerance: < 0.03)
+- Cosine similarity: 0.999998 (tolerance: > 0.999)
+- Consistency across 64 measurement frames
+- Compute units: `CPU_AND_NE` (ANE acceleration enabled)
+
+See: [`tests/parity_tests/parity_report_ane.md`](../tests/parity_tests/parity_report_ane.md)
+
+## Usage
+
+### Export to CoreML
+
+```python
+from mamba_ane.modules.hybrid1d import StatefulMambaHybrid1D
+import coremltools as ct
+
+# Load weights (or train from scratch)
+model = StatefulMambaHybrid1D(d_model=512, num_heads=8, d_state=64)
+
+# Trace to CoreML
+traced = ct.models.neural_network.NeuralNetworkBuilder(
+    inputs=[...],
+    outputs=[...]
+)
+model.to_coreml(traced, compute_units=ct.ComputeUnit.CPU_AND_NE)
+```
+
+### Inference
+
+```python
+model.eval()
+with torch.no_grad():
+    output, state = model(input_ids, state)
+```
+
+## Configuration
+
+Model config in `mamba_ane/configs/`:
+- **d_model** — Hidden dimension (default: 512)
+- **num_heads** — Attention heads (default: 8)
+- **d_state** — State dimension (default: 64)
+- **seq_length** — Maximum sequence length (default: 2048)
+
+## Testing
+
+Run all parity tests:
+
+```bash
+python -m pytest tests/parity_tests/ -v
+```
+
+Specific test suites:
+- GPU parity: `python tests/parity_tests/test_impl_gpu.py`
+- ANE parity: `python tests/parity_tests/test_ane_mac.py`
+
+See: [`tests/parity_tests/`](../tests/parity_tests/)
+
+## References
+
+- **Mamba-3 Original**: https://github.com/state-spaces/mamba/
+- **StatefulMobileNet**: https://github.com/Dorianhgn/StatefulMobileNet - *A step by step implementation of mamba operations in torch to make the `Mamba3` model work on ANE.*
+- **ANE Documentation**: https://developer.apple.com/documentation/coreml/neural_engine
+- **CoreML Tools**: https://github.com/apple/coremltools
+
+## Status
+
+- ✅ Architecture ported to pure PyTorch
+- ✅ GPU/ANE numerical parity verified
+- ✅ CoreML export working
+- ✅ FP16 quantization tested
+- 🟡 `Mamba3 SISO → ANE Pytorch → CoreML` model weights conversion.
+- 🟡 Production benchmarking on iPhone 17 Pro ANE

--- a/mamba_ane/README.md
+++ b/mamba_ane/README.md
@@ -1,0 +1,13 @@
+# Mamba ANE
+
+Topics to cover:
+
+- install the env : 
+
+    conda create -n ane_export with python3.12
+
+    pip install -r requirements.txt
+
+    or direct a venv
+
+- convert the model : load the weight from mamba_ssm.modules.mamba3 import Mamba3 and load it in

--- a/mamba_ane/__init__.py
+++ b/mamba_ane/__init__.py
@@ -1,0 +1,1 @@
+"""mamba_ane — ANE-native Mamba3 components and models."""

--- a/mamba_ane/docs/mamba3_siso_viz.html
+++ b/mamba_ane/docs/mamba3_siso_viz.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Mamba-3 SISO — ANE-Native Implementation</title>
+<title>Mamba-3 SISO — Interactive ANE Porting Guide</title>
 <style>
 :root {
   --bg: #0d1117; --bg-card: #161b22; --bg-code: #0a0e14;
@@ -31,10 +31,10 @@ pre code { background: none; border: none; padding: 0; font-size: inherit; }
 .hero { padding: 40px 0 32px; border-bottom: 1px solid var(--border); }
 .badges { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
 .badge { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; border-radius: 20px; font-size: .72rem; font-weight: 600; border: 1px solid; }
+.badge.triton { color: var(--orange); border-color: var(--orange); background: rgba(249,115,22,.1); }
 .badge.pytorch { color: var(--green); border-color: var(--green); background: rgba(34,197,94,.1); }
 .badge.ane { color: var(--blue); border-color: var(--blue); background: rgba(96,165,250,.1); }
 .badge.state { color: var(--purple); border-color: var(--purple); background: rgba(167,139,250,.1); }
-.badge.rmsnorm { color: var(--yellow); border-color: var(--yellow); background: rgba(251,191,36,.1); }
 .subtitle { color: var(--muted); font-size: 1.05rem; margin: 8px 0 28px; }
 .config-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px,1fr)); gap: 10px; margin-top: 16px; }
 .cfg { background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 10px 14px; }
@@ -63,20 +63,22 @@ pre code { background: none; border: none; padding: 0; font-size: inherit; }
 .sp-title { font-size: 1.1rem; font-weight: 600; }
 .sp-tag { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: .7rem; font-weight: 600; margin-left: 10px; }
 .tag-safe   { background: rgba(34,197,94,.15);   color: var(--green); }
-.tag-buf    { background: rgba(167,139,250,.15);  color: var(--purple); }
+.tag-defuse { background: rgba(249,115,22,.15);  color: var(--orange); }
+.tag-kernel { background: rgba(239,68,68,.15);   color: var(--red); }
 
 .sp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
 @media(max-width:900px){ .sp-grid { grid-template-columns: 1fr; } }
 .sp-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 10px; padding: 18px; }
 .sp-card.math  { border-color: rgba(96,165,250,.35); }
 .sp-card.shape { border-color: rgba(167,139,250,.35); }
-.sp-card.ane-c { border-color: rgba(34,197,94,.35); }
+.sp-card.triton-c { border-color: rgba(249,115,22,.35); }
+.sp-card.torch-c  { border-color: rgba(34,197,94,.35); }
 .sp-card.wide { grid-column: 1 / -1; }
 
 /* tensor shape pills */
 .trows { display: flex; flex-direction: column; gap: 7px; }
 .trow  { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.tname { font-family: var(--mono); font-size: .78rem; color: var(--muted); min-width: 110px; }
+.tname { font-family: var(--mono); font-size: .78rem; color: var(--muted); min-width: 90px; }
 .tshape { font-family: var(--mono); font-size: .78rem; background: rgba(96,165,250,.1); border: 1px solid rgba(96,165,250,.3); color: var(--blue); border-radius: 5px; padding: 1px 8px; }
 .tarrow { color: var(--dim); }
 
@@ -108,17 +110,21 @@ input[type=range] { accent-color: var(--blue); width: 80px; cursor: pointer; }
 button { background: rgba(96,165,250,.12); border: 1px solid rgba(96,165,250,.35); color: var(--blue); border-radius: 6px; padding: 5px 13px; font-size: .78rem; cursor: pointer; transition: background .15s; }
 button:hover { background: rgba(96,165,250,.25); }
 
-/* ── CODE PANEL ── */
+/* ── CODE COMPARE ── */
+.code-compare { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; }
+@media(max-width:900px){ .code-compare { grid-template-columns: 1fr; } }
 .cpanel { border-radius: 10px; overflow: hidden; border: 1px solid var(--border); }
 .cp-head { padding: 10px 16px; font-size: .78rem; font-weight: 600; display: flex; align-items: center; gap: 8px; }
-.cp-head.ane-h { background: rgba(34,197,94,.1); border-bottom: 1px solid rgba(34,197,94,.3); color: var(--green); }
-.cpanel pre { border: none; border-radius: 0; margin: 0; font-size: .75rem; max-height: 820px; overflow-y: auto; }
+.cp-head.triton-h { background: rgba(249,115,22,.1); border-bottom: 1px solid rgba(249,115,22,.3); color: var(--orange); }
+.cp-head.torch-h  { background: rgba(34,197,94,.1);  border-bottom: 1px solid rgba(34,197,94,.3);  color: var(--green); }
+.cpanel pre { border: none; border-radius: 0; margin: 0; font-size: .75rem; max-height: 680px; overflow-y: auto; }
 
 /* syntax */
 .kw { color: #f97316; } .fn { color: #60a5fa; } .cm { color: #484f58; font-style: italic; }
 .num { color: #fbbf24; } .cls { color: #a78bfa; } .str { color: #86efac; }
-.hl-buf { background: rgba(167,139,250,.1); display: block; }
-.hl-key { background: rgba(34,197,94,.08); display: block; }
+.hl-rm { background: rgba(239,68,68,.12); display: block; }
+.hl-add { background: rgba(34,197,94,.1); display: block; }
+.hl-chg { background: rgba(249,115,22,.1); display: block; }
 
 /* ── SHAPE TABLE ── */
 .shape-table { width: 100%; border-collapse: collapse; font-size: .83rem; }
@@ -136,26 +142,28 @@ button:hover { background: rgba(96,165,250,.25); }
 <header class="hero">
 <div class="container">
   <div class="badges">
-    <span class="badge pytorch">✓ Pure PyTorch — all 8 stages</span>
-    <span class="badge ane">🍎 Apple ANE / CoreML target</span>
-    <span class="badge state">◈ register_buffer stateful API</span>
-    <span class="badge rmsnorm">⬡ RMSNormANE — no .float() casts</span>
+    <span class="badge triton">⚡ Triton / CuteDSL — needs defusing</span>
+    <span class="badge pytorch">✓ Pure PyTorch — ANE-safe</span>
+    <span class="badge ane">🍎 Apple ANE / Metal target</span>
+    <span class="badge state">◈ Stateful Inference API</span>
   </div>
-  <h1>Mamba-3 SISO — ANE-Native</h1>
-  <p class="subtitle">mamba_ane/modules/mamba3.py — completed ANE implementation, no Triton/CuteDSL kernels</p>
+  <h1>Mamba-3 SISO</h1>
+  <p class="subtitle">Interactive implementation guide — from CUDA kernels to pure PyTorch for CoreML / ANE</p>
 
   <h4>Locked Configuration</h4>
   <div class="config-grid">
     <div class="cfg"><div class="cfg-k">d_model</div><div class="cfg-v">256</div></div>
-    <div class="cfg"><div class="cfg-k">d_inner</div><div class="cfg-v">512</div><div class="cfg-d">H × headdim</div></div>
-    <div class="cfg"><div class="cfg-k">nheads (H)</div><div class="cfg-v">8</div></div>
+    <div class="cfg"><div class="cfg-k">d_inner</div><div class="cfg-v">512</div><div class="cfg-d">expand=2 × d_model</div></div>
+    <div class="cfg"><div class="cfg-k">nheads (H)</div><div class="cfg-v">8</div><div class="cfg-d">d_inner / headdim</div></div>
     <div class="cfg"><div class="cfg-k">headdim (P)</div><div class="cfg-v">64</div></div>
     <div class="cfg"><div class="cfg-k">d_state (S)</div><div class="cfg-v">64</div></div>
-    <div class="cfg"><div class="cfg-k">num_rope_angles</div><div class="cfg-v">16</div></div>
-    <div class="cfg"><div class="cfg-k">rotary_dim</div><div class="cfg-v">32</div><div class="cfg-d">2 × rope_angles</div></div>
+    <div class="cfg"><div class="cfg-k">ngroups</div><div class="cfg-v">1</div><div class="cfg-d">num_bc_heads</div></div>
+    <div class="cfg"><div class="cfg-k">rope_fraction</div><div class="cfg-v">0.5</div><div class="cfg-d">pairwise</div></div>
+    <div class="cfg"><div class="cfg-k">num_rope_angles</div><div class="cfg-v">16</div><div class="cfg-d">d_state×0.5/2</div></div>
+    <div class="cfg"><div class="cfg-k">rotary_dim</div><div class="cfg-v">32</div><div class="cfg-d">first 32 of 64 dims</div></div>
     <div class="cfg"><div class="cfg-k">in_proj out</div><div class="cfg-v">1192</div><div class="cfg-d">512+512+64+64+8+8+8+16</div></div>
-    <div class="cfg"><div class="cfg-k">Batch</div><div class="cfg-v">1</div><div class="cfg-d">inference only</div></div>
-    <div class="cfg"><div class="cfg-k">Stateful</div><div class="cfg-v" style="color:var(--purple)">buf</div><div class="cfg-d">register_buffer</div></div>
+    <div class="cfg"><div class="cfg-k">is_mimo</div><div class="cfg-v" style="color:var(--red)">False</div></div>
+    <div class="cfg"><div class="cfg-k">is_outproj_norm</div><div class="cfg-v" style="color:var(--red)">False</div></div>
   </div>
 </div>
 </header>
@@ -163,101 +171,106 @@ button:hover { background: rgba(96,165,250,.25); }
 <!-- ═══════════════════════════ PIPELINE ═══════════════════════════ -->
 <section id="pipeline">
 <div class="container">
-  <h2>forward() Pipeline</h2>
-  <p>Seqlen=1 inference. All stages are pure PyTorch — ANE-compatible. Click any stage to see the math, shapes, and implementation.</p>
+  <h2>step() Pipeline</h2>
+  <p>Click any stage to see the math, tensor shapes, and Triton → PyTorch translation.</p>
 
   <div class="pipe-wrap">
-    <svg class="pipe-svg" viewBox="0 0 1100 130" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg class="pipe-svg" viewBox="0 0 1100 120" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <!-- arrows -->
       <defs><marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#3d444d"/></marker></defs>
-      <line x1="116" y1="64" x2="132" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
-      <line x1="252" y1="64" x2="268" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
-      <line x1="388" y1="64" x2="404" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
-      <line x1="524" y1="64" x2="540" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
-      <line x1="660" y1="64" x2="676" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
-      <line x1="796" y1="64" x2="812" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
-      <line x1="932" y1="64" x2="948" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="116" y1="60" x2="132" y2="60" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="252" y1="60" x2="268" y2="60" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="388" y1="60" x2="404" y2="60" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="524" y1="60" x2="540" y2="60" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="660" y1="60" x2="676" y2="60" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="796" y1="60" x2="812" y2="60" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="932" y1="60" x2="948" y2="60" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
 
-      <!-- Stage 1 -->
+      <!-- Stage 1: in_proj + split — green -->
       <g class="pnode" data-stage="1" onclick="showStage(1)">
-        <rect x="2" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
-        <text x="59" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 1</text>
-        <text x="59" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">in_proj</text>
-        <text x="59" y="80" text-anchor="middle" fill="#7d8590" font-size="9">+ slice ×8</text>
-        <text x="59" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+        <rect x="2" y="20" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="59" y="47" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 1</text>
+        <text x="59" y="62" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">in_proj</text>
+        <text x="59" y="76" text-anchor="middle" fill="#7d8590" font-size="9">+ split×8</text>
+        <text x="59" y="91" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
       </g>
 
-      <!-- Stage 2 -->
+      <!-- Stage 2: Activations — green -->
       <g class="pnode" data-stage="2" onclick="showStage(2)">
-        <rect x="134" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
-        <text x="191" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 2</text>
-        <text x="191" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">Activations</text>
-        <text x="191" y="80" text-anchor="middle" fill="#7d8590" font-size="9">A, Δt, λ, z</text>
-        <text x="191" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+        <rect x="134" y="20" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="191" y="47" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 2</text>
+        <text x="191" y="62" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">Activations</text>
+        <text x="191" y="76" text-anchor="middle" fill="#7d8590" font-size="9">A, Δt, λ</text>
+        <text x="191" y="91" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
       </g>
 
-      <!-- Stage 3 -->
+      <!-- Stage 3: K/Q Norm — orange (RMSNormGated is Triton) -->
       <g class="pnode" data-stage="3" onclick="showStage(3)">
-        <rect x="270" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
-        <text x="327" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 3</text>
-        <text x="327" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">K, Q Norm</text>
-        <text x="327" y="80" text-anchor="middle" fill="#7d8590" font-size="9">RMSNormANE</text>
-        <text x="327" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+        <rect x="270" y="20" width="114" height="80" rx="8" fill="#1e1408" stroke="#f97316" stroke-width="1.5"/>
+        <text x="327" y="47" text-anchor="middle" fill="#f97316" font-size="9" font-weight="700" font-family="monospace">STAGE 3</text>
+        <text x="327" y="62" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">K, Q Norm</text>
+        <text x="327" y="76" text-anchor="middle" fill="#7d8590" font-size="9">RMSNorm+bcast</text>
+        <text x="327" y="91" text-anchor="middle" fill="#f97316" font-size="8">⚡ defuse</text>
       </g>
 
-      <!-- Stage 4 -->
+      <!-- Stage 4: RoPE — red (full Triton kernel) -->
       <g class="pnode" data-stage="4" onclick="showStage(4)">
-        <rect x="406" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
-        <text x="463" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 4</text>
-        <text x="463" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">RoPE</text>
-        <text x="463" y="80" text-anchor="middle" fill="#7d8590" font-size="9">angle accum + rot</text>
-        <text x="463" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+        <rect x="406" y="20" width="114" height="80" rx="8" fill="#1e0808" stroke="#ef4444" stroke-width="1.5"/>
+        <text x="463" y="47" text-anchor="middle" fill="#ef4444" font-size="9" font-weight="700" font-family="monospace">STAGE 4</text>
+        <text x="463" y="62" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">RoPE Rotation</text>
+        <text x="463" y="76" text-anchor="middle" fill="#7d8590" font-size="9">angle+bias+rot</text>
+        <text x="463" y="91" text-anchor="middle" fill="#ef4444" font-size="8">⚡ Triton kernel</text>
       </g>
 
-      <!-- Stage 5 -->
+      <!-- Stage 5: SSM Coefficients — green -->
       <g class="pnode" data-stage="5" onclick="showStage(5)">
-        <rect x="542" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
-        <text x="599" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 5</text>
-        <text x="599" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">SSM Coeffs</text>
-        <text x="599" y="80" text-anchor="middle" fill="#7d8590" font-size="9">α, β, γ</text>
-        <text x="599" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+        <rect x="542" y="20" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="599" y="47" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 5</text>
+        <text x="599" y="62" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">SSM Coeffs</text>
+        <text x="599" y="76" text-anchor="middle" fill="#7d8590" font-size="9">α, β, γ</text>
+        <text x="599" y="91" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
       </g>
 
-      <!-- Stage 6 -->
+      <!-- Stage 6: State Update — red (CuteDSL) -->
       <g class="pnode" data-stage="6" onclick="showStage(6)">
-        <rect x="678" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#a78bfa" stroke-width="1.5"/>
-        <text x="735" y="51" text-anchor="middle" fill="#a78bfa" font-size="9" font-weight="700" font-family="monospace">STAGE 6</text>
-        <text x="735" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">SSM Update</text>
-        <text x="735" y="80" text-anchor="middle" fill="#7d8590" font-size="9">h = αh + Δh</text>
-        <text x="735" y="95" text-anchor="middle" fill="#a78bfa" font-size="8">◈ state write</text>
+        <rect x="678" y="20" width="114" height="80" rx="8" fill="#1e0808" stroke="#ef4444" stroke-width="1.5"/>
+        <text x="735" y="47" text-anchor="middle" fill="#ef4444" font-size="9" font-weight="700" font-family="monospace">STAGE 6</text>
+        <text x="735" y="62" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">SSM Update</text>
+        <text x="735" y="76" text-anchor="middle" fill="#7d8590" font-size="9">h = αh + Δh</text>
+        <text x="735" y="91" text-anchor="middle" fill="#ef4444" font-size="8">⚡ CuteDSL</text>
       </g>
 
-      <!-- Stage 7 -->
+      <!-- Stage 7: Output + Gate — green -->
       <g class="pnode" data-stage="7" onclick="showStage(7)">
-        <rect x="814" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
-        <text x="871" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 7</text>
-        <text x="871" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">Output y</text>
-        <text x="871" y="80" text-anchor="middle" fill="#7d8590" font-size="9">h·Q + D·V</text>
-        <text x="871" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+        <rect x="814" y="20" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="871" y="47" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 7</text>
+        <text x="871" y="62" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">Output y</text>
+        <text x="871" y="76" text-anchor="middle" fill="#7d8590" font-size="9">h·Q + D·V + gate</text>
+        <text x="871" y="91" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
       </g>
 
-      <!-- Stage 8 -->
+      <!-- Stage 8: out_proj — green -->
       <g class="pnode" data-stage="8" onclick="showStage(8)">
-        <rect x="950" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
-        <text x="1007" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 8</text>
-        <text x="1007" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">out_proj</text>
-        <text x="1007" y="80" text-anchor="middle" fill="#7d8590" font-size="9">Linear + z gate</text>
-        <text x="1007" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+        <rect x="950" y="20" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="1007" y="47" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 8</text>
+        <text x="1007" y="62" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">out_proj</text>
+        <text x="1007" y="76" text-anchor="middle" fill="#7d8590" font-size="9">Linear(512→256)</text>
+        <text x="1007" y="91" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
       </g>
 
-      <!-- State buffer annotations -->
-      <text x="735" y="14" text-anchor="middle" fill="#a78bfa" font-size="8">ssm_state · k_state · v_state · angle_state</text>
-      <line x1="735" y1="16" x2="735" y2="24" stroke="#a78bfa" stroke-width="1" marker-end="url(#arr)"/>
+      <!-- State inputs (top arrows) -->
+      <text x="679" y="14" text-anchor="middle" fill="#a78bfa" font-size="8">ssm_state, k_state, v_state</text>
+      <line x1="735" y1="16" x2="735" y2="20" stroke="#a78bfa" stroke-width="1" marker-end="url(#arr)"/>
+      <text x="463" y="14" text-anchor="middle" fill="#a78bfa" font-size="8">angle_state</text>
+      <line x1="463" y1="16" x2="463" y2="20" stroke="#a78bfa" stroke-width="1" marker-end="url(#arr)"/>
     </svg>
   </div>
 
   <div class="legend">
-    <div class="legend-i"><div class="legend-dot" style="background:#22c55e"></div>ANE-safe (nn.Linear, F.softplus, torch.matmul…)</div>
-    <div class="legend-i"><div class="legend-dot" style="background:#a78bfa"></div>register_buffer state write (in-place [:] update)</div>
+    <div class="legend-i"><div class="legend-dot" style="background:#22c55e"></div>ANE-safe (nn.Linear, F.softplus, F.silu…)</div>
+    <div class="legend-i"><div class="legend-dot" style="background:#f97316"></div>Needs defusing (RMSNormGated Triton)</div>
+    <div class="legend-i"><div class="legend-dot" style="background:#ef4444"></div>Full Triton/CuteDSL kernel — replace entirely</div>
+    <div class="legend-i"><div class="legend-dot" style="background:#a78bfa"></div>Stateful tensors (persist between steps)</div>
   </div>
 
   <!-- ── STAGE PANELS ── -->
@@ -267,41 +280,55 @@ button:hover { background: rgba(96,165,250,.25); }
     <div class="spanel" id="sp1">
       <div class="sp-header">
         <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">1</div>
-        <div><div class="sp-title">in_proj + explicit slicing<span class="sp-tag tag-safe">✓ safe</span></div>
-             <div style="color:var(--muted);font-size:.82rem">nn.Linear with pre-computed boundary indices _s0…_s7</div></div>
+        <div><div class="sp-title">in_proj + split<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">nn.Linear → slice — fully CoreML-compatible</div></div>
       </div>
       <div class="sp-grid">
         <div class="sp-card math">
           <h4>Operation</h4>
           <div class="math-block">
-            <div class="trow"><span class="ml">zxBCdt</span><span class="mn">= in_proj(x) &nbsp; [256→1192]</span></div>
-            <div style="margin-top:8px;font-size:.75rem;color:var(--muted)">Sliced via pre-computed boundaries:</div>
-            <div class="trow" style="margin-top:4px"><span class="ml">z_raw</span><span class="mn">: [0 : 512] &nbsp;←&nbsp; gate</span></div>
-            <div class="trow"><span class="ml">x_raw</span><span class="mn">: [512:1024] ←&nbsp; values (V)</span></div>
-            <div class="trow"><span class="ml">B_raw</span><span class="mn">: [1024:1088] ←&nbsp; keys (K)</span></div>
-            <div class="trow"><span class="ml">C_raw</span><span class="mn">: [1088:1152] ←&nbsp; queries (Q)</span></div>
-            <div class="trow"><span class="ml">dd_dt</span><span class="mn">: [1152:1160] ←&nbsp; Δt̂</span></div>
-            <div class="trow"><span class="ml">dd_A</span><span class="mn">: [1160:1168] ←&nbsp; Â</span></div>
-            <div class="trow"><span class="ml">trap_raw</span><span class="mn">: [1168:1176] ←&nbsp; trap</span></div>
-            <div class="trow"><span class="ml">angles_raw</span><span class="mn">: [1176:1192] ←&nbsp; RoPE Δθ</span></div>
+            <div class="trow"><span class="ml">zxBCdt</span> <span class="mn">= in_proj(u)</span></div>
+            <div style="margin-top:8px;font-size:.75rem;color:var(--muted)">Split into 8 chunks (dim=-1):</div>
+            <div class="trow" style="margin-top:4px"><span class="ml">z</span><span class="mn">: 512</span></div>
+            <div class="trow"><span class="ml">x</span><span class="mn">: 512 &nbsp;←&nbsp; values (V)</span></div>
+            <div class="trow"><span class="ml">B_raw</span><span class="mn">: 64 &nbsp;←&nbsp; keys (K)</span></div>
+            <div class="trow"><span class="ml">C_raw</span><span class="mn">: 64 &nbsp;←&nbsp; queries (Q)</span></div>
+            <div class="trow"><span class="ml">dd_dt</span><span class="mn">: 8 &nbsp;←&nbsp; Δt̂</span></div>
+            <div class="trow"><span class="ml">dd_A</span><span class="mn">: 8 &nbsp;←&nbsp; Â</span></div>
+            <div class="trow"><span class="ml">trap</span><span class="mn">: 8 &nbsp;←&nbsp; trap</span></div>
+            <div class="trow"><span class="ml">angles</span><span class="mn">: 16 &nbsp;←&nbsp; RoPE increments</span></div>
           </div>
         </div>
         <div class="sp-card shape">
           <h4>Tensor Shapes</h4>
           <div class="trows">
-            <div class="trow"><span class="tname">x (input)</span><span class="tshape">(1, 256)</span></div>
-            <div class="trow"><span class="tname">zxBCdt</span><span class="tshape">(1, 1192)</span></div>
-            <div style="margin-top:8px"></div>
-            <div class="trow"><span class="tname">z_raw, x_raw</span><span class="tshape">(1, 512)</span></div>
+            <div class="trow"><span class="tname">u</span><span class="tshape">(1, 256)</span><span class="tarrow">→</span></div>
+            <div class="trow"><span class="tname">in_proj out</span><span class="tshape">(1, 1192)</span></div>
+            <div class="trow" style="margin-top:8px;"><span class="tname">z, x</span><span class="tshape">(1, 512)</span></div>
             <div class="trow"><span class="tname">B_raw, C_raw</span><span class="tshape">(1, 64)</span></div>
-            <div class="trow"><span class="tname">dd_dt, dd_A, trap_raw</span><span class="tshape">(1, 8)</span></div>
-            <div class="trow"><span class="tname">angles_raw</span><span class="tshape">(1, 16)</span></div>
+            <div class="trow"><span class="tname">dd_dt, dd_A, trap</span><span class="tshape">(1, 8)</span></div>
+            <div class="trow"><span class="tname">angles</span><span class="tshape">(1, 16)</span></div>
           </div>
         </div>
-        <div class="sp-card ane-c wide">
-          <h4>ANE Implementation</h4>
-          <pre><code><span class="cm"># Slice boundaries are precomputed in __init__ to avoid recomputing</span>
-<span class="cm"># _s0=512, _s1=1024, _s2=1088, _s3=1152, _s4=1160, _s5=1168, _s6=1176, _s7=1192</span>
+        <div class="sp-card triton-c">
+          <h4>Original Code (no custom kernel)</h4>
+          <pre><code><span class="cm"># mamba3.py step() — standard PyTorch</span>
+zxBCdt = self.in_proj(u)
+z, x, B, C, dd_dt, dd_A, trap, angles = \
+    torch.split(zxBCdt, [
+        self.d_inner,   <span class="cm"># 512</span>
+        self.d_inner,   <span class="cm"># 512</span>
+        self.d_state,   <span class="cm"># 64</span>
+        self.d_state,   <span class="cm"># 64</span>
+        self.nheads,    <span class="cm"># 8</span>
+        self.nheads,    <span class="cm"># 8</span>
+        self.nheads,    <span class="cm"># 8</span>
+        self.num_rope_angles], dim=-1)  <span class="cm"># 16</span></code></pre>
+        </div>
+        <div class="sp-card torch-c">
+          <h4>PyTorch ANE — explicit slice indices</h4>
+          <pre><code><span class="cm"># mamba_ane/modules/mamba3.py — MambaBlock.forward()</span>
+<span class="cm"># _s0..._s7 precomputed in __init__ — no recompute per step</span>
 zxBCdt     = self.in_proj(x)
 z_raw      = zxBCdt[..., :self._s0]
 x_raw      = zxBCdt[..., self._s0:self._s1]
@@ -311,7 +338,7 @@ dd_dt      = zxBCdt[..., self._s3:self._s4]
 dd_A       = zxBCdt[..., self._s4:self._s5]
 trap_raw   = zxBCdt[..., self._s5:self._s6]
 angles_raw = zxBCdt[..., self._s6:self._s7]</code></pre>
-          <div class="note ok">Explicit slice notation over torch.split — produces smaller CoreML MIL graphs with fewer split ops. nn.Linear converts 1:1 to a CoreML linear op.</div>
+          <div class="note ok">Explicit slicing over torch.split produces a smaller CoreML MIL graph. nn.Linear converts 1:1 to CoreML. Batch is fixed at 1 for inference.</div>
         </div>
       </div>
     </div>
@@ -320,38 +347,49 @@ angles_raw = zxBCdt[..., self._s6:self._s7]</code></pre>
     <div class="spanel" id="sp2">
       <div class="sp-header">
         <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">2</div>
-        <div><div class="sp-title">Activations + dt_bias + SiLU gate<span class="sp-tag tag-safe">✓ safe</span></div>
-             <div style="color:var(--muted);font-size:.82rem">softplus, sigmoid, silu — all CoreML mlprogram ops</div></div>
+        <div><div class="sp-title">Data-dependent Activations<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">softplus, sigmoid, silu — all ANE-compatible</div></div>
       </div>
       <div class="sp-grid">
         <div class="sp-card math">
           <h4>Equations (per-head scalars)</h4>
           <div class="math-block">
-            <div class="trow"><span class="ml">A<sub>h</sub></span><span class="mn">= −(</span><span class="mf">softplus</span><span class="mn">(Â<sub>h</sub>) + ε<sub>A</sub>)</span></div>
-            <div class="trow"><span class="ml">Δt<sub>h</sub></span><span class="mn">= </span><span class="mf">softplus</span><span class="mn">(Δt̂<sub>h</sub> + b<sup>Δt</sup><sub>h</sub>)</span></div>
-            <div class="trow"><span class="ml">λ<sub>h</sub></span><span class="mn">= </span><span class="mf">sigmoid</span><span class="mn">(trap<sub>h</sub>)</span></div>
-            <div class="trow"><span class="ml">z</span><span class="mn">= </span><span class="mf">silu</span><span class="mn">(z_raw) &nbsp;←&nbsp; gate precomputed here</span></div>
-            <div style="margin-top:10px;font-size:.75rem;color:var(--muted)">ε<sub>A</sub> = 1e-4 — ensures A is strictly negative</div>
+            <div class="trow"><span class="ml">A<sub>h</sub></span> <span class="mn">= −(</span><span class="mf">softplus</span><span class="mn">(Â<sub>h</sub>) + ε<sub>A</sub>)</span></div>
+            <div class="trow"><span class="ml">Δt<sub>h</sub></span> <span class="mn">= </span><span class="mf">softplus</span><span class="mn">(Δt̂<sub>h</sub> + b<sup>Δt</sup><sub>h</sub>)</span></div>
+            <div class="trow"><span class="ml">λ<sub>h</sub></span> <span class="mn">= </span><span class="mf">sigmoid</span><span class="mn">(trap<sub>h</sub>)</span></div>
+            <div class="trow"><span class="ml">z</span> <span class="mn">= </span><span class="mf">silu</span><span class="mn">(z_raw) &nbsp;←&nbsp; gate pre-activated</span></div>
+            <div style="margin-top:10px;font-size:.75rem;color:var(--muted)">A_floor = 1e-4 (additive, not clamp)</div>
             <div style="font-size:.75rem;color:var(--muted)">dt_bias: learned per-head, shape (H=8,)</div>
           </div>
         </div>
         <div class="sp-card shape">
           <h4>Tensor Shapes</h4>
           <div class="trows">
-            <div class="trow"><span class="tname">dd_A → A</span><span class="tshape">(1, 8)</span><span class="tarrow">negative</span></div>
-            <div class="trow"><span class="tname">dd_dt → DT</span><span class="tshape">(1, 8)</span><span class="tarrow">positive</span></div>
-            <div class="trow"><span class="tname">trap_raw → lam</span><span class="tshape">(1, 8)</span><span class="tarrow">∈ (0,1)</span></div>
-            <div class="trow"><span class="tname">z_raw → z</span><span class="tshape">(1, 512)</span><span class="tarrow">gate</span></div>
-            <div style="margin-top:8px;font-size:.78rem;color:var(--muted)">dt_bias (param): <span class="tshape">(8,)</span></div>
+            <div class="trow"><span class="tname">dd_A</span><span class="tshape">(1, 8)</span><span class="tarrow">→</span><span class="tname">A</span><span class="tshape">(1, 8)</span></div>
+            <div class="trow"><span class="tname">dd_dt</span><span class="tshape">(1, 8)</span><span class="tarrow">→</span><span class="tname">DT</span><span class="tshape">(1, 8)</span></div>
+            <div class="trow"><span class="tname">trap</span><span class="tshape">(1, 8)</span><span class="tarrow">→</span><span class="tname">λ</span><span class="tshape">(1, 8)</span></div>
+            <div class="trow"><span class="tname">z_raw</span><span class="tshape">(1, 512)</span><span class="tarrow">→</span><span class="tname">z</span><span class="tshape">(1, 512)</span></div>
+            <div style="margin-top:8px;font-size:.78rem;color:var(--muted)">dt_bias (static param): <span class="tshape">(8,)</span></div>
           </div>
         </div>
-        <div class="sp-card ane-c wide">
-          <h4>ANE Implementation</h4>
-          <pre><code>A   = -(F.softplus(dd_A) + <span class="num">1e-4</span>)          <span class="cm"># (1, H=8) — strictly negative</span>
-DT  = F.softplus(dd_dt + self.dt_bias)   <span class="cm"># (1, H=8) — strictly positive</span>
-lam = torch.sigmoid(trap_raw)            <span class="cm"># (1, H=8) — trapezoid weight</span>
-z   = F.silu(z_raw)                      <span class="cm"># (1, 512) — gate preactivated here</span></code></pre>
-          <div class="note ok">No .float() casts — ANE runs fp16. The +1e-4 additive floor replaces torch.clamp for CoreML compatibility (clamp with min can inhibit graph fusion).</div>
+        <div class="sp-card triton-c">
+          <h4>Original Code</h4>
+          <pre><code><span class="cm"># in _preprocess — standard torch ops</span>
+_A = -F.softplus(A_proj.to(torch.float32))
+_A = torch.clamp(_A, max=-self.A_floor)
+DT = F.softplus(dd_dt + self.dt_bias)
+trap = torch.sigmoid(trap_proj)</code></pre>
+        </div>
+        <div class="sp-card torch-c">
+          <h4>PyTorch ANE — no .float() casts</h4>
+          <pre><code><span class="cm"># No .float() — ANE stays in fp16</span>
+<span class="cm"># +1e-4 additive floor instead of clamp (avoids CoreML fusion inhibition)</span>
+A   = -(F.softplus(dd_A) + <span class="num">1e-4</span>)
+DT  = F.softplus(dd_dt + self.dt_bias)
+lam = torch.sigmoid(trap_raw)
+<span class="cm"># Gate pre-activated here — applied flat in Stage 8</span>
+z   = F.silu(z_raw)</code></pre>
+          <div class="note ok">F.softplus, torch.sigmoid, F.silu all map to CoreML mlprogram ops. No .float() casts keep activations in the model's native dtype (fp16 on ANE).</div>
         </div>
       </div>
     </div>
@@ -359,21 +397,21 @@ z   = F.silu(z_raw)                      <span class="cm"># (1, 512) — gate pr
     <!-- STAGE 3 -->
     <div class="spanel" id="sp3">
       <div class="sp-header">
-        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">3</div>
-        <div><div class="sp-title">K, Q — RMSNormANE + head expand + bias<span class="sp-tag tag-safe">✓ safe</span></div>
-             <div style="color:var(--muted);font-size:.82rem">RMSNormANE avoids .float() casts and uses x*x instead of pow(2)</div></div>
+        <div class="sp-num" style="background:rgba(249,115,22,.15);color:var(--orange)">3</div>
+        <div><div class="sp-title">K, Q — Reshape + RMSNorm + Broadcast<span class="sp-tag tag-defuse">⚡ defuse RMSNormGated</span></div>
+             <div style="color:var(--muted);font-size:.82rem">RMSNormGated is a Triton kernel — replace with RMSNormANE (no .float(), x*x)</div></div>
       </div>
       <div class="sp-grid">
         <div class="sp-card math">
-          <h4>Pipeline</h4>
+          <h4>Pipeline (SISO: r=1, g=1)</h4>
           <div class="math-block">
             <div class="trow"><span class="mv">B_raw</span><span class="mn">: (1, 64)</span></div>
             <div class="trow" style="padding-left:12px"><span class="mn">→ view(1,1,1,64) → </span><span class="mf">RMSNormANE</span></div>
-            <div class="trow" style="padding-left:12px"><span class="mn">→ repeat(1,1,H,1) → squeeze(1)</span></div>
+            <div class="trow" style="padding-left:12px"><span class="mn">→ repeat(1,1,H,1).squeeze(1) → (1,H,64)</span></div>
             <div class="trow" style="padding-left:12px"><span class="mn">→ + B_bias → </span><span class="mv">K_pre: (1,8,64)</span></div>
-            <div style="margin-top:8px;color:var(--muted);font-size:.76rem">Same for C_raw → Q_pre</div>
-            <div style="margin-top:8px;color:var(--muted);font-size:.76rem">RMSNormANE: var = (x*x).mean(-1), no pow(2)</div>
-            <div style="font-size:.76rem;color:var(--muted)">B_bias/C_bias shape: (1, H, S) — directly addable</div>
+            <div style="margin-top:8px;color:var(--muted);font-size:.76rem">Same pipeline for C_raw → Q_pre</div>
+            <div style="margin-top:4px;color:var(--muted);font-size:.76rem">Bias added here (not inside RoPE kernel)</div>
+            <div style="font-size:.76rem;color:var(--muted)">RMSNormANE: var=(x*x).mean(-1), rsqrt()</div>
           </div>
         </div>
         <div class="sp-card shape">
@@ -387,23 +425,38 @@ z   = F.silu(z_raw)                      <span class="cm"># (1, 512) — gate pr
             <div class="trow"><span class="tname">K_pre, Q_pre</span><span class="tshape">(1, 8, 64)</span></div>
           </div>
         </div>
-        <div class="sp-card ane-c wide">
-          <h4>ANE Implementation</h4>
-          <pre><code><span class="cm"># RMSNormANE (no .float() cast, x*x instead of pow(2))</span>
+        <div class="sp-card triton-c">
+          <h4>Original (uses Triton RMSNormGated)</h4>
+          <pre><code><span class="cm"># _preprocess in mamba3.py</span>
+<span class="kw">from</span> mamba_ssm.ops.triton.layernorm_gated \
+    <span class="kw">import</span> RMSNorm <span class="kw">as</span> RMSNormGated
+<span class="cm"># ↑ Triton kernel — NOT portable</span>
+
+B = rearrange(B, <span class="str">"b (r g s) -> b r g s"</span>,
+              g=self.num_bc_heads, r=<span class="num">1</span>)
+C = rearrange(C, <span class="str">"b (r g s) -> b r g s"</span>,
+              g=self.num_bc_heads, r=<span class="num">1</span>)
+B = self.B_norm(B)   <span class="cm"># Triton RMSNorm on s-dim</span>
+C = self.C_norm(C)
+B = B.expand(-<span class="num">1</span>, -<span class="num">1</span>, self.nheads, -<span class="num">1</span>)
+C = C.expand(-<span class="num">1</span>, -<span class="num">1</span>, self.nheads, -<span class="num">1</span>)</code></pre>
+        </div>
+        <div class="sp-card torch-c">
+          <h4>PyTorch ANE — RMSNormANE</h4>
+          <pre><code><span class="cm"># RMSNormANE: no .float() cast, x*x avoids pow(2) CoreML regression</span>
 <span class="kw">class</span> <span class="cls">RMSNormANE</span>(nn.Module):
     <span class="kw">def</span> <span class="fn">forward</span>(self, x):
         variance = (x * x).mean(-<span class="num">1</span>, keepdim=<span class="kw">True</span>)
-        rms_inv  = torch.rsqrt(variance + self.eps)
-        <span class="kw">return</span> x * rms_inv * self.weight
+        <span class="kw">return</span> x * torch.rsqrt(variance + self.eps) * self.weight
 
-<span class="cm"># Stage 3 in forward()</span>
-K_norm     = self.B_norm(B_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))       <span class="cm"># (1, 1, 1, 64)</span>
+<span class="cm"># Stage 3 — bias folded in here, not in RoPE kernel</span>
+K_norm     = self.B_norm(B_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))
 Q_norm     = self.C_norm(C_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))
-K_expanded = K_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)  <span class="cm"># (1, 8, 64)</span>
+K_expanded = K_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)
 Q_expanded = Q_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)
-K_pre      = K_expanded + self.B_bias                                <span class="cm"># (1, 8, 64)</span>
+K_pre      = K_expanded + self.B_bias   <span class="cm"># B_bias: (1, H, S)</span>
 Q_pre      = Q_expanded + self.C_bias</code></pre>
-          <div class="note ok">RMSNormANE uses x*x (elementwise mul) instead of pow(2) because pow() with a literal exponent can produce a CoreML power op that forces CPU fallback on some ANE firmware versions. rsqrt() maps to a native ANE recip-sqrt op.</div>
+          <div class="note warn">B_bias/C_bias are (1, H, S) — no rearrange needed. rsqrt() maps to a native ANE op. x*x instead of pow(2) avoids a CoreML power op that can force CPU fallback on some ANE firmware.</div>
         </div>
       </div>
     </div>
@@ -411,60 +464,72 @@ Q_pre      = Q_expanded + self.C_bias</code></pre>
     <!-- STAGE 4 -->
     <div class="spanel" id="sp4">
       <div class="sp-header">
-        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">4</div>
-        <div><div class="sp-title">RoPE — angle accumulation + pairwise rotation<span class="sp-tag tag-safe">✓ safe</span></div>
-             <div style="color:var(--muted);font-size:.82rem">Pure PyTorch apply_rope — stateless rotation, no kernel dependency</div></div>
+        <div class="sp-num" style="background:rgba(239,68,68,.15);color:var(--red)">4</div>
+        <div><div class="sp-title">Angle Update + RoPE Pairwise<span class="sp-tag tag-kernel">⚡ full Triton kernel</span></div>
+             <div style="color:var(--muted);font-size:.82rem"><code>apply_rotary_qk_inference_fwd</code> — bias+angle+rotation fused; replace with apply_rope()</div></div>
       </div>
       <div class="sp-grid">
         <div class="sp-card math">
-          <h4>Three Operations</h4>
+          <h4>Two Fused Operations</h4>
           <div class="math-block">
-            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">① Expand angles to all heads</div>
-            <div class="trow"><span class="ml">angles</span><span class="mn">= angles_raw.view(1,1,16).repeat(1,H,1)</span></div>
-            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">② Angle accumulation (no mod 2π)</div>
+            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">① Angle accumulation (bias now in Stage 3)</div>
             <div class="trow"><span class="ml">Δθ</span><span class="mn">= </span><span class="mf">tanh</span><span class="mn">(angles) · π · Δt.unsqueeze(-1)</span></div>
-            <div class="trow"><span class="ml">θ</span><span class="mn">= angle_state + Δθ &nbsp; (accumulated)</span></div>
-            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">③ Pairwise rotation (first rotary_dim=32 dims)</div>
+            <div class="trow"><span class="ml">θ</span><span class="mn">= angle_state + Δθ &nbsp;</span><span style="color:var(--red);font-size:.8em">(no mod 2π!)</span></div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">② Pairwise rotation (first 32 of 64 dims)</div>
             <div class="trow"><span class="ml">[x'<sub>2i</sub>]</span><span class="mn">= cos(θ<sub>i</sub>)·x<sub>2i</sub> − sin(θ<sub>i</sub>)·x<sub>2i+1</sub></span></div>
             <div class="trow"><span class="ml">[x'<sub>2i+1</sub>]</span><span class="mn">= sin(θ<sub>i</sub>)·x<sub>2i</sub> + cos(θ<sub>i</sub>)·x<sub>2i+1</sub></span></div>
-            <div style="font-size:.76rem;color:var(--muted)">Dims 32–63 pass through unchanged</div>
+            <div style="font-size:.76rem;color:var(--muted)">Dims 32–63: pass through unchanged</div>
           </div>
         </div>
         <div class="sp-card shape">
           <h4>Tensor Shapes</h4>
           <div class="trows">
-            <div class="trow"><span class="tname">angles_raw</span><span class="tshape">(1, 16)</span></div>
-            <div class="trow"><span class="tname">angles (expanded)</span><span class="tshape">(1, 8, 16)</span></div>
+            <div class="trow"><span class="tname">K_pre, Q_pre</span><span class="tshape">(1, 8, 64)</span><span class="tarrow">in</span></div>
+            <div class="trow"><span class="tname">angles_raw</span><span class="tshape">(1, 16)</span><span class="tarrow">→ expand to</span><span class="tshape">(1, 8, 16)</span></div>
             <div class="trow"><span class="tname">DT.unsqueeze(-1)</span><span class="tshape">(1, 8, 1)</span></div>
-            <div class="trow"><span class="tname">delta_theta</span><span class="tshape">(1, 8, 16)</span></div>
-            <div class="trow"><span class="tname">angle_state (buf)</span><span class="tshape">(1, 8, 16)</span></div>
-            <div class="trow"><span class="tname">theta (new)</span><span class="tshape">(1, 8, 16)</span></div>
-            <div class="trow"><span class="tname">K_pre, Q_pre</span><span class="tshape">(1, 8, 64)</span></div>
-            <div class="trow"><span class="tname">K_rot, Q_rot</span><span class="tshape">(1, 8, 64)</span></div>
-            <div style="margin-top:6px;font-size:.76rem;color:var(--muted)">rotary_dim=32: dims [0:32] rotate, [32:64] pass</div>
+            <div class="trow"><span class="tname">angle_state (buf)</span><span class="tshape">(1, 8, 16)</span><span class="tarrow">→ updated</span></div>
+            <div class="trow"><span class="tname">theta</span><span class="tshape">(1, 8, 16)</span></div>
+            <div class="trow"><span class="tname">K_rot, Q_rot</span><span class="tshape">(1, 8, 64)</span><span class="tarrow">out</span></div>
+            <div style="margin-top:8px;font-size:.78rem;color:var(--muted)">rotary_dim=32: only dims [0:32] rotate</div>
           </div>
         </div>
-        <div class="sp-card ane-c wide">
-          <h4>ANE Implementation</h4>
-          <pre><code><span class="cm"># apply_rope helper — stateless, called for both K and Q</span>
-<span class="kw">def</span> <span class="fn">apply_rope</span>(self, x, cos, sin):
-    <span class="cm"># x: (1, H, S=64), cos/sin: (1, H, 16)</span>
-    x_rot  = x[..., :self.rotary_dim]          <span class="cm"># (1, H, 32)</span>
-    x_pass = x[..., self.rotary_dim:]          <span class="cm"># (1, H, 32)</span>
-    x0 = x_rot[..., <span class="num">0</span>::<span class="num">2</span>]                     <span class="cm"># even dims  (1, H, 16)</span>
-    x1 = x_rot[..., <span class="num">1</span>::<span class="num">2</span>]                     <span class="cm"># odd dims   (1, H, 16)</span>
-    out_rot = torch.stack(
-        [x0 * cos - x1 * sin,
-         x0 * sin + x1 * cos], dim=-<span class="num">1</span>).flatten(-<span class="num">2</span>)  <span class="cm"># (1, H, 32)</span>
-    <span class="kw">return</span> torch.cat([out_rot, x_pass], dim=-<span class="num">1</span>)       <span class="cm"># (1, H, 64)</span>
-
-<span class="cm"># Stage 4 in forward()</span>
-angles      = angles_raw.view(<span class="num">1</span>, <span class="num">1</span>, self.num_rope_angles).repeat(<span class="num">1</span>, self.num_heads, <span class="num">1</span>)
+        <div class="sp-card triton-c">
+          <h4>Original (Triton kernel)</h4>
+          <pre><code><span class="cm"># mamba3.py step() — fused Triton</span>
+bias_q = rearrange(self.C_bias, <span class="str">"h r n -> r h n"</span>)
+bias_k = rearrange(self.B_bias, <span class="str">"h r n -> r h n"</span>)
+<span class="cm"># rotate_pairwise=True for SISO</span>
+C, B, nxt_angle = apply_rotary_qk_inference_fwd(
+    q=C, k=B,
+    angle_state=angle_state,
+    angle_proj=angles,
+    dt=DT,
+    bias_q=bias_q,
+    bias_k=bias_k,
+    rotate_pairwise=<span class="kw">True</span>)
+<span class="cm"># angles: tanh(sigmoid-approx)*pi*dt INSIDE kernel
+# no mod 2π applied in the Triton code</span></code></pre>
+        </div>
+        <div class="sp-card torch-c">
+          <h4>PyTorch ANE — apply_rope()</h4>
+          <pre><code><span class="cm"># Bias was added in Stage 3 — only angle+rot here</span>
+angles      = angles_raw.view(<span class="num">1</span>, <span class="num">1</span>, self.num_rope_angles) \
+                        .repeat(<span class="num">1</span>, self.num_heads, <span class="num">1</span>)   <span class="cm"># (1,H,16)</span>
 delta_theta = torch.tanh(angles) * math.pi * DT.unsqueeze(-<span class="num">1</span>)
-theta       = self.angle_state + delta_theta
-K_rot       = self.apply_rope(K_pre, torch.cos(theta), torch.sin(theta))
-Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))</code></pre>
-          <div class="note info">angle_state is a register_buffer — it is written in Stage 6 after the state update block. cos/sin computed per-step from accumulated theta; no precomputed table needed.</div>
+theta       = self.angle_state + delta_theta              <span class="cm"># (1,H,16)</span>
+K_rot = self.apply_rope(K_pre, torch.cos(theta), torch.sin(theta))
+Q_rot = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))
+
+<span class="cm"># apply_rope — stateless, operates on (1, H, S)</span>
+<span class="kw">def</span> <span class="fn">apply_rope</span>(self, x, cos, sin):
+    x_rot  = x[..., :self.rotary_dim]          <span class="cm"># (1,H,32)</span>
+    x_pass = x[..., self.rotary_dim:]
+    x0, x1 = x_rot[..., <span class="num">0</span>::<span class="num">2</span>], x_rot[..., <span class="num">1</span>::<span class="num">2</span>]
+    out_rot = torch.stack(
+        [x0*cos - x1*sin, x0*sin + x1*cos], dim=-<span class="num">1</span>
+    ).flatten(-<span class="num">2</span>)
+    <span class="kw">return</span> torch.cat([out_rot, x_pass], dim=-<span class="num">1</span>)</code></pre>
+          <div class="note info">Input is (1,H,S) not (B,1,H,S) — bias was absorbed in Stage 3 so there is no squeeze needed here. The kernel used tl.sigmoid(2x)*2-1 as tanh approx; torch.tanh is numerically identical.</div>
         </div>
       </div>
     </div>
@@ -473,8 +538,8 @@ Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))</code><
     <div class="spanel" id="sp5">
       <div class="sp-header">
         <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">5</div>
-        <div><div class="sp-title">Trapezoid Discretization Coefficients<span class="sp-tag tag-safe">✓ safe</span></div>
-             <div style="color:var(--muted);font-size:.82rem">α, β, γ — computed explicitly from A, DT, λ before the state update</div></div>
+        <div><div class="sp-title">SSM Discretization Coefficients<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">α, β, γ — all computed inside mamba3_step_fn, but trivial to extract</div></div>
       </div>
       <div class="sp-grid">
         <div class="sp-card math">
@@ -483,8 +548,7 @@ Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))</code><
             <div class="trow"><span class="ml">α<sub>h</sub></span><span class="mn">= exp(A<sub>h</sub> · Δt<sub>h</sub>) &nbsp;←&nbsp; decay</span></div>
             <div class="trow"><span class="ml">β<sub>h</sub></span><span class="mn">= (1 − λ<sub>h</sub>) · Δt<sub>h</sub> · α<sub>h</sub> &nbsp;←&nbsp; past weight</span></div>
             <div class="trow"><span class="ml">γ<sub>h</sub></span><span class="mn">= λ<sub>h</sub> · Δt<sub>h</sub> &nbsp;←&nbsp; present weight</span></div>
-            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">λ=0 → ZOH (zero-order hold), λ=1 → forward Euler</div>
-            <div style="margin-top:4px;color:var(--muted);font-size:.76rem">Coefficients broadcast to (1,H,1,1) for outer-product dims</div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">λ (trap) interpolates between ZOH (λ=0) and forward Euler (λ=1).</div>
           </div>
         </div>
         <div class="sp-card shape">
@@ -492,22 +556,35 @@ Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))</code><
           <div class="trows">
             <div class="trow"><span class="tname">A</span><span class="tshape">(1, 8)</span><span class="tarrow">negative</span></div>
             <div class="trow"><span class="tname">DT</span><span class="tshape">(1, 8)</span><span class="tarrow">positive</span></div>
-            <div class="trow"><span class="tname">lam (λ)</span><span class="tshape">(1, 8)</span><span class="tarrow">∈ (0,1)</span></div>
-            <div class="trow"><span class="tname">alpha</span><span class="tshape">(1, 8)</span><span class="tarrow">scalar</span></div>
+            <div class="trow"><span class="tname">λ</span><span class="tshape">(1, 8)</span><span class="tarrow">∈ (0, 1)</span></div>
+            <div class="trow"><span class="tname">alpha, beta, gamma</span><span class="tshape">(1, 8)</span></div>
             <div class="trow"><span class="tname">g4, b4 (broadcast)</span><span class="tshape">(1, 8, 1, 1)</span></div>
-            <div class="trow"><span class="tname">alpha broadcast</span><span class="tshape">(1, 8, 1, 1)</span></div>
           </div>
         </div>
-        <div class="sp-card ane-c wide">
-          <h4>ANE Implementation</h4>
-          <pre><code>alpha = torch.exp(A * DT)                   <span class="cm"># (1, H=8)   — decay factor</span>
-beta  = (<span class="num">1.0</span> - lam) * DT * alpha            <span class="cm"># (1, H=8)   — past weighting</span>
-gamma = lam * DT                             <span class="cm"># (1, H=8)   — present weighting</span>
+        <div class="sp-card triton-c">
+          <h4>Original (inside CuteDSL mamba3_step_fn)</h4>
+          <pre><code><span class="cm"># These coefficients are computed inside the
+# mamba3_step_fn CuteDSL kernel.
+# There is NO explicit Python code for them —
+# they are fused with the state update.</span>
+mamba3_step_fn(
+    ssm_state, k_state, v_state,
+    A, B, C, self.D, x, DT, trap,
+    xpj, outproj=outpj,
+    out=y, z=z, zproj=zpj,
+    tile_D=<span class="num">64</span>, num_warps=<span class="num">4</span>)</code></pre>
+        </div>
+        <div class="sp-card torch-c">
+          <h4>PyTorch ANE — explicit</h4>
+          <pre><code><span class="cm"># Compute all coefficients explicitly</span>
+alpha = torch.exp(A * DT)              <span class="cm"># (1, H) — decay</span>
+beta  = (<span class="num">1.0</span> - lam) * DT * alpha     <span class="cm"># (1, H) — past weight</span>
+gamma = lam * DT                       <span class="cm"># (1, H) — present weight</span>
 
-<span class="cm"># Broadcast to (1, H, 1, 1) for outer-product accumulation</span>
-g4 = gamma[:, :, <span class="kw">None</span>, <span class="kw">None</span>]              <span class="cm"># (1, 8, 1, 1)</span>
+<span class="cm"># Broadcast to (1, H, 1, 1) for outer-product dims</span>
+g4 = gamma[:, :, <span class="kw">None</span>, <span class="kw">None</span>]
 b4 = beta[:, :,  <span class="kw">None</span>, <span class="kw">None</span>]</code></pre>
-          <div class="note ok">torch.exp is ANE-safe. β = (1−λ)·Δt·α reuses alpha — no redundant exp. The [:,:,None,None] broadcast avoids einsum and maps to simple reshape+mul on ANE.</div>
+          <div class="note ok">torch.exp is ANE-safe. β reuses alpha — no redundant exp. [:,:,None,None] broadcast avoids einsum and maps to a reshape+mul on ANE.</div>
         </div>
       </div>
     </div>
@@ -515,62 +592,75 @@ b4 = beta[:, :,  <span class="kw">None</span>, <span class="kw">None</span>]</co
     <!-- STAGE 6 -->
     <div class="spanel" id="sp6">
       <div class="sp-header">
-        <div class="sp-num" style="background:rgba(167,139,250,.15);color:var(--purple)">6</div>
-        <div><div class="sp-title">SSM Recurrence — matmul outer products + state write<span class="sp-tag tag-buf">◈ state write</span></div>
-             <div style="color:var(--muted);font-size:.82rem">torch.matmul outer products; in-place buffer update via [:]</div></div>
+        <div class="sp-num" style="background:rgba(239,68,68,.15);color:var(--red)">6</div>
+        <div><div class="sp-title">SSM State Update (Trapezoid Recurrence)<span class="sp-tag tag-kernel">⚡ CuteDSL kernel</span></div>
+             <div style="color:var(--muted);font-size:.82rem">The core <code>mamba3_step_fn</code> CuteDSL kernel — replace with matmul outer products + register_buffer writes</div></div>
       </div>
       <div class="sp-grid">
         <div class="sp-card math">
           <h4>Second-Order Recurrence</h4>
           <div class="math-block">
-            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">Outer products (P×S matrices per head):</div>
-            <div class="trow"><span class="ml">o<sub>prev</sub></span><span class="mn">= v_state ⊗ k_state &nbsp; (prev step)</span></div>
-            <div class="trow"><span class="ml">o<sub>curr</sub></span><span class="mn">= V ⊗ K_rot &nbsp; (current step)</span></div>
-            <div style="margin-top:10px;"><div class="trow"><span class="ml">h</span><span class="mn">= α · ssm_state + β · o<sub>prev</sub> + γ · o<sub>curr</sub></span></div></div>
-            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">State write (in-place, CoreML StateType):</div>
-            <div class="trow" style="padding-left:8px"><span class="ml">ssm_state</span><span class="mn">← h</span></div>
-            <div class="trow" style="padding-left:8px"><span class="ml">k_state</span><span class="mn">← K_rot.unsqueeze(1)</span></div>
-            <div class="trow" style="padding-left:8px"><span class="ml">v_state</span><span class="mn">← V</span></div>
-            <div class="trow" style="padding-left:8px"><span class="ml">angle_state</span><span class="mn">← theta</span></div>
+            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">Outer products (headdim × d_state matrices):</div>
+            <div class="trow"><span class="ml">Δh</span><span class="mn">= β · (v_state ⊗ k_state)</span></div>
+            <div class="trow" style="padding-left:28px"><span class="mn">+ γ · (V ⊗ K_rot)</span></div>
+            <div style="margin-top:10px;"><div class="trow"><span class="ml">h</span><span class="mn">= α · ssm_state + Δh</span></div></div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">⊗ = outer product → (H, P, S) matrix</div>
+            <div style="font-size:.76rem;color:var(--muted)">State writes: ssm_state, k_state, v_state, angle_state</div>
           </div>
         </div>
         <div class="sp-card shape">
           <h4>Tensor Shapes</h4>
           <div class="trows">
-            <div class="trow"><span class="tname">V (= x_raw reshaped)</span><span class="tshape">(1, 8, 64)</span></div>
-            <div class="trow"><span class="tname">K_rot</span><span class="tshape">(1, 8, 64)</span></div>
             <div class="trow"><span class="tname">ssm_state (buf)</span><span class="tshape">(1, 8, 64, 64)</span></div>
             <div class="trow"><span class="tname">k_state (buf)</span><span class="tshape">(1, 1, 8, 64)</span></div>
             <div class="trow"><span class="tname">v_state (buf)</span><span class="tshape">(1, 8, 64)</span></div>
-            <div class="trow"><span class="tname">V.unsqueeze(-1)</span><span class="tshape">(1, 8, 64, 1)</span></div>
-            <div class="trow"><span class="tname">K_rot.unsqueeze(-2)</span><span class="tshape">(1, 8, 1, 64)</span></div>
+            <div class="trow"><span class="tname">V (= x_raw reshaped)</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">K_rot</span><span class="tshape">(1, 8, 64)</span></div>
             <div class="trow"><span class="tname">outer_curr, outer_prev</span><span class="tshape">(1, 8, 64, 64)</span></div>
             <div class="trow"><span class="tname">new_h</span><span class="tshape">(1, 8, 64, 64)</span></div>
           </div>
         </div>
-        <div class="sp-card ane-c wide">
-          <h4>ANE Implementation</h4>
+        <div class="sp-card triton-c wide">
+          <h4>Original (CuteDSL — all fused)</h4>
+          <pre><code><span class="cm"># This single call performs stages 5+6+7 fused in CuteDSL
+# (NVIDIA Cute DSL — H100 only, not portable)</span>
+y = torch.empty_like(x)
+mamba3_step_fn(
+    ssm_state,          <span class="cm"># (B, H, P, S) — modified in-place</span>
+    k_state,            <span class="cm"># (B, 1, H, S) — modified in-place</span>
+    v_state,            <span class="cm"># (B, H, P)   — modified in-place</span>
+    A,                  <span class="cm"># (B, H)</span>
+    B,                  <span class="cm"># (B, 1, H, S) — K after RoPE</span>
+    C,                  <span class="cm"># (B, 1, H, S) — Q after RoPE</span>
+    self.D,             <span class="cm"># (H,)          — skip scalar</span>
+    x,                  <span class="cm"># (B, 1, H, P)  — values (V)</span>
+    DT, trap, xpj,
+    outproj=outpj, state_out=<span class="kw">None</span>,
+    out=y, z=z, zproj=zpj,
+    tile_D=<span class="num">64</span>, num_warps=<span class="num">4</span>)</code></pre>
+        </div>
+        <div class="sp-card torch-c wide">
+          <h4>PyTorch ANE — matmul outer products + register_buffer writes</h4>
           <pre><code><span class="cm"># Reshape x_raw into (1, H, P) value vectors</span>
-V = x_raw.reshape(<span class="num">1</span>, self.num_heads, self.headdim)   <span class="cm"># (1, 8, 64)</span>
+V = x_raw.reshape(<span class="num">1</span>, self.num_heads, self.headdim)     <span class="cm"># (1, 8, 64)</span>
 
 <span class="cm"># Outer products via broadcast matmul (avoids einsum — ANE-safe)</span>
-<span class="cm"># (1,H,P,1) × (1,H,1,S) → (1,H,P,S)</span>
+<span class="cm"># (1,H,P,1) @ (1,H,1,S) → (1,H,P,S)</span>
 outer_curr = torch.matmul(V.unsqueeze(-<span class="num">1</span>),
-                           K_rot.unsqueeze(-<span class="num">2</span>))          <span class="cm"># (1, 8, 64, 64)</span>
+                           K_rot.unsqueeze(-<span class="num">2</span>))           <span class="cm"># (1, 8, 64, 64)</span>
 outer_prev = torch.matmul(self.v_state.unsqueeze(-<span class="num">1</span>),
                            self.k_state.squeeze(<span class="num">1</span>).unsqueeze(-<span class="num">2</span>))
 
 <span class="cm"># Trapezoid state update</span>
 new_h = (alpha[:, :, <span class="kw">None</span>, <span class="kw">None</span>] * self.ssm_state
-         + b4 * outer_prev
-         + g4 * outer_curr)                              <span class="cm"># (1, 8, 64, 64)</span>
+         + b4 * outer_prev + g4 * outer_curr)
 
-<span class="cm"># In-place register_buffer writes (CoreML ct.StateType)</span>
-<span class="hl-buf"><span class="kw">self</span>.ssm_state[:]   = new_h</span>
-<span class="hl-buf"><span class="kw">self</span>.k_state[:]     = K_rot.unsqueeze(<span class="num">1</span>)   <span class="cm"># store as (1, 1, 8, 64)</span></span>
-<span class="hl-buf"><span class="kw">self</span>.v_state[:]     = V</span>
-<span class="hl-buf"><span class="kw">self</span>.angle_state[:] = theta</span></code></pre>
-          <div class="note warn">The [:] assignment writes through to the ct.StateType buffer in CoreML — equivalent to copy_() but produces cleaner MIL graph. torch.einsum("bhp,bhs->bhps") is avoided here — matmul with unsqueeze is equivalent and maps reliably to ANE matmul ops.</div>
+<span class="cm"># In-place register_buffer writes — picked up by ct.StateType export</span>
+self.ssm_state[:]   = new_h
+self.k_state[:]     = K_rot.unsqueeze(<span class="num">1</span>)    <span class="cm"># store as (1, 1, 8, 64)</span>
+self.v_state[:]     = V
+self.angle_state[:] = theta                   <span class="cm"># written here, computed in Stage 4</span></code></pre>
+          <div class="note warn">matmul+unsqueeze replaces torch.einsum("bhp,bhs->bhps") — equivalent, but matmul maps more reliably to ANE. [:] assignment writes through to ct.StateType; angle_state is also written here (it was computed in Stage 4 but deferred to this single write block).</div>
         </div>
       </div>
     </div>
@@ -579,18 +669,18 @@ new_h = (alpha[:, :, <span class="kw">None</span>, <span class="kw">None</span>]
     <div class="spanel" id="sp7">
       <div class="sp-header">
         <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">7</div>
-        <div><div class="sp-title">Output contraction + D skip<span class="sp-tag tag-safe">✓ safe</span></div>
-             <div style="color:var(--muted);font-size:.82rem">h·Q via matmul + D skip scalar — standard ops</div></div>
+        <div><div class="sp-title">Output y + D skip<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">Matrix-vector product + D skip — all standard ops</div></div>
       </div>
       <div class="sp-grid">
         <div class="sp-card math">
           <h4>Output Computation</h4>
           <div class="math-block">
-            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">Contract h (P×S) with Q (S) per head:</div>
-            <div class="trow"><span class="ml">y<sub>h</sub></span><span class="mn">= h<sub>h</sub> · Q_rot<sub>h</sub></span></div>
-            <div style="font-size:.76rem;color:var(--muted);">&nbsp;&nbsp;&nbsp;= Σ<sub>s</sub> h[p,s] · Q_rot[s] &nbsp;→ (1,H,P)</span></div>
-            <div style="margin-top:10px;"><div class="trow"><span class="ml">y_ssm</span><span class="mn">= y + D<sub>h</sub> · V<sub>h</sub></span></div></div>
-            <div style="font-size:.76rem;color:var(--muted);margin-top:4px">D: skip scalar (H,) — one per head, broadcast to (1,H,1)</div>
+            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">Contract h (P×S matrix) with Q_rot (S vector):</div>
+            <div class="trow"><span class="ml">y<sub>h</sub></span><span class="mn">= h<sub>h</sub> · Q_rot<sub>h</sub> + D<sub>h</sub> · V<sub>h</sub></span></div>
+            <div style="font-size:.76rem;color:var(--muted);">&nbsp;&nbsp;&nbsp;= Σ<sub>s</sub> h[p,s] · Q_rot[s] + D · V[p]</div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">D is the skip scalar — one per head.</div>
+            <div style="font-size:.76rem;color:var(--muted)">SiLU gate (z) applied in Stage 8 at flat shape.</div>
           </div>
         </div>
         <div class="sp-card shape">
@@ -604,14 +694,17 @@ new_h = (alpha[:, :, <span class="kw">None</span>, <span class="kw">None</span>]
             <div class="trow"><span class="tname">y_ssm (after skip)</span><span class="tshape">(1, 8, 64)</span></div>
           </div>
         </div>
-        <div class="sp-card ane-c wide">
-          <h4>ANE Implementation</h4>
-          <pre><code><span class="cm"># h·Q: (1,H,P,S) @ (1,H,S,1) → (1,H,P,1) → squeeze → (1,H,P)</span>
+        <div class="sp-card torch-c wide">
+          <h4>PyTorch ANE</h4>
+          <pre><code><span class="cm"># h·Q_rot: (1,H,P,S) @ (1,H,S,1) → squeeze → (1,H,P)</span>
+<span class="cm"># Q_rot is already (1,H,S) — no squeeze(1) needed (not (1,1,H,S))</span>
 y_ssm = torch.matmul(new_h, Q_rot.unsqueeze(-<span class="num">1</span>)).squeeze(-<span class="num">1</span>)
 
-<span class="cm"># D skip: one scalar per head, broadcast to (1, H, P)</span>
-y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">1</span>, <span class="num">1</span>))</code></pre>
-          <div class="note ok">matmul contracts over S — maps to a native ANE batched GEMM. D.view(1,-1,1) avoids a separate expand() call; ANE handles the implicit broadcast in the multiply.</div>
+<span class="cm"># D skip: scalar per head, broadcast to (1, H, P)</span>
+y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">1</span>, <span class="num">1</span>))
+
+<span class="cm"># Gate (z, pre-SiLU'd in Stage 2) applied flat in Stage 8</span></code></pre>
+          <div class="note ok">matmul contracts over S — native ANE batched GEMM. D.view(1,-1,1) lets ANE handle the broadcast implicitly. SiLU gate is applied at flat (1,512) in Stage 8 for potential MIL fusion with out_proj.</div>
         </div>
       </div>
     </div>
@@ -621,36 +714,34 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
       <div class="sp-header">
         <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">8</div>
         <div><div class="sp-title">out_proj + z gate<span class="sp-tag tag-safe">✓ safe</span></div>
-             <div style="color:var(--muted);font-size:.82rem">reshape → elementwise gate with z (pre-SiLU'd) → nn.Linear</div></div>
+             <div style="color:var(--muted);font-size:.82rem">flatten → gate with pre-SiLU'd z → nn.Linear</div></div>
       </div>
       <div class="sp-grid">
         <div class="sp-card math">
           <h4>Final Projection</h4>
           <div class="math-block">
-            <div class="trow"><span class="ml">y_flat</span><span class="mn">= y_ssm.reshape(1, d_inner)</span></div>
-            <div class="trow"><span class="ml">gated</span><span class="mn">= y_flat · </span><span class="mf">SiLU</span><span class="mn">(z_raw) &nbsp; [= y_flat · z]</span></div>
-            <div class="trow"><span class="ml">out</span><span class="mn">= W<sub>out</sub> · gated &nbsp;(no bias)</span></div>
-            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">z was preactivated in Stage 2: z = silu(z_raw)</div>
-            <div style="font-size:.76rem;color:var(--muted)">Gate is applied at flat (1,512) shape, before out_proj</div>
+            <div class="trow"><span class="ml">out</span><span class="mn">= W<sub>out</sub> · (y_ssm.reshape(1,512) · z)</span></div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">z = silu(z_raw) was computed in Stage 2.</div>
+            <div style="font-size:.76rem;color:var(--muted)">Gate applied at flat (1,512) — no per-head reshape.</div>
+            <div style="font-size:.76rem;color:var(--muted)">States are register_buffers — no explicit returns.</div>
           </div>
         </div>
         <div class="sp-card shape">
           <h4>Tensor Shapes</h4>
           <div class="trows">
-            <div class="trow"><span class="tname">y_ssm</span><span class="tshape">(1, 8, 64)</span></div>
-            <div class="trow"><span class="tname">y_ssm.reshape</span><span class="tshape">(1, 512)</span></div>
-            <div class="trow"><span class="tname">z (from Stage 2)</span><span class="tshape">(1, 512)</span></div>
+            <div class="trow"><span class="tname">y_ssm</span><span class="tshape">(1, 8, 64)</span><span class="tarrow">reshape→</span><span class="tshape">(1, 512)</span></div>
+            <div class="trow"><span class="tname">z (gate)</span><span class="tshape">(1, 512)</span><span class="tarrow">from Stage 2</span></div>
             <div class="trow"><span class="tname">gated</span><span class="tshape">(1, 512)</span></div>
             <div class="trow"><span class="tname">W_out</span><span class="tshape">(256, 512)</span><span class="tarrow">no bias</span></div>
             <div class="trow"><span class="tname">out</span><span class="tshape">(1, 256)</span></div>
           </div>
         </div>
-        <div class="sp-card ane-c wide">
-          <h4>ANE Implementation</h4>
-          <pre><code><span class="cm"># z was F.silu(z_raw) in Stage 2 — shape (1, 512)</span>
-<span class="cm"># Flatten y_ssm and apply gate before linear projection</span>
+        <div class="sp-card torch-c wide">
+          <h4>PyTorch ANE</h4>
+          <pre><code><span class="cm"># z (silu'd in Stage 2) applied flat — no per-head reshape needed</span>
+<span class="cm"># States written via register_buffer[:] — no explicit return of states</span>
 <span class="kw">return</span> self.out_proj(y_ssm.reshape(<span class="num">1</span>, self.d_inner) * z)</code></pre>
-          <div class="note ok">The SiLU gate is at flat (1,512) — avoids a reshape-after-gate. Fusing reshape+mul+linear gives coremltools a better chance to emit a single fused MIL op. No dtype cast needed — all ops stay in the model's native dtype.</div>
+          <div class="note ok">Gate at flat (1,512) gives coremltools a chance to fuse mul+linear into a single MIL op. No dtype cast — stays in model dtype throughout. States live in register_buffers; no tuple return needed.</div>
         </div>
       </div>
     </div>
@@ -663,7 +754,7 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
 <section id="visualizers">
 <div class="container">
   <h2>Interactive Visualizers</h2>
-  <p>Explore the two key mathematical primitives: RoPE rotation (Stage 4) and SSM state update (Stage 6).</p>
+  <p>Explore the two key mathematical primitives being defused from Triton kernels.</p>
 
   <div class="viz-grid">
 
@@ -671,7 +762,7 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
     <div class="viz-card">
       <div class="viz-head">
         <h3>RoPE Pairwise Rotation</h3>
-        <span class="badge pytorch" style="font-size:.7rem">Stage 4 · apply_rope</span>
+        <span class="badge triton" style="font-size:.7rem">Stage 4</span>
       </div>
       <canvas id="ropeCanvas" width="560" height="340"></canvas>
       <div class="viz-controls">
@@ -693,7 +784,7 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
     <div class="viz-card">
       <div class="viz-head">
         <h3>SSM State Update (Outer Product)</h3>
-        <span class="badge state" style="font-size:.7rem">Stage 6 · matmul</span>
+        <span class="badge triton" style="font-size:.7rem">Stage 6</span>
       </div>
       <canvas id="ssmCanvas" width="560" height="340"></canvas>
       <div class="viz-controls">
@@ -719,51 +810,82 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
 </div>
 </section>
 
-<!-- ═══════════════════════════ FULL FORWARD ═══════════════════════════ -->
+<!-- ═══════════════════════════ CODE COMPARE ═══════════════════════════ -->
 <section id="code">
 <div class="container">
-  <h2>Complete forward() + Helpers</h2>
-  <p>Full source of <code>mamba_ane/modules/mamba3.py</code> — MambaBlock.forward() and its helper classes.</p>
+  <h2>Full step() Comparison</h2>
+  <p>Left: original Mamba-3 step() with Triton/CuteDSL kernels. Right: MambaBlock.forward() from mamba_ane/modules/mamba3.py — pure PyTorch, register_buffer states.</p>
 
-  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+  <div class="code-compare">
     <div class="cpanel">
-      <div class="cp-head ane-h">⬡ RMSNormANE — ANE-friendly norm</div>
-      <pre><code><span class="kw">class</span> <span class="cls">RMSNormANE</span>(nn.Module):
-    <span class="cm">"""No .float() casts; x*x replaces pow(2)."""</span>
+      <div class="cp-head triton-h">⚡ Original mamba3.py — step() [Triton + CuteDSL]</div>
+      <pre><code><span class="kw">def</span> <span class="fn">step</span>(self, u, angle_state, ssm_state, k_state, v_state):
+    <span class="cm"># u: (B, d_model=256)</span>
 
-    <span class="kw">def</span> <span class="fn">__init__</span>(self, dim, eps=<span class="num">1e-5</span>):
-        <span class="kw">super</span>().__init__()
-        self.eps    = eps
-        self.weight = nn.Parameter(torch.ones(dim))
+    <span class="cm"># 1. in_proj + split</span>
+    zxBCdt = self.in_proj(u)
+    z, x, B, C, dd_dt, dd_A, trap, angles = \
+        torch.split(zxBCdt, [
+            self.d_inner, self.d_inner,
+            self.d_state * self.num_bc_heads * self.mimo_rank,
+            self.d_state * self.num_bc_heads * self.mimo_rank,
+            self.nheads, self.nheads, self.nheads,
+            self.num_rope_angles], dim=-<span class="num">1</span>)
 
-    <span class="kw">def</span> <span class="fn">forward</span>(self, x):
-        variance = (x * x).mean(-<span class="num">1</span>, keepdim=<span class="kw">True</span>)
-        rms_inv  = torch.rsqrt(variance + self.eps)
-        <span class="kw">return</span> x * rms_inv * self.weight</code></pre>
+    <span class="cm"># 2+3. Activations + KQ norm (calls _preprocess)</span>
+    DT, B, C, x, z, trap, A, angles = \
+        self._preprocess(dd_A, dd_dt, B, C, x, z, trap, angles)
+    <span class="cm"># _preprocess uses: Triton RMSNormGated for B_norm/C_norm</span>
+
+    <span class="cm"># 4. Bias + angle accumulation + RoPE</span>
+    bias_q = rearrange(self.C_bias, <span class="str">"h r n -> r h n"</span>)
+    bias_k = rearrange(self.B_bias, <span class="str">"h r n -> r h n"</span>)
+    rotate_pairwise = <span class="kw">not</span> self.is_mimo  <span class="cm"># True for SISO</span>
+<span class="hl-chg">    C, B, nxt_angle_state = apply_rotary_qk_inference_fwd(
+        q=C, k=B, angle_state=angle_state,
+        angle_proj=angles, dt=DT,
+        bias_q=bias_q, bias_k=bias_k,
+        conjugate=<span class="kw">False</span>, inplace=<span class="kw">False</span>,
+        rotate_pairwise=rotate_pairwise)</span>
+    <span class="cm"># ↑ Triton kernel — NOT portable</span>
+
+    nxt_v_state = x
+    nxt_k_state = B
+
+    <span class="cm"># SISO branch: xpj, zpj, outpj = ones</span>
+    xpj = torch.ones(self.mimo_rank, self.nheads,
+                     self.headdim, device=x.device)
+    zpj = torch.ones_like(xpj)
+    outpj = torch.ones_like(xpj)
+
+    <span class="cm"># 5+6+7. SSM coefficients + state update + output</span>
+    y = torch.empty_like(x)
+<span class="hl-rm">    mamba3_step_fn(
+        ssm_state, k_state, v_state,
+        A, B, C, self.D, x, DT, trap, xpj,
+        outproj=outpj, state_out=<span class="kw">None</span>,
+        out=y, z=z, zproj=zpj,
+        tile_D=<span class="num">64</span>, num_warps=<span class="num">4</span>)</span>
+    <span class="cm"># ↑ CuteDSL kernel — H100 only, NOT portable</span>
+
+    <span class="cm"># 8. out_proj</span>
+    out = rearrange(y, <span class="str">"b h p -> b (h p)"</span>)
+    out = self.out_proj(out.to(x.dtype))
+
+    angle_state.copy_(nxt_angle_state)
+    k_state.copy_(nxt_k_state)
+    v_state.copy_(nxt_v_state)
+
+    <span class="kw">return</span> out, nxt_angle_state, ssm_state, nxt_k_state, nxt_v_state</code></pre>
     </div>
 
     <div class="cpanel">
-      <div class="cp-head ane-h">↻ apply_rope — stateless pairwise rotation</div>
-      <pre><code><span class="kw">def</span> <span class="fn">apply_rope</span>(self, x, cos, sin):
-    <span class="cm">"""x: (1,H,S), cos/sin: (1,H,num_rope_angles)"""</span>
-    x_rot  = x[..., :self.rotary_dim]    <span class="cm"># (1,H,32)</span>
-    x_pass = x[..., self.rotary_dim:]    <span class="cm"># (1,H,32)</span>
-    x0 = x_rot[..., <span class="num">0</span>::<span class="num">2</span>]              <span class="cm"># even (1,H,16)</span>
-    x1 = x_rot[..., <span class="num">1</span>::<span class="num">2</span>]              <span class="cm"># odd  (1,H,16)</span>
-    out_rot = torch.stack(
-        [x0 * cos - x1 * sin,
-         x0 * sin + x1 * cos],
-        dim=-<span class="num">1</span>).flatten(-<span class="num">2</span>)            <span class="cm"># (1,H,32)</span>
-    <span class="kw">return</span> torch.cat([out_rot, x_pass], dim=-<span class="num">1</span>)</code></pre>
-    </div>
-  </div>
-
-  <div style="margin-top:16px;">
-    <div class="cpanel">
-      <div class="cp-head ane-h">◈ MambaBlock.forward() — complete ANE implementation</div>
+      <div class="cp-head torch-h">✓ MambaBlock.forward() — mamba_ane/modules/mamba3.py</div>
       <pre><code><span class="kw">def</span> <span class="fn">forward</span>(self, x):
-    <span class="cm"># ── Stage 1: in_proj + explicit slice ──────────────────────────</span>
-    zxBCdt     = self.in_proj(x)
+    <span class="cm"># x: (1, d_model) — states live in register_buffers</span>
+
+    <span class="cm"># 1. in_proj + explicit slice</span>
+<span class="hl-add">    zxBCdt     = self.in_proj(x)
     z_raw      = zxBCdt[..., :self._s0]
     x_raw      = zxBCdt[..., self._s0:self._s1]
     B_raw      = zxBCdt[..., self._s1:self._s2]
@@ -771,55 +893,51 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
     dd_dt      = zxBCdt[..., self._s3:self._s4]
     dd_A       = zxBCdt[..., self._s4:self._s5]
     trap_raw   = zxBCdt[..., self._s5:self._s6]
-    angles_raw = zxBCdt[..., self._s6:self._s7]
+    angles_raw = zxBCdt[..., self._s6:self._s7]</span>
 
-    <span class="cm"># ── Stage 2: activations ──────────────────────────────────────</span>
-    A   = -(F.softplus(dd_A) + <span class="num">1e-4</span>)
+    <span class="cm"># 2. Activations — no .float() casts</span>
+<span class="hl-add">    A   = -(F.softplus(dd_A) + <span class="num">1e-4</span>)
     DT  = F.softplus(dd_dt + self.dt_bias)
     lam = torch.sigmoid(trap_raw)
-    z   = F.silu(z_raw)
+    z   = F.silu(z_raw)                    <span class="cm"># gate pre-activated</span></span>
 
-    <span class="cm"># ── Stage 3: K/Q RMSNormANE + expand + bias ───────────────────</span>
-    K_norm     = self.B_norm(B_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))
+    <span class="cm"># 3. K/Q RMSNormANE + expand + bias</span>
+<span class="hl-add">    K_norm     = self.B_norm(B_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))
     Q_norm     = self.C_norm(C_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))
-    K_expanded = K_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)
-    Q_expanded = Q_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)
-    K_pre      = K_expanded + self.B_bias                           <span class="cm"># (1, H, S)</span>
-    Q_pre      = Q_expanded + self.C_bias
+    K_pre      = K_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>) + self.B_bias
+    Q_pre      = Q_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>) + self.C_bias</span>
 
-    <span class="cm"># ── Stage 4: RoPE angle accumulation ──────────────────────────</span>
-    angles      = angles_raw.view(<span class="num">1</span>, <span class="num">1</span>, self.num_rope_angles).repeat(<span class="num">1</span>, self.num_heads, <span class="num">1</span>)
+    <span class="cm"># 4. Angle accumulation + RoPE (bias already in K_pre/Q_pre)</span>
+<span class="hl-add">    angles      = angles_raw.view(<span class="num">1</span>, <span class="num">1</span>, self.num_rope_angles).repeat(<span class="num">1</span>, self.num_heads, <span class="num">1</span>)
     delta_theta = torch.tanh(angles) * math.pi * DT.unsqueeze(-<span class="num">1</span>)
     theta       = self.angle_state + delta_theta
     K_rot       = self.apply_rope(K_pre, torch.cos(theta), torch.sin(theta))
-    Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))
+    Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))</span>
 
-    <span class="cm"># ── Stage 5: trapezoid coefficients ───────────────────────────</span>
-    alpha = torch.exp(A * DT)
+    <span class="cm"># 5. Trapezoid coefficients</span>
+<span class="hl-add">    alpha = torch.exp(A * DT)
     beta  = (<span class="num">1.0</span> - lam) * DT * alpha
     gamma = lam * DT
     g4    = gamma[:, :, <span class="kw">None</span>, <span class="kw">None</span>]
-    b4    = beta[:, :,  <span class="kw">None</span>, <span class="kw">None</span>]
+    b4    = beta[:, :,  <span class="kw">None</span>, <span class="kw">None</span>]</span>
 
-    <span class="cm"># ── Stage 6: SSM recurrence + state writes ────────────────────</span>
-    V           = x_raw.reshape(<span class="num">1</span>, self.num_heads, self.headdim)
-    outer_curr  = torch.matmul(V.unsqueeze(-<span class="num">1</span>),
-                               K_rot.unsqueeze(-<span class="num">2</span>))
-    outer_prev  = torch.matmul(self.v_state.unsqueeze(-<span class="num">1</span>),
+    <span class="cm"># 6. SSM recurrence — matmul outer products; state writes</span>
+<span class="hl-add">    V          = x_raw.reshape(<span class="num">1</span>, self.num_heads, self.headdim)
+    outer_curr = torch.matmul(V.unsqueeze(-<span class="num">1</span>), K_rot.unsqueeze(-<span class="num">2</span>))
+    outer_prev = torch.matmul(self.v_state.unsqueeze(-<span class="num">1</span>),
                                self.k_state.squeeze(<span class="num">1</span>).unsqueeze(-<span class="num">2</span>))
-    new_h       = (alpha[:, :, <span class="kw">None</span>, <span class="kw">None</span>] * self.ssm_state
-                   + b4 * outer_prev
-                   + g4 * outer_curr)
+    new_h      = (alpha[:, :, <span class="kw">None</span>, <span class="kw">None</span>] * self.ssm_state
+                  + b4 * outer_prev + g4 * outer_curr)
+    self.ssm_state[:]   = new_h
+    self.k_state[:]     = K_rot.unsqueeze(<span class="num">1</span>)
+    self.v_state[:]     = V
+    self.angle_state[:] = theta</span>
 
-<span class="hl-buf">    self.ssm_state[:]   = new_h</span>
-<span class="hl-buf">    self.k_state[:]     = K_rot.unsqueeze(<span class="num">1</span>)</span>
-<span class="hl-buf">    self.v_state[:]     = V</span>
-<span class="hl-buf">    self.angle_state[:] = theta</span>
-
-    <span class="cm"># ── Stages 7+8: output contraction + D skip + out_proj ────────</span>
-    y_ssm = torch.matmul(new_h, Q_rot.unsqueeze(-<span class="num">1</span>)).squeeze(-<span class="num">1</span>)
+    <span class="cm"># 7+8. Output + D skip + z gate + out_proj</span>
+<span class="hl-add">    y_ssm = torch.matmul(new_h, Q_rot.unsqueeze(-<span class="num">1</span>)).squeeze(-<span class="num">1</span>)
     y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">1</span>, <span class="num">1</span>))
-    <span class="kw">return</span> self.out_proj(y_ssm.reshape(<span class="num">1</span>, self.d_inner) * z)</code></pre>
+    <span class="kw">return</span> self.out_proj(y_ssm.reshape(<span class="num">1</span>, self.d_inner) * z)</span>
+    <span class="cm"># ↑ z gate applied flat; states in buffers — no tuple return</span></code></pre>
     </div>
   </div>
 </div>
@@ -828,28 +946,28 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
 <!-- ═══════════════════════════ SHAPE TABLE ═══════════════════════════ -->
 <section id="shapes">
 <div class="container">
-  <h2>Stateful Buffers — Tensor Reference</h2>
-  <p>All four states are <code>register_buffer()</code> — picked up by <code>ct.StateType</code> during CoreML export. Written in-place via <code>[:]</code> in Stage 6.</p>
+  <h2>Stateful Inference — Tensor Shapes Reference</h2>
+  <p>All four states are <code>register_buffer()</code> — written in-place via <code>[:]</code>; picked up by <code>ct.StateType</code> during CoreML export.</p>
   <table class="shape-table">
-    <thead><tr><th>Buffer / Tensor</th><th>Shape</th><th>Description</th><th>dtype</th><th>Note</th></tr></thead>
+    <thead><tr><th>Tensor</th><th>Shape</th><th>Description</th><th>dtype</th><th>ANE note</th></tr></thead>
     <tbody>
       <tr><td>angle_state</td><td>(1, 8, 16)</td><td>Accumulated RoPE phase θ — NOT wrapped mod 2π</td><td>float32</td><td>register_buffer</td></tr>
-      <tr><td>ssm_state</td><td>(1, 8, 64, 64)</td><td>SSM hidden state h — (B, H, P, S) outer-product matrix</td><td>float32</td><td>register_buffer · 2MB</td></tr>
+      <tr><td>ssm_state</td><td>(1, 8, 64, 64)</td><td>SSM hidden state h — (1, H, P, S) outer product matrix</td><td>float32</td><td>register_buffer · 2MB</td></tr>
       <tr><td>k_state</td><td>(1, 1, 8, 64)</td><td>K_rot from previous step — trapezoid past term</td><td>model dtype</td><td>register_buffer</td></tr>
       <tr><td>v_state</td><td>(1, 8, 64)</td><td>V from previous step — trapezoid past term</td><td>model dtype</td><td>register_buffer</td></tr>
-      <tr><td>x (input)</td><td>(1, 256)</td><td>Token embedding — seqlen=1 inference</td><td>model dtype</td><td>forward() arg</td></tr>
-      <tr><td>out (output)</td><td>(1, 256)</td><td>Output embedding</td><td>model dtype</td><td>return value</td></tr>
-      <tr><td>D (param)</td><td>(8,)</td><td>Skip scalar — one per head, learned</td><td>float32</td><td>nn.Parameter</td></tr>
-      <tr><td>dt_bias (param)</td><td>(8,)</td><td>Δt bias — shifts initialization of time-step scale</td><td>float32</td><td>nn.Parameter</td></tr>
-      <tr><td>B_bias, C_bias</td><td>(1, 8, 64)</td><td>Per-head bias added to K/Q after RMSNorm expand</td><td>float32</td><td>nn.Parameter</td></tr>
+      <tr><td>x (input)</td><td>(1, 256)</td><td>Token embedding at current step — batch fixed at 1</td><td>model dtype</td><td>✓ safe</td></tr>
+      <tr><td>out (output)</td><td>(1, 256)</td><td>Output embedding</td><td>model dtype</td><td>✓ safe</td></tr>
+      <tr><td>D (param)</td><td>(8,)</td><td>Skip scalar — one per head, learned</td><td>float32</td><td>✓ safe</td></tr>
+      <tr><td>dt_bias (param)</td><td>(8,)</td><td>Δt bias — shifts initialization of time-step scale</td><td>float32</td><td>✓ safe</td></tr>
+      <tr><td>B_bias, C_bias</td><td>(1, 8, 64)</td><td>Per-head bias on K/Q — added after RMSNormANE expand</td><td>float32</td><td>✓ safe</td></tr>
     </tbody>
   </table>
 
   <div style="margin-top:24px;">
-    <h4>ANE Compatibility Summary</h4>
-    <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:10px;margin-top:12px;">
+    <h4>ANE Compatibility Checklist</h4>
+    <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(280px,1fr));gap:10px;margin-top:12px;">
       <div style="background:var(--bg-card);border:1px solid rgba(34,197,94,.3);border-radius:8px;padding:14px;">
-        <div style="color:var(--green);font-weight:600;margin-bottom:8px;">✓ Confirmed ANE-safe</div>
+        <div style="color:var(--green);font-weight:600;margin-bottom:8px;">✓ ANE-safe (use as-is)</div>
         <div style="font-size:.8rem;color:var(--muted);line-height:2;">
           nn.Linear (in_proj, out_proj)<br>
           Explicit slice indexing [..., a:b]<br>
@@ -862,24 +980,24 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
         </div>
       </div>
       <div style="background:var(--bg-card);border:1px solid rgba(249,115,22,.3);border-radius:8px;padding:14px;">
-        <div style="color:var(--orange);font-weight:600;margin-bottom:8px;">⚠ Verify in CoreML Perf Report</div>
+        <div style="color:var(--orange);font-weight:600;margin-bottom:8px;">⚠ Verify in CoreML Performance Report</div>
         <div style="font-size:.8rem;color:var(--muted);line-height:2;">
-          RMSNormANE (custom class — verify weight loading)<br>
-          .repeat() on K_norm expand → may fuse or not<br>
-          torch.stack in apply_rope → cat fallback on some firmware<br>
-          ssm_state (1,8,64,64) — 2MB per block, ANE SRAM pressure<br>
-          fp16 accumulation in outer products
+          RMSNormANE (custom — verify weight load)<br>
+          .repeat() for head expand → may or may not fuse<br>
+          torch.stack in apply_rope → cat fallback risk<br>
+          ssm_state (1,8,64,64) — 2MB ANE SRAM pressure<br>
+          fp16 outer product accumulation
         </div>
       </div>
-      <div style="background:var(--bg-card);border:1px solid rgba(96,165,250,.3);border-radius:8px;padding:14px;">
-        <div style="color:var(--blue);font-weight:600;margin-bottom:8px;">✓ Removed from original</div>
+      <div style="background:var(--bg-card);border:1px solid rgba(239,68,68,.3);border-radius:8px;padding:14px;">
+        <div style="color:var(--red);font-weight:600;margin-bottom:8px;">✗ Removed / replaced</div>
         <div style="font-size:.8rem;color:var(--muted);line-height:2;">
           RMSNormGated (Triton import)<br>
           apply_rotary_qk_inference_fwd<br>
           mamba3_step_fn (CuteDSL)<br>
-          mamba3_siso_combined (prefill kernel)<br>
-          Any triton.*, tilelang.*, cute.* import<br>
-          einsum (replaced with matmul+unsqueeze)<br>
+          mamba3_siso_combined (prefill only)<br>
+          torch.einsum (→ matmul+unsqueeze)<br>
+          .float() casts on activations<br>
           inference_params dict
         </div>
       </div>
@@ -890,8 +1008,8 @@ y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">
 
 <footer style="padding:32px 0;border-top:1px solid var(--border);color:var(--dim);font-size:.78rem;">
 <div class="container">
-  Mamba-3 SISO ANE-Native · Config: d_model=256, d_state=64, nheads=8, headdim=64, num_rope_angles=16 · Batch=1 (inference) ·
-  Source: <code>mamba_ane/modules/mamba3.py</code>
+  Mamba-3 SISO ANE Porting Guide · Config: d_model=256, d_state=64, nheads=8, headdim=64, rope_fraction=0.5 ·
+  Original: <code>mamba_ssm/modules/mamba3.py</code> · ANE: <code>mamba_ane/modules/mamba3.py</code>
 </div>
 </footer>
 
@@ -905,7 +1023,10 @@ function showStage(n) {
   document.querySelectorAll('.spanel').forEach(p => p.classList.remove('active'));
   document.querySelectorAll('.pnode').forEach(p => p.classList.remove('active'));
 
-  if (activeStage === n) { activeStage = null; return; }
+  if (activeStage === n) {
+    activeStage = null;
+    return;
+  }
   activeStage = n;
 
   const panel = document.getElementById('sp' + n);
@@ -925,8 +1046,8 @@ const ropeCtx    = ropeCanvas.getContext('2d');
 const W = 560, H = 340;
 
 function drawRope() {
-  const theta      = parseInt(document.getElementById('ropeTheta').value) / 100;
-  const step       = parseInt(document.getElementById('ropeStep').value);
+  const theta   = parseInt(document.getElementById('ropeTheta').value) / 100;
+  const step    = parseInt(document.getElementById('ropeStep').value);
   const cumulTheta = theta + step * 0.4;
 
   document.getElementById('ropeThetaVal').textContent = theta.toFixed(2);
@@ -1004,7 +1125,7 @@ function drawRope() {
 
   ropeCtx.fillStyle = '#e6edf3';
   ropeCtx.font = 'bold 12px monospace';
-  ropeCtx.fillText('apply_rope (Stage 4)', rx, 34);
+  ropeCtx.fillText('Pairwise RoPE (SISO)', rx, 34);
 
   ropeCtx.fillStyle = '#7d8590';
   ropeCtx.font = '11px monospace';
@@ -1129,16 +1250,16 @@ function drawSSM() {
   const green  = v => `rgba(${Math.round(20+v*50)},${Math.round(120+v*80)},${Math.round(60+v*20)},${0.3+v*0.7})`;
 
   const sz = 14;
-  drawMatrix(H_prev,   12, 28, sz, 'α·ssm_state', blue);
-  drawMatrix(op_prev, 190, 28, sz, 'β·outer_prev', orange);
-  drawMatrix(op_curr, 370, 28, sz, 'γ·outer_curr', green);
+  drawMatrix(H_prev,   12, 28, sz, 'α·h_prev', blue);
+  drawMatrix(op_prev, 190, 28, sz, 'β·(V⊗K)_prev', orange);
+  drawMatrix(op_curr, 370, 28, sz, 'γ·(V⊗K)_curr', green);
 
   ssmCtx.fillStyle = '#7d8590';
   ssmCtx.font = 'bold 20px sans-serif';
   ssmCtx.fillText('+', 175, 28 + N*sz/2 + 8);
   ssmCtx.fillText('+', 355, 28 + N*sz/2 + 8);
 
-  drawMatrix(H_new, 185, 210, sz, 'new_h  →  self.ssm_state[:] = new_h', green);
+  drawMatrix(H_new, 185, 210, sz, 'h_new = α·h_prev + β·(V⊗K)_prev + γ·(V⊗K)_curr', green);
 
   ssmCtx.fillStyle = '#e6edf3';
   ssmCtx.font = 'bold 11px monospace';
@@ -1146,9 +1267,9 @@ function drawSSM() {
 
   const ex = 370, ey = 215;
   ssmCtx.fillStyle = '#30363d';
-  ssmCtx.fillRect(ex, ey, 175, 115);
+  ssmCtx.fillRect(ex, ey, 175, 110);
   ssmCtx.strokeStyle = '#3d444d';
-  ssmCtx.strokeRect(ex, ey, 175, 115);
+  ssmCtx.strokeRect(ex, ey, 175, 110);
 
   ssmCtx.fillStyle = '#60a5fa';
   ssmCtx.font = '11px monospace';
@@ -1157,10 +1278,11 @@ function drawSSM() {
   ssmCtx.fillText('β = ' + beta.toFixed(2)  + '  (past weight)', ex+10, ey+42);
   ssmCtx.fillStyle = '#22c55e';
   ssmCtx.fillText('γ = ' + gamma.toFixed(2) + '  (curr weight)', ex+10, ey+62);
+
   ssmCtx.fillStyle = '#484f58';
-  ssmCtx.fillText('Shapes (H=1 shown):', ex+10, ey+82);
+  ssmCtx.fillText('Shapes (B=1,H=1 shown):', ex+10, ey+82);
   ssmCtx.fillStyle = '#7d8590';
-  ssmCtx.fillText('h: (H,P,S)  V⊗K: (H,P,S)', ex+10, ey+98);
+  ssmCtx.fillText('h: (H,P,S) V⊗K: (H,P,S)', ex+10, ey+98);
 }
 
 document.getElementById('alpha').addEventListener('input', drawSSM);

--- a/mamba_ane/docs/mamba3_siso_viz.html
+++ b/mamba_ane/docs/mamba3_siso_viz.html
@@ -1,0 +1,1172 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Mamba-3 SISO — ANE-Native Implementation</title>
+<style>
+:root {
+  --bg: #0d1117; --bg-card: #161b22; --bg-code: #0a0e14;
+  --border: #30363d; --text: #e6edf3; --muted: #7d8590; --dim: #3d444d;
+  --green: #22c55e; --orange: #f97316; --blue: #60a5fa;
+  --purple: #a78bfa; --red: #ef4444; --yellow: #fbbf24;
+  --font: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --mono: 'Cascadia Code', 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+}
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body { font-family: var(--font); background: var(--bg); color: var(--text); font-size: 14px; line-height: 1.6; }
+.container { max-width: 1380px; margin: 0 auto; padding: 0 24px; }
+section { padding: 48px 0; border-bottom: 1px solid var(--border); }
+h1 { font-size: 2rem; font-weight: 700; letter-spacing: -0.02em; }
+h2 { font-size: 1.35rem; font-weight: 600; margin-bottom: 8px; }
+h3 { font-size: 1rem; font-weight: 600; margin-bottom: 10px; }
+h4 { font-size: 0.75rem; font-weight: 600; text-transform: uppercase; letter-spacing: .06em; color: var(--muted); margin-bottom: 10px; }
+p { color: var(--muted); margin-bottom: 10px; line-height: 1.7; }
+code { font-family: var(--mono); font-size: .82em; background: rgba(255,255,255,.05); border: 1px solid var(--border); border-radius: 4px; padding: 1px 5px; }
+pre { font-family: var(--mono); font-size: .78rem; background: var(--bg-code); border: 1px solid var(--border); border-radius: 8px; padding: 16px; overflow-x: auto; line-height: 1.75; }
+pre code { background: none; border: none; padding: 0; font-size: inherit; }
+
+/* ── HERO ── */
+.hero { padding: 40px 0 32px; border-bottom: 1px solid var(--border); }
+.badges { display: flex; gap: 8px; flex-wrap: wrap; margin-bottom: 16px; }
+.badge { display: inline-flex; align-items: center; gap: 5px; padding: 3px 10px; border-radius: 20px; font-size: .72rem; font-weight: 600; border: 1px solid; }
+.badge.pytorch { color: var(--green); border-color: var(--green); background: rgba(34,197,94,.1); }
+.badge.ane { color: var(--blue); border-color: var(--blue); background: rgba(96,165,250,.1); }
+.badge.state { color: var(--purple); border-color: var(--purple); background: rgba(167,139,250,.1); }
+.badge.rmsnorm { color: var(--yellow); border-color: var(--yellow); background: rgba(251,191,36,.1); }
+.subtitle { color: var(--muted); font-size: 1.05rem; margin: 8px 0 28px; }
+.config-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(140px,1fr)); gap: 10px; margin-top: 16px; }
+.cfg { background: var(--bg-card); border: 1px solid var(--border); border-radius: 8px; padding: 10px 14px; }
+.cfg-k { font-family: var(--mono); font-size: .75rem; color: var(--muted); }
+.cfg-v { font-family: var(--mono); font-size: 1.15rem; font-weight: 700; color: var(--blue); margin-top: 3px; }
+.cfg-d { font-size: .7rem; color: var(--dim); margin-top: 2px; }
+
+/* ── PIPELINE ── */
+.pipe-wrap { overflow-x: auto; padding: 8px 0 24px; margin-bottom: 4px; }
+.pipe-svg { min-width: 1100px; display: block; }
+.pnode { cursor: pointer; }
+.pnode rect { transition: filter .18s; }
+.pnode:hover rect { filter: brightness(1.3); }
+.pnode.active rect { filter: brightness(1.5); stroke-width: 2.5 !important; }
+.legend { display: flex; gap: 20px; flex-wrap: wrap; margin-top: 4px; }
+.legend-i { display: flex; align-items: center; gap: 7px; font-size: .75rem; color: var(--muted); }
+.legend-dot { width: 11px; height: 11px; border-radius: 3px; flex-shrink: 0; }
+
+/* ── STAGE PANELS ── */
+.stage-panels { margin-top: 28px; }
+.spanel { display: none; }
+.spanel.active { display: block; animation: fadeUp .2s ease; }
+@keyframes fadeUp { from { opacity:0; transform:translateY(8px); } to { opacity:1; transform:translateY(0); } }
+.sp-header { display: flex; align-items: center; gap: 14px; margin-bottom: 20px; }
+.sp-num { width: 36px; height: 36px; border-radius: 9px; display: flex; align-items: center; justify-content: center; font-weight: 700; font-size: 1rem; flex-shrink: 0; }
+.sp-title { font-size: 1.1rem; font-weight: 600; }
+.sp-tag { display: inline-block; padding: 2px 8px; border-radius: 4px; font-size: .7rem; font-weight: 600; margin-left: 10px; }
+.tag-safe   { background: rgba(34,197,94,.15);   color: var(--green); }
+.tag-buf    { background: rgba(167,139,250,.15);  color: var(--purple); }
+
+.sp-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 14px; }
+@media(max-width:900px){ .sp-grid { grid-template-columns: 1fr; } }
+.sp-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 10px; padding: 18px; }
+.sp-card.math  { border-color: rgba(96,165,250,.35); }
+.sp-card.shape { border-color: rgba(167,139,250,.35); }
+.sp-card.ane-c { border-color: rgba(34,197,94,.35); }
+.sp-card.wide { grid-column: 1 / -1; }
+
+/* tensor shape pills */
+.trows { display: flex; flex-direction: column; gap: 7px; }
+.trow  { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.tname { font-family: var(--mono); font-size: .78rem; color: var(--muted); min-width: 110px; }
+.tshape { font-family: var(--mono); font-size: .78rem; background: rgba(96,165,250,.1); border: 1px solid rgba(96,165,250,.3); color: var(--blue); border-radius: 5px; padding: 1px 8px; }
+.tarrow { color: var(--dim); }
+
+/* math display */
+.math-block { background: rgba(20,30,50,.6); border: 1px solid rgba(96,165,250,.2); border-radius: 7px; padding: 13px 16px; margin: 6px 0; font-family: var(--mono); font-size: .82rem; line-height: 2; }
+.ml { color: var(--yellow); }
+.mf { color: var(--blue); }
+.mv { color: var(--purple); }
+.mn { color: var(--text); }
+
+/* notes */
+.note { border-left: 3px solid; border-radius: 0 7px 7px 0; padding: 10px 14px; margin-top: 10px; font-size: .8rem; color: var(--muted); }
+.note.ok  { border-color: var(--green); background: rgba(34,197,94,.06); }
+.note.warn{ border-color: var(--orange); background: rgba(249,115,22,.06); }
+.note.info{ border-color: var(--blue); background: rgba(96,165,250,.06); }
+
+/* ── VISUALIZERS ── */
+.viz-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; }
+@media(max-width:900px){ .viz-grid { grid-template-columns: 1fr; } }
+.viz-card { background: var(--bg-card); border: 1px solid var(--border); border-radius: 12px; overflow: hidden; }
+.viz-head { padding: 14px 18px; border-bottom: 1px solid var(--border); display: flex; align-items: center; justify-content: space-between; }
+.viz-head h3 { margin: 0; }
+canvas { display: block; background: #070b10; }
+.viz-controls { padding: 12px 18px; border-top: 1px solid var(--border); display: flex; gap: 16px; flex-wrap: wrap; align-items: center; }
+.cg { display: flex; align-items: center; gap: 7px; }
+label { font-size: .78rem; color: var(--muted); white-space: nowrap; }
+input[type=range] { accent-color: var(--blue); width: 80px; cursor: pointer; }
+.vval { font-family: var(--mono); font-size: .78rem; color: var(--blue); min-width: 42px; }
+button { background: rgba(96,165,250,.12); border: 1px solid rgba(96,165,250,.35); color: var(--blue); border-radius: 6px; padding: 5px 13px; font-size: .78rem; cursor: pointer; transition: background .15s; }
+button:hover { background: rgba(96,165,250,.25); }
+
+/* ── CODE PANEL ── */
+.cpanel { border-radius: 10px; overflow: hidden; border: 1px solid var(--border); }
+.cp-head { padding: 10px 16px; font-size: .78rem; font-weight: 600; display: flex; align-items: center; gap: 8px; }
+.cp-head.ane-h { background: rgba(34,197,94,.1); border-bottom: 1px solid rgba(34,197,94,.3); color: var(--green); }
+.cpanel pre { border: none; border-radius: 0; margin: 0; font-size: .75rem; max-height: 820px; overflow-y: auto; }
+
+/* syntax */
+.kw { color: #f97316; } .fn { color: #60a5fa; } .cm { color: #484f58; font-style: italic; }
+.num { color: #fbbf24; } .cls { color: #a78bfa; } .str { color: #86efac; }
+.hl-buf { background: rgba(167,139,250,.1); display: block; }
+.hl-key { background: rgba(34,197,94,.08); display: block; }
+
+/* ── SHAPE TABLE ── */
+.shape-table { width: 100%; border-collapse: collapse; font-size: .83rem; }
+.shape-table th { text-align: left; padding: 9px 14px; border-bottom: 2px solid var(--border); color: var(--muted); font-size: .72rem; text-transform: uppercase; letter-spacing: .05em; }
+.shape-table td { padding: 9px 14px; border-bottom: 1px solid var(--border); font-family: var(--mono); vertical-align: top; }
+.shape-table tr:hover td { background: rgba(255,255,255,.02); }
+.shape-table td:first-child { color: var(--yellow); }
+.shape-table td:nth-child(2) { color: var(--blue); }
+.shape-table td:nth-child(3) { color: var(--muted); font-family: var(--font); font-size: .8rem; }
+</style>
+</head>
+<body>
+
+<!-- ═══════════════════════════ HERO ═══════════════════════════ -->
+<header class="hero">
+<div class="container">
+  <div class="badges">
+    <span class="badge pytorch">✓ Pure PyTorch — all 8 stages</span>
+    <span class="badge ane">🍎 Apple ANE / CoreML target</span>
+    <span class="badge state">◈ register_buffer stateful API</span>
+    <span class="badge rmsnorm">⬡ RMSNormANE — no .float() casts</span>
+  </div>
+  <h1>Mamba-3 SISO — ANE-Native</h1>
+  <p class="subtitle">mamba_ane/modules/mamba3.py — completed ANE implementation, no Triton/CuteDSL kernels</p>
+
+  <h4>Locked Configuration</h4>
+  <div class="config-grid">
+    <div class="cfg"><div class="cfg-k">d_model</div><div class="cfg-v">256</div></div>
+    <div class="cfg"><div class="cfg-k">d_inner</div><div class="cfg-v">512</div><div class="cfg-d">H × headdim</div></div>
+    <div class="cfg"><div class="cfg-k">nheads (H)</div><div class="cfg-v">8</div></div>
+    <div class="cfg"><div class="cfg-k">headdim (P)</div><div class="cfg-v">64</div></div>
+    <div class="cfg"><div class="cfg-k">d_state (S)</div><div class="cfg-v">64</div></div>
+    <div class="cfg"><div class="cfg-k">num_rope_angles</div><div class="cfg-v">16</div></div>
+    <div class="cfg"><div class="cfg-k">rotary_dim</div><div class="cfg-v">32</div><div class="cfg-d">2 × rope_angles</div></div>
+    <div class="cfg"><div class="cfg-k">in_proj out</div><div class="cfg-v">1192</div><div class="cfg-d">512+512+64+64+8+8+8+16</div></div>
+    <div class="cfg"><div class="cfg-k">Batch</div><div class="cfg-v">1</div><div class="cfg-d">inference only</div></div>
+    <div class="cfg"><div class="cfg-k">Stateful</div><div class="cfg-v" style="color:var(--purple)">buf</div><div class="cfg-d">register_buffer</div></div>
+  </div>
+</div>
+</header>
+
+<!-- ═══════════════════════════ PIPELINE ═══════════════════════════ -->
+<section id="pipeline">
+<div class="container">
+  <h2>forward() Pipeline</h2>
+  <p>Seqlen=1 inference. All stages are pure PyTorch — ANE-compatible. Click any stage to see the math, shapes, and implementation.</p>
+
+  <div class="pipe-wrap">
+    <svg class="pipe-svg" viewBox="0 0 1100 130" fill="none" xmlns="http://www.w3.org/2000/svg">
+      <defs><marker id="arr" markerWidth="8" markerHeight="8" refX="6" refY="3" orient="auto"><path d="M0,0 L0,6 L8,3 z" fill="#3d444d"/></marker></defs>
+      <line x1="116" y1="64" x2="132" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="252" y1="64" x2="268" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="388" y1="64" x2="404" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="524" y1="64" x2="540" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="660" y1="64" x2="676" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="796" y1="64" x2="812" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+      <line x1="932" y1="64" x2="948" y2="64" stroke="#3d444d" stroke-width="1.5" marker-end="url(#arr)"/>
+
+      <!-- Stage 1 -->
+      <g class="pnode" data-stage="1" onclick="showStage(1)">
+        <rect x="2" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="59" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 1</text>
+        <text x="59" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">in_proj</text>
+        <text x="59" y="80" text-anchor="middle" fill="#7d8590" font-size="9">+ slice ×8</text>
+        <text x="59" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+      </g>
+
+      <!-- Stage 2 -->
+      <g class="pnode" data-stage="2" onclick="showStage(2)">
+        <rect x="134" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="191" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 2</text>
+        <text x="191" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">Activations</text>
+        <text x="191" y="80" text-anchor="middle" fill="#7d8590" font-size="9">A, Δt, λ, z</text>
+        <text x="191" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+      </g>
+
+      <!-- Stage 3 -->
+      <g class="pnode" data-stage="3" onclick="showStage(3)">
+        <rect x="270" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="327" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 3</text>
+        <text x="327" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">K, Q Norm</text>
+        <text x="327" y="80" text-anchor="middle" fill="#7d8590" font-size="9">RMSNormANE</text>
+        <text x="327" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+      </g>
+
+      <!-- Stage 4 -->
+      <g class="pnode" data-stage="4" onclick="showStage(4)">
+        <rect x="406" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="463" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 4</text>
+        <text x="463" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">RoPE</text>
+        <text x="463" y="80" text-anchor="middle" fill="#7d8590" font-size="9">angle accum + rot</text>
+        <text x="463" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+      </g>
+
+      <!-- Stage 5 -->
+      <g class="pnode" data-stage="5" onclick="showStage(5)">
+        <rect x="542" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="599" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 5</text>
+        <text x="599" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">SSM Coeffs</text>
+        <text x="599" y="80" text-anchor="middle" fill="#7d8590" font-size="9">α, β, γ</text>
+        <text x="599" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+      </g>
+
+      <!-- Stage 6 -->
+      <g class="pnode" data-stage="6" onclick="showStage(6)">
+        <rect x="678" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#a78bfa" stroke-width="1.5"/>
+        <text x="735" y="51" text-anchor="middle" fill="#a78bfa" font-size="9" font-weight="700" font-family="monospace">STAGE 6</text>
+        <text x="735" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">SSM Update</text>
+        <text x="735" y="80" text-anchor="middle" fill="#7d8590" font-size="9">h = αh + Δh</text>
+        <text x="735" y="95" text-anchor="middle" fill="#a78bfa" font-size="8">◈ state write</text>
+      </g>
+
+      <!-- Stage 7 -->
+      <g class="pnode" data-stage="7" onclick="showStage(7)">
+        <rect x="814" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="871" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 7</text>
+        <text x="871" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">Output y</text>
+        <text x="871" y="80" text-anchor="middle" fill="#7d8590" font-size="9">h·Q + D·V</text>
+        <text x="871" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+      </g>
+
+      <!-- Stage 8 -->
+      <g class="pnode" data-stage="8" onclick="showStage(8)">
+        <rect x="950" y="24" width="114" height="80" rx="8" fill="#0f1e14" stroke="#22c55e" stroke-width="1.5"/>
+        <text x="1007" y="51" text-anchor="middle" fill="#22c55e" font-size="9" font-weight="700" font-family="monospace">STAGE 8</text>
+        <text x="1007" y="66" text-anchor="middle" fill="#e6edf3" font-size="10" font-weight="600">out_proj</text>
+        <text x="1007" y="80" text-anchor="middle" fill="#7d8590" font-size="9">Linear + z gate</text>
+        <text x="1007" y="95" text-anchor="middle" fill="#22c55e" font-size="8">✓ safe</text>
+      </g>
+
+      <!-- State buffer annotations -->
+      <text x="735" y="14" text-anchor="middle" fill="#a78bfa" font-size="8">ssm_state · k_state · v_state · angle_state</text>
+      <line x1="735" y1="16" x2="735" y2="24" stroke="#a78bfa" stroke-width="1" marker-end="url(#arr)"/>
+    </svg>
+  </div>
+
+  <div class="legend">
+    <div class="legend-i"><div class="legend-dot" style="background:#22c55e"></div>ANE-safe (nn.Linear, F.softplus, torch.matmul…)</div>
+    <div class="legend-i"><div class="legend-dot" style="background:#a78bfa"></div>register_buffer state write (in-place [:] update)</div>
+  </div>
+
+  <!-- ── STAGE PANELS ── -->
+  <div class="stage-panels">
+
+    <!-- STAGE 1 -->
+    <div class="spanel" id="sp1">
+      <div class="sp-header">
+        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">1</div>
+        <div><div class="sp-title">in_proj + explicit slicing<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">nn.Linear with pre-computed boundary indices _s0…_s7</div></div>
+      </div>
+      <div class="sp-grid">
+        <div class="sp-card math">
+          <h4>Operation</h4>
+          <div class="math-block">
+            <div class="trow"><span class="ml">zxBCdt</span><span class="mn">= in_proj(x) &nbsp; [256→1192]</span></div>
+            <div style="margin-top:8px;font-size:.75rem;color:var(--muted)">Sliced via pre-computed boundaries:</div>
+            <div class="trow" style="margin-top:4px"><span class="ml">z_raw</span><span class="mn">: [0 : 512] &nbsp;←&nbsp; gate</span></div>
+            <div class="trow"><span class="ml">x_raw</span><span class="mn">: [512:1024] ←&nbsp; values (V)</span></div>
+            <div class="trow"><span class="ml">B_raw</span><span class="mn">: [1024:1088] ←&nbsp; keys (K)</span></div>
+            <div class="trow"><span class="ml">C_raw</span><span class="mn">: [1088:1152] ←&nbsp; queries (Q)</span></div>
+            <div class="trow"><span class="ml">dd_dt</span><span class="mn">: [1152:1160] ←&nbsp; Δt̂</span></div>
+            <div class="trow"><span class="ml">dd_A</span><span class="mn">: [1160:1168] ←&nbsp; Â</span></div>
+            <div class="trow"><span class="ml">trap_raw</span><span class="mn">: [1168:1176] ←&nbsp; trap</span></div>
+            <div class="trow"><span class="ml">angles_raw</span><span class="mn">: [1176:1192] ←&nbsp; RoPE Δθ</span></div>
+          </div>
+        </div>
+        <div class="sp-card shape">
+          <h4>Tensor Shapes</h4>
+          <div class="trows">
+            <div class="trow"><span class="tname">x (input)</span><span class="tshape">(1, 256)</span></div>
+            <div class="trow"><span class="tname">zxBCdt</span><span class="tshape">(1, 1192)</span></div>
+            <div style="margin-top:8px"></div>
+            <div class="trow"><span class="tname">z_raw, x_raw</span><span class="tshape">(1, 512)</span></div>
+            <div class="trow"><span class="tname">B_raw, C_raw</span><span class="tshape">(1, 64)</span></div>
+            <div class="trow"><span class="tname">dd_dt, dd_A, trap_raw</span><span class="tshape">(1, 8)</span></div>
+            <div class="trow"><span class="tname">angles_raw</span><span class="tshape">(1, 16)</span></div>
+          </div>
+        </div>
+        <div class="sp-card ane-c wide">
+          <h4>ANE Implementation</h4>
+          <pre><code><span class="cm"># Slice boundaries are precomputed in __init__ to avoid recomputing</span>
+<span class="cm"># _s0=512, _s1=1024, _s2=1088, _s3=1152, _s4=1160, _s5=1168, _s6=1176, _s7=1192</span>
+zxBCdt     = self.in_proj(x)
+z_raw      = zxBCdt[..., :self._s0]
+x_raw      = zxBCdt[..., self._s0:self._s1]
+B_raw      = zxBCdt[..., self._s1:self._s2]
+C_raw      = zxBCdt[..., self._s2:self._s3]
+dd_dt      = zxBCdt[..., self._s3:self._s4]
+dd_A       = zxBCdt[..., self._s4:self._s5]
+trap_raw   = zxBCdt[..., self._s5:self._s6]
+angles_raw = zxBCdt[..., self._s6:self._s7]</code></pre>
+          <div class="note ok">Explicit slice notation over torch.split — produces smaller CoreML MIL graphs with fewer split ops. nn.Linear converts 1:1 to a CoreML linear op.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- STAGE 2 -->
+    <div class="spanel" id="sp2">
+      <div class="sp-header">
+        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">2</div>
+        <div><div class="sp-title">Activations + dt_bias + SiLU gate<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">softplus, sigmoid, silu — all CoreML mlprogram ops</div></div>
+      </div>
+      <div class="sp-grid">
+        <div class="sp-card math">
+          <h4>Equations (per-head scalars)</h4>
+          <div class="math-block">
+            <div class="trow"><span class="ml">A<sub>h</sub></span><span class="mn">= −(</span><span class="mf">softplus</span><span class="mn">(Â<sub>h</sub>) + ε<sub>A</sub>)</span></div>
+            <div class="trow"><span class="ml">Δt<sub>h</sub></span><span class="mn">= </span><span class="mf">softplus</span><span class="mn">(Δt̂<sub>h</sub> + b<sup>Δt</sup><sub>h</sub>)</span></div>
+            <div class="trow"><span class="ml">λ<sub>h</sub></span><span class="mn">= </span><span class="mf">sigmoid</span><span class="mn">(trap<sub>h</sub>)</span></div>
+            <div class="trow"><span class="ml">z</span><span class="mn">= </span><span class="mf">silu</span><span class="mn">(z_raw) &nbsp;←&nbsp; gate precomputed here</span></div>
+            <div style="margin-top:10px;font-size:.75rem;color:var(--muted)">ε<sub>A</sub> = 1e-4 — ensures A is strictly negative</div>
+            <div style="font-size:.75rem;color:var(--muted)">dt_bias: learned per-head, shape (H=8,)</div>
+          </div>
+        </div>
+        <div class="sp-card shape">
+          <h4>Tensor Shapes</h4>
+          <div class="trows">
+            <div class="trow"><span class="tname">dd_A → A</span><span class="tshape">(1, 8)</span><span class="tarrow">negative</span></div>
+            <div class="trow"><span class="tname">dd_dt → DT</span><span class="tshape">(1, 8)</span><span class="tarrow">positive</span></div>
+            <div class="trow"><span class="tname">trap_raw → lam</span><span class="tshape">(1, 8)</span><span class="tarrow">∈ (0,1)</span></div>
+            <div class="trow"><span class="tname">z_raw → z</span><span class="tshape">(1, 512)</span><span class="tarrow">gate</span></div>
+            <div style="margin-top:8px;font-size:.78rem;color:var(--muted)">dt_bias (param): <span class="tshape">(8,)</span></div>
+          </div>
+        </div>
+        <div class="sp-card ane-c wide">
+          <h4>ANE Implementation</h4>
+          <pre><code>A   = -(F.softplus(dd_A) + <span class="num">1e-4</span>)          <span class="cm"># (1, H=8) — strictly negative</span>
+DT  = F.softplus(dd_dt + self.dt_bias)   <span class="cm"># (1, H=8) — strictly positive</span>
+lam = torch.sigmoid(trap_raw)            <span class="cm"># (1, H=8) — trapezoid weight</span>
+z   = F.silu(z_raw)                      <span class="cm"># (1, 512) — gate preactivated here</span></code></pre>
+          <div class="note ok">No .float() casts — ANE runs fp16. The +1e-4 additive floor replaces torch.clamp for CoreML compatibility (clamp with min can inhibit graph fusion).</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- STAGE 3 -->
+    <div class="spanel" id="sp3">
+      <div class="sp-header">
+        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">3</div>
+        <div><div class="sp-title">K, Q — RMSNormANE + head expand + bias<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">RMSNormANE avoids .float() casts and uses x*x instead of pow(2)</div></div>
+      </div>
+      <div class="sp-grid">
+        <div class="sp-card math">
+          <h4>Pipeline</h4>
+          <div class="math-block">
+            <div class="trow"><span class="mv">B_raw</span><span class="mn">: (1, 64)</span></div>
+            <div class="trow" style="padding-left:12px"><span class="mn">→ view(1,1,1,64) → </span><span class="mf">RMSNormANE</span></div>
+            <div class="trow" style="padding-left:12px"><span class="mn">→ repeat(1,1,H,1) → squeeze(1)</span></div>
+            <div class="trow" style="padding-left:12px"><span class="mn">→ + B_bias → </span><span class="mv">K_pre: (1,8,64)</span></div>
+            <div style="margin-top:8px;color:var(--muted);font-size:.76rem">Same for C_raw → Q_pre</div>
+            <div style="margin-top:8px;color:var(--muted);font-size:.76rem">RMSNormANE: var = (x*x).mean(-1), no pow(2)</div>
+            <div style="font-size:.76rem;color:var(--muted)">B_bias/C_bias shape: (1, H, S) — directly addable</div>
+          </div>
+        </div>
+        <div class="sp-card shape">
+          <h4>Tensor Shapes</h4>
+          <div class="trows">
+            <div class="trow"><span class="tname">B_raw, C_raw</span><span class="tshape">(1, 64)</span></div>
+            <div class="trow"><span class="tname">after view</span><span class="tshape">(1, 1, 1, 64)</span></div>
+            <div class="trow"><span class="tname">after RMSNormANE</span><span class="tshape">(1, 1, 1, 64)</span></div>
+            <div class="trow"><span class="tname">after repeat+squeeze</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">B_bias, C_bias (param)</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">K_pre, Q_pre</span><span class="tshape">(1, 8, 64)</span></div>
+          </div>
+        </div>
+        <div class="sp-card ane-c wide">
+          <h4>ANE Implementation</h4>
+          <pre><code><span class="cm"># RMSNormANE (no .float() cast, x*x instead of pow(2))</span>
+<span class="kw">class</span> <span class="cls">RMSNormANE</span>(nn.Module):
+    <span class="kw">def</span> <span class="fn">forward</span>(self, x):
+        variance = (x * x).mean(-<span class="num">1</span>, keepdim=<span class="kw">True</span>)
+        rms_inv  = torch.rsqrt(variance + self.eps)
+        <span class="kw">return</span> x * rms_inv * self.weight
+
+<span class="cm"># Stage 3 in forward()</span>
+K_norm     = self.B_norm(B_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))       <span class="cm"># (1, 1, 1, 64)</span>
+Q_norm     = self.C_norm(C_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))
+K_expanded = K_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)  <span class="cm"># (1, 8, 64)</span>
+Q_expanded = Q_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)
+K_pre      = K_expanded + self.B_bias                                <span class="cm"># (1, 8, 64)</span>
+Q_pre      = Q_expanded + self.C_bias</code></pre>
+          <div class="note ok">RMSNormANE uses x*x (elementwise mul) instead of pow(2) because pow() with a literal exponent can produce a CoreML power op that forces CPU fallback on some ANE firmware versions. rsqrt() maps to a native ANE recip-sqrt op.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- STAGE 4 -->
+    <div class="spanel" id="sp4">
+      <div class="sp-header">
+        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">4</div>
+        <div><div class="sp-title">RoPE — angle accumulation + pairwise rotation<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">Pure PyTorch apply_rope — stateless rotation, no kernel dependency</div></div>
+      </div>
+      <div class="sp-grid">
+        <div class="sp-card math">
+          <h4>Three Operations</h4>
+          <div class="math-block">
+            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">① Expand angles to all heads</div>
+            <div class="trow"><span class="ml">angles</span><span class="mn">= angles_raw.view(1,1,16).repeat(1,H,1)</span></div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">② Angle accumulation (no mod 2π)</div>
+            <div class="trow"><span class="ml">Δθ</span><span class="mn">= </span><span class="mf">tanh</span><span class="mn">(angles) · π · Δt.unsqueeze(-1)</span></div>
+            <div class="trow"><span class="ml">θ</span><span class="mn">= angle_state + Δθ &nbsp; (accumulated)</span></div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">③ Pairwise rotation (first rotary_dim=32 dims)</div>
+            <div class="trow"><span class="ml">[x'<sub>2i</sub>]</span><span class="mn">= cos(θ<sub>i</sub>)·x<sub>2i</sub> − sin(θ<sub>i</sub>)·x<sub>2i+1</sub></span></div>
+            <div class="trow"><span class="ml">[x'<sub>2i+1</sub>]</span><span class="mn">= sin(θ<sub>i</sub>)·x<sub>2i</sub> + cos(θ<sub>i</sub>)·x<sub>2i+1</sub></span></div>
+            <div style="font-size:.76rem;color:var(--muted)">Dims 32–63 pass through unchanged</div>
+          </div>
+        </div>
+        <div class="sp-card shape">
+          <h4>Tensor Shapes</h4>
+          <div class="trows">
+            <div class="trow"><span class="tname">angles_raw</span><span class="tshape">(1, 16)</span></div>
+            <div class="trow"><span class="tname">angles (expanded)</span><span class="tshape">(1, 8, 16)</span></div>
+            <div class="trow"><span class="tname">DT.unsqueeze(-1)</span><span class="tshape">(1, 8, 1)</span></div>
+            <div class="trow"><span class="tname">delta_theta</span><span class="tshape">(1, 8, 16)</span></div>
+            <div class="trow"><span class="tname">angle_state (buf)</span><span class="tshape">(1, 8, 16)</span></div>
+            <div class="trow"><span class="tname">theta (new)</span><span class="tshape">(1, 8, 16)</span></div>
+            <div class="trow"><span class="tname">K_pre, Q_pre</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">K_rot, Q_rot</span><span class="tshape">(1, 8, 64)</span></div>
+            <div style="margin-top:6px;font-size:.76rem;color:var(--muted)">rotary_dim=32: dims [0:32] rotate, [32:64] pass</div>
+          </div>
+        </div>
+        <div class="sp-card ane-c wide">
+          <h4>ANE Implementation</h4>
+          <pre><code><span class="cm"># apply_rope helper — stateless, called for both K and Q</span>
+<span class="kw">def</span> <span class="fn">apply_rope</span>(self, x, cos, sin):
+    <span class="cm"># x: (1, H, S=64), cos/sin: (1, H, 16)</span>
+    x_rot  = x[..., :self.rotary_dim]          <span class="cm"># (1, H, 32)</span>
+    x_pass = x[..., self.rotary_dim:]          <span class="cm"># (1, H, 32)</span>
+    x0 = x_rot[..., <span class="num">0</span>::<span class="num">2</span>]                     <span class="cm"># even dims  (1, H, 16)</span>
+    x1 = x_rot[..., <span class="num">1</span>::<span class="num">2</span>]                     <span class="cm"># odd dims   (1, H, 16)</span>
+    out_rot = torch.stack(
+        [x0 * cos - x1 * sin,
+         x0 * sin + x1 * cos], dim=-<span class="num">1</span>).flatten(-<span class="num">2</span>)  <span class="cm"># (1, H, 32)</span>
+    <span class="kw">return</span> torch.cat([out_rot, x_pass], dim=-<span class="num">1</span>)       <span class="cm"># (1, H, 64)</span>
+
+<span class="cm"># Stage 4 in forward()</span>
+angles      = angles_raw.view(<span class="num">1</span>, <span class="num">1</span>, self.num_rope_angles).repeat(<span class="num">1</span>, self.num_heads, <span class="num">1</span>)
+delta_theta = torch.tanh(angles) * math.pi * DT.unsqueeze(-<span class="num">1</span>)
+theta       = self.angle_state + delta_theta
+K_rot       = self.apply_rope(K_pre, torch.cos(theta), torch.sin(theta))
+Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))</code></pre>
+          <div class="note info">angle_state is a register_buffer — it is written in Stage 6 after the state update block. cos/sin computed per-step from accumulated theta; no precomputed table needed.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- STAGE 5 -->
+    <div class="spanel" id="sp5">
+      <div class="sp-header">
+        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">5</div>
+        <div><div class="sp-title">Trapezoid Discretization Coefficients<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">α, β, γ — computed explicitly from A, DT, λ before the state update</div></div>
+      </div>
+      <div class="sp-grid">
+        <div class="sp-card math">
+          <h4>Trapezoid Discretization</h4>
+          <div class="math-block">
+            <div class="trow"><span class="ml">α<sub>h</sub></span><span class="mn">= exp(A<sub>h</sub> · Δt<sub>h</sub>) &nbsp;←&nbsp; decay</span></div>
+            <div class="trow"><span class="ml">β<sub>h</sub></span><span class="mn">= (1 − λ<sub>h</sub>) · Δt<sub>h</sub> · α<sub>h</sub> &nbsp;←&nbsp; past weight</span></div>
+            <div class="trow"><span class="ml">γ<sub>h</sub></span><span class="mn">= λ<sub>h</sub> · Δt<sub>h</sub> &nbsp;←&nbsp; present weight</span></div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">λ=0 → ZOH (zero-order hold), λ=1 → forward Euler</div>
+            <div style="margin-top:4px;color:var(--muted);font-size:.76rem">Coefficients broadcast to (1,H,1,1) for outer-product dims</div>
+          </div>
+        </div>
+        <div class="sp-card shape">
+          <h4>Tensor Shapes</h4>
+          <div class="trows">
+            <div class="trow"><span class="tname">A</span><span class="tshape">(1, 8)</span><span class="tarrow">negative</span></div>
+            <div class="trow"><span class="tname">DT</span><span class="tshape">(1, 8)</span><span class="tarrow">positive</span></div>
+            <div class="trow"><span class="tname">lam (λ)</span><span class="tshape">(1, 8)</span><span class="tarrow">∈ (0,1)</span></div>
+            <div class="trow"><span class="tname">alpha</span><span class="tshape">(1, 8)</span><span class="tarrow">scalar</span></div>
+            <div class="trow"><span class="tname">g4, b4 (broadcast)</span><span class="tshape">(1, 8, 1, 1)</span></div>
+            <div class="trow"><span class="tname">alpha broadcast</span><span class="tshape">(1, 8, 1, 1)</span></div>
+          </div>
+        </div>
+        <div class="sp-card ane-c wide">
+          <h4>ANE Implementation</h4>
+          <pre><code>alpha = torch.exp(A * DT)                   <span class="cm"># (1, H=8)   — decay factor</span>
+beta  = (<span class="num">1.0</span> - lam) * DT * alpha            <span class="cm"># (1, H=8)   — past weighting</span>
+gamma = lam * DT                             <span class="cm"># (1, H=8)   — present weighting</span>
+
+<span class="cm"># Broadcast to (1, H, 1, 1) for outer-product accumulation</span>
+g4 = gamma[:, :, <span class="kw">None</span>, <span class="kw">None</span>]              <span class="cm"># (1, 8, 1, 1)</span>
+b4 = beta[:, :,  <span class="kw">None</span>, <span class="kw">None</span>]</code></pre>
+          <div class="note ok">torch.exp is ANE-safe. β = (1−λ)·Δt·α reuses alpha — no redundant exp. The [:,:,None,None] broadcast avoids einsum and maps to simple reshape+mul on ANE.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- STAGE 6 -->
+    <div class="spanel" id="sp6">
+      <div class="sp-header">
+        <div class="sp-num" style="background:rgba(167,139,250,.15);color:var(--purple)">6</div>
+        <div><div class="sp-title">SSM Recurrence — matmul outer products + state write<span class="sp-tag tag-buf">◈ state write</span></div>
+             <div style="color:var(--muted);font-size:.82rem">torch.matmul outer products; in-place buffer update via [:]</div></div>
+      </div>
+      <div class="sp-grid">
+        <div class="sp-card math">
+          <h4>Second-Order Recurrence</h4>
+          <div class="math-block">
+            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">Outer products (P×S matrices per head):</div>
+            <div class="trow"><span class="ml">o<sub>prev</sub></span><span class="mn">= v_state ⊗ k_state &nbsp; (prev step)</span></div>
+            <div class="trow"><span class="ml">o<sub>curr</sub></span><span class="mn">= V ⊗ K_rot &nbsp; (current step)</span></div>
+            <div style="margin-top:10px;"><div class="trow"><span class="ml">h</span><span class="mn">= α · ssm_state + β · o<sub>prev</sub> + γ · o<sub>curr</sub></span></div></div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">State write (in-place, CoreML StateType):</div>
+            <div class="trow" style="padding-left:8px"><span class="ml">ssm_state</span><span class="mn">← h</span></div>
+            <div class="trow" style="padding-left:8px"><span class="ml">k_state</span><span class="mn">← K_rot.unsqueeze(1)</span></div>
+            <div class="trow" style="padding-left:8px"><span class="ml">v_state</span><span class="mn">← V</span></div>
+            <div class="trow" style="padding-left:8px"><span class="ml">angle_state</span><span class="mn">← theta</span></div>
+          </div>
+        </div>
+        <div class="sp-card shape">
+          <h4>Tensor Shapes</h4>
+          <div class="trows">
+            <div class="trow"><span class="tname">V (= x_raw reshaped)</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">K_rot</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">ssm_state (buf)</span><span class="tshape">(1, 8, 64, 64)</span></div>
+            <div class="trow"><span class="tname">k_state (buf)</span><span class="tshape">(1, 1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">v_state (buf)</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">V.unsqueeze(-1)</span><span class="tshape">(1, 8, 64, 1)</span></div>
+            <div class="trow"><span class="tname">K_rot.unsqueeze(-2)</span><span class="tshape">(1, 8, 1, 64)</span></div>
+            <div class="trow"><span class="tname">outer_curr, outer_prev</span><span class="tshape">(1, 8, 64, 64)</span></div>
+            <div class="trow"><span class="tname">new_h</span><span class="tshape">(1, 8, 64, 64)</span></div>
+          </div>
+        </div>
+        <div class="sp-card ane-c wide">
+          <h4>ANE Implementation</h4>
+          <pre><code><span class="cm"># Reshape x_raw into (1, H, P) value vectors</span>
+V = x_raw.reshape(<span class="num">1</span>, self.num_heads, self.headdim)   <span class="cm"># (1, 8, 64)</span>
+
+<span class="cm"># Outer products via broadcast matmul (avoids einsum — ANE-safe)</span>
+<span class="cm"># (1,H,P,1) × (1,H,1,S) → (1,H,P,S)</span>
+outer_curr = torch.matmul(V.unsqueeze(-<span class="num">1</span>),
+                           K_rot.unsqueeze(-<span class="num">2</span>))          <span class="cm"># (1, 8, 64, 64)</span>
+outer_prev = torch.matmul(self.v_state.unsqueeze(-<span class="num">1</span>),
+                           self.k_state.squeeze(<span class="num">1</span>).unsqueeze(-<span class="num">2</span>))
+
+<span class="cm"># Trapezoid state update</span>
+new_h = (alpha[:, :, <span class="kw">None</span>, <span class="kw">None</span>] * self.ssm_state
+         + b4 * outer_prev
+         + g4 * outer_curr)                              <span class="cm"># (1, 8, 64, 64)</span>
+
+<span class="cm"># In-place register_buffer writes (CoreML ct.StateType)</span>
+<span class="hl-buf"><span class="kw">self</span>.ssm_state[:]   = new_h</span>
+<span class="hl-buf"><span class="kw">self</span>.k_state[:]     = K_rot.unsqueeze(<span class="num">1</span>)   <span class="cm"># store as (1, 1, 8, 64)</span></span>
+<span class="hl-buf"><span class="kw">self</span>.v_state[:]     = V</span>
+<span class="hl-buf"><span class="kw">self</span>.angle_state[:] = theta</span></code></pre>
+          <div class="note warn">The [:] assignment writes through to the ct.StateType buffer in CoreML — equivalent to copy_() but produces cleaner MIL graph. torch.einsum("bhp,bhs->bhps") is avoided here — matmul with unsqueeze is equivalent and maps reliably to ANE matmul ops.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- STAGE 7 -->
+    <div class="spanel" id="sp7">
+      <div class="sp-header">
+        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">7</div>
+        <div><div class="sp-title">Output contraction + D skip<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">h·Q via matmul + D skip scalar — standard ops</div></div>
+      </div>
+      <div class="sp-grid">
+        <div class="sp-card math">
+          <h4>Output Computation</h4>
+          <div class="math-block">
+            <div style="color:var(--muted);font-size:.76rem;margin-bottom:6px">Contract h (P×S) with Q (S) per head:</div>
+            <div class="trow"><span class="ml">y<sub>h</sub></span><span class="mn">= h<sub>h</sub> · Q_rot<sub>h</sub></span></div>
+            <div style="font-size:.76rem;color:var(--muted);">&nbsp;&nbsp;&nbsp;= Σ<sub>s</sub> h[p,s] · Q_rot[s] &nbsp;→ (1,H,P)</span></div>
+            <div style="margin-top:10px;"><div class="trow"><span class="ml">y_ssm</span><span class="mn">= y + D<sub>h</sub> · V<sub>h</sub></span></div></div>
+            <div style="font-size:.76rem;color:var(--muted);margin-top:4px">D: skip scalar (H,) — one per head, broadcast to (1,H,1)</div>
+          </div>
+        </div>
+        <div class="sp-card shape">
+          <h4>Tensor Shapes</h4>
+          <div class="trows">
+            <div class="trow"><span class="tname">new_h</span><span class="tshape">(1, 8, 64, 64)</span></div>
+            <div class="trow"><span class="tname">Q_rot.unsqueeze(-1)</span><span class="tshape">(1, 8, 64, 1)</span></div>
+            <div class="trow"><span class="tname">matmul result</span><span class="tshape">(1, 8, 64, 1)</span></div>
+            <div class="trow"><span class="tname">y_ssm (squeezed)</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">D.view(1,-1,1)</span><span class="tshape">(1, 8, 1)</span></div>
+            <div class="trow"><span class="tname">y_ssm (after skip)</span><span class="tshape">(1, 8, 64)</span></div>
+          </div>
+        </div>
+        <div class="sp-card ane-c wide">
+          <h4>ANE Implementation</h4>
+          <pre><code><span class="cm"># h·Q: (1,H,P,S) @ (1,H,S,1) → (1,H,P,1) → squeeze → (1,H,P)</span>
+y_ssm = torch.matmul(new_h, Q_rot.unsqueeze(-<span class="num">1</span>)).squeeze(-<span class="num">1</span>)
+
+<span class="cm"># D skip: one scalar per head, broadcast to (1, H, P)</span>
+y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">1</span>, <span class="num">1</span>))</code></pre>
+          <div class="note ok">matmul contracts over S — maps to a native ANE batched GEMM. D.view(1,-1,1) avoids a separate expand() call; ANE handles the implicit broadcast in the multiply.</div>
+        </div>
+      </div>
+    </div>
+
+    <!-- STAGE 8 -->
+    <div class="spanel" id="sp8">
+      <div class="sp-header">
+        <div class="sp-num" style="background:rgba(34,197,94,.15);color:var(--green)">8</div>
+        <div><div class="sp-title">out_proj + z gate<span class="sp-tag tag-safe">✓ safe</span></div>
+             <div style="color:var(--muted);font-size:.82rem">reshape → elementwise gate with z (pre-SiLU'd) → nn.Linear</div></div>
+      </div>
+      <div class="sp-grid">
+        <div class="sp-card math">
+          <h4>Final Projection</h4>
+          <div class="math-block">
+            <div class="trow"><span class="ml">y_flat</span><span class="mn">= y_ssm.reshape(1, d_inner)</span></div>
+            <div class="trow"><span class="ml">gated</span><span class="mn">= y_flat · </span><span class="mf">SiLU</span><span class="mn">(z_raw) &nbsp; [= y_flat · z]</span></div>
+            <div class="trow"><span class="ml">out</span><span class="mn">= W<sub>out</sub> · gated &nbsp;(no bias)</span></div>
+            <div style="margin-top:10px;color:var(--muted);font-size:.76rem">z was preactivated in Stage 2: z = silu(z_raw)</div>
+            <div style="font-size:.76rem;color:var(--muted)">Gate is applied at flat (1,512) shape, before out_proj</div>
+          </div>
+        </div>
+        <div class="sp-card shape">
+          <h4>Tensor Shapes</h4>
+          <div class="trows">
+            <div class="trow"><span class="tname">y_ssm</span><span class="tshape">(1, 8, 64)</span></div>
+            <div class="trow"><span class="tname">y_ssm.reshape</span><span class="tshape">(1, 512)</span></div>
+            <div class="trow"><span class="tname">z (from Stage 2)</span><span class="tshape">(1, 512)</span></div>
+            <div class="trow"><span class="tname">gated</span><span class="tshape">(1, 512)</span></div>
+            <div class="trow"><span class="tname">W_out</span><span class="tshape">(256, 512)</span><span class="tarrow">no bias</span></div>
+            <div class="trow"><span class="tname">out</span><span class="tshape">(1, 256)</span></div>
+          </div>
+        </div>
+        <div class="sp-card ane-c wide">
+          <h4>ANE Implementation</h4>
+          <pre><code><span class="cm"># z was F.silu(z_raw) in Stage 2 — shape (1, 512)</span>
+<span class="cm"># Flatten y_ssm and apply gate before linear projection</span>
+<span class="kw">return</span> self.out_proj(y_ssm.reshape(<span class="num">1</span>, self.d_inner) * z)</code></pre>
+          <div class="note ok">The SiLU gate is at flat (1,512) — avoids a reshape-after-gate. Fusing reshape+mul+linear gives coremltools a better chance to emit a single fused MIL op. No dtype cast needed — all ops stay in the model's native dtype.</div>
+        </div>
+      </div>
+    </div>
+
+  </div><!-- end stage-panels -->
+</div>
+</section>
+
+<!-- ═══════════════════════════ VISUALIZERS ═══════════════════════════ -->
+<section id="visualizers">
+<div class="container">
+  <h2>Interactive Visualizers</h2>
+  <p>Explore the two key mathematical primitives: RoPE rotation (Stage 4) and SSM state update (Stage 6).</p>
+
+  <div class="viz-grid">
+
+    <!-- RoPE Canvas -->
+    <div class="viz-card">
+      <div class="viz-head">
+        <h3>RoPE Pairwise Rotation</h3>
+        <span class="badge pytorch" style="font-size:.7rem">Stage 4 · apply_rope</span>
+      </div>
+      <canvas id="ropeCanvas" width="560" height="340"></canvas>
+      <div class="viz-controls">
+        <div class="cg">
+          <label>θ (rad)</label>
+          <input type="range" id="ropeTheta" min="0" max="628" value="78" step="1">
+          <span class="vval" id="ropeThetaVal">0.78</span>
+        </div>
+        <div class="cg">
+          <label>Step</label>
+          <input type="range" id="ropeStep" min="0" max="20" value="0" step="1">
+          <span class="vval" id="ropeStepVal">0</span>
+        </div>
+        <button onclick="animateRope()">▶ Animate</button>
+      </div>
+    </div>
+
+    <!-- SSM State Canvas -->
+    <div class="viz-card">
+      <div class="viz-head">
+        <h3>SSM State Update (Outer Product)</h3>
+        <span class="badge state" style="font-size:.7rem">Stage 6 · matmul</span>
+      </div>
+      <canvas id="ssmCanvas" width="560" height="340"></canvas>
+      <div class="viz-controls">
+        <div class="cg">
+          <label>α (decay)</label>
+          <input type="range" id="alpha" min="0" max="100" value="85" step="1">
+          <span class="vval" id="alphaVal">0.85</span>
+        </div>
+        <div class="cg">
+          <label>β (past)</label>
+          <input type="range" id="beta" min="0" max="100" value="10" step="1">
+          <span class="vval" id="betaVal">0.10</span>
+        </div>
+        <div class="cg">
+          <label>γ (curr)</label>
+          <input type="range" id="gamma" min="0" max="100" value="40" step="1">
+          <span class="vval" id="gammaVal">0.40</span>
+        </div>
+        <button onclick="drawSSM()">↺ Refresh</button>
+      </div>
+    </div>
+  </div>
+</div>
+</section>
+
+<!-- ═══════════════════════════ FULL FORWARD ═══════════════════════════ -->
+<section id="code">
+<div class="container">
+  <h2>Complete forward() + Helpers</h2>
+  <p>Full source of <code>mamba_ane/modules/mamba3.py</code> — MambaBlock.forward() and its helper classes.</p>
+
+  <div style="display:grid;grid-template-columns:1fr 1fr;gap:16px;">
+    <div class="cpanel">
+      <div class="cp-head ane-h">⬡ RMSNormANE — ANE-friendly norm</div>
+      <pre><code><span class="kw">class</span> <span class="cls">RMSNormANE</span>(nn.Module):
+    <span class="cm">"""No .float() casts; x*x replaces pow(2)."""</span>
+
+    <span class="kw">def</span> <span class="fn">__init__</span>(self, dim, eps=<span class="num">1e-5</span>):
+        <span class="kw">super</span>().__init__()
+        self.eps    = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    <span class="kw">def</span> <span class="fn">forward</span>(self, x):
+        variance = (x * x).mean(-<span class="num">1</span>, keepdim=<span class="kw">True</span>)
+        rms_inv  = torch.rsqrt(variance + self.eps)
+        <span class="kw">return</span> x * rms_inv * self.weight</code></pre>
+    </div>
+
+    <div class="cpanel">
+      <div class="cp-head ane-h">↻ apply_rope — stateless pairwise rotation</div>
+      <pre><code><span class="kw">def</span> <span class="fn">apply_rope</span>(self, x, cos, sin):
+    <span class="cm">"""x: (1,H,S), cos/sin: (1,H,num_rope_angles)"""</span>
+    x_rot  = x[..., :self.rotary_dim]    <span class="cm"># (1,H,32)</span>
+    x_pass = x[..., self.rotary_dim:]    <span class="cm"># (1,H,32)</span>
+    x0 = x_rot[..., <span class="num">0</span>::<span class="num">2</span>]              <span class="cm"># even (1,H,16)</span>
+    x1 = x_rot[..., <span class="num">1</span>::<span class="num">2</span>]              <span class="cm"># odd  (1,H,16)</span>
+    out_rot = torch.stack(
+        [x0 * cos - x1 * sin,
+         x0 * sin + x1 * cos],
+        dim=-<span class="num">1</span>).flatten(-<span class="num">2</span>)            <span class="cm"># (1,H,32)</span>
+    <span class="kw">return</span> torch.cat([out_rot, x_pass], dim=-<span class="num">1</span>)</code></pre>
+    </div>
+  </div>
+
+  <div style="margin-top:16px;">
+    <div class="cpanel">
+      <div class="cp-head ane-h">◈ MambaBlock.forward() — complete ANE implementation</div>
+      <pre><code><span class="kw">def</span> <span class="fn">forward</span>(self, x):
+    <span class="cm"># ── Stage 1: in_proj + explicit slice ──────────────────────────</span>
+    zxBCdt     = self.in_proj(x)
+    z_raw      = zxBCdt[..., :self._s0]
+    x_raw      = zxBCdt[..., self._s0:self._s1]
+    B_raw      = zxBCdt[..., self._s1:self._s2]
+    C_raw      = zxBCdt[..., self._s2:self._s3]
+    dd_dt      = zxBCdt[..., self._s3:self._s4]
+    dd_A       = zxBCdt[..., self._s4:self._s5]
+    trap_raw   = zxBCdt[..., self._s5:self._s6]
+    angles_raw = zxBCdt[..., self._s6:self._s7]
+
+    <span class="cm"># ── Stage 2: activations ──────────────────────────────────────</span>
+    A   = -(F.softplus(dd_A) + <span class="num">1e-4</span>)
+    DT  = F.softplus(dd_dt + self.dt_bias)
+    lam = torch.sigmoid(trap_raw)
+    z   = F.silu(z_raw)
+
+    <span class="cm"># ── Stage 3: K/Q RMSNormANE + expand + bias ───────────────────</span>
+    K_norm     = self.B_norm(B_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))
+    Q_norm     = self.C_norm(C_raw.view(<span class="num">1</span>, <span class="num">1</span>, <span class="num">1</span>, self.d_state))
+    K_expanded = K_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)
+    Q_expanded = Q_norm.repeat(<span class="num">1</span>, <span class="num">1</span>, self.num_heads, <span class="num">1</span>).squeeze(<span class="num">1</span>)
+    K_pre      = K_expanded + self.B_bias                           <span class="cm"># (1, H, S)</span>
+    Q_pre      = Q_expanded + self.C_bias
+
+    <span class="cm"># ── Stage 4: RoPE angle accumulation ──────────────────────────</span>
+    angles      = angles_raw.view(<span class="num">1</span>, <span class="num">1</span>, self.num_rope_angles).repeat(<span class="num">1</span>, self.num_heads, <span class="num">1</span>)
+    delta_theta = torch.tanh(angles) * math.pi * DT.unsqueeze(-<span class="num">1</span>)
+    theta       = self.angle_state + delta_theta
+    K_rot       = self.apply_rope(K_pre, torch.cos(theta), torch.sin(theta))
+    Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))
+
+    <span class="cm"># ── Stage 5: trapezoid coefficients ───────────────────────────</span>
+    alpha = torch.exp(A * DT)
+    beta  = (<span class="num">1.0</span> - lam) * DT * alpha
+    gamma = lam * DT
+    g4    = gamma[:, :, <span class="kw">None</span>, <span class="kw">None</span>]
+    b4    = beta[:, :,  <span class="kw">None</span>, <span class="kw">None</span>]
+
+    <span class="cm"># ── Stage 6: SSM recurrence + state writes ────────────────────</span>
+    V           = x_raw.reshape(<span class="num">1</span>, self.num_heads, self.headdim)
+    outer_curr  = torch.matmul(V.unsqueeze(-<span class="num">1</span>),
+                               K_rot.unsqueeze(-<span class="num">2</span>))
+    outer_prev  = torch.matmul(self.v_state.unsqueeze(-<span class="num">1</span>),
+                               self.k_state.squeeze(<span class="num">1</span>).unsqueeze(-<span class="num">2</span>))
+    new_h       = (alpha[:, :, <span class="kw">None</span>, <span class="kw">None</span>] * self.ssm_state
+                   + b4 * outer_prev
+                   + g4 * outer_curr)
+
+<span class="hl-buf">    self.ssm_state[:]   = new_h</span>
+<span class="hl-buf">    self.k_state[:]     = K_rot.unsqueeze(<span class="num">1</span>)</span>
+<span class="hl-buf">    self.v_state[:]     = V</span>
+<span class="hl-buf">    self.angle_state[:] = theta</span>
+
+    <span class="cm"># ── Stages 7+8: output contraction + D skip + out_proj ────────</span>
+    y_ssm = torch.matmul(new_h, Q_rot.unsqueeze(-<span class="num">1</span>)).squeeze(-<span class="num">1</span>)
+    y_ssm = y_ssm + (V * self.D.view(<span class="num">1</span>, -<span class="num">1</span>, <span class="num">1</span>))
+    <span class="kw">return</span> self.out_proj(y_ssm.reshape(<span class="num">1</span>, self.d_inner) * z)</code></pre>
+    </div>
+  </div>
+</div>
+</section>
+
+<!-- ═══════════════════════════ SHAPE TABLE ═══════════════════════════ -->
+<section id="shapes">
+<div class="container">
+  <h2>Stateful Buffers — Tensor Reference</h2>
+  <p>All four states are <code>register_buffer()</code> — picked up by <code>ct.StateType</code> during CoreML export. Written in-place via <code>[:]</code> in Stage 6.</p>
+  <table class="shape-table">
+    <thead><tr><th>Buffer / Tensor</th><th>Shape</th><th>Description</th><th>dtype</th><th>Note</th></tr></thead>
+    <tbody>
+      <tr><td>angle_state</td><td>(1, 8, 16)</td><td>Accumulated RoPE phase θ — NOT wrapped mod 2π</td><td>float32</td><td>register_buffer</td></tr>
+      <tr><td>ssm_state</td><td>(1, 8, 64, 64)</td><td>SSM hidden state h — (B, H, P, S) outer-product matrix</td><td>float32</td><td>register_buffer · 2MB</td></tr>
+      <tr><td>k_state</td><td>(1, 1, 8, 64)</td><td>K_rot from previous step — trapezoid past term</td><td>model dtype</td><td>register_buffer</td></tr>
+      <tr><td>v_state</td><td>(1, 8, 64)</td><td>V from previous step — trapezoid past term</td><td>model dtype</td><td>register_buffer</td></tr>
+      <tr><td>x (input)</td><td>(1, 256)</td><td>Token embedding — seqlen=1 inference</td><td>model dtype</td><td>forward() arg</td></tr>
+      <tr><td>out (output)</td><td>(1, 256)</td><td>Output embedding</td><td>model dtype</td><td>return value</td></tr>
+      <tr><td>D (param)</td><td>(8,)</td><td>Skip scalar — one per head, learned</td><td>float32</td><td>nn.Parameter</td></tr>
+      <tr><td>dt_bias (param)</td><td>(8,)</td><td>Δt bias — shifts initialization of time-step scale</td><td>float32</td><td>nn.Parameter</td></tr>
+      <tr><td>B_bias, C_bias</td><td>(1, 8, 64)</td><td>Per-head bias added to K/Q after RMSNorm expand</td><td>float32</td><td>nn.Parameter</td></tr>
+    </tbody>
+  </table>
+
+  <div style="margin-top:24px;">
+    <h4>ANE Compatibility Summary</h4>
+    <div style="display:grid;grid-template-columns:repeat(auto-fill,minmax(300px,1fr));gap:10px;margin-top:12px;">
+      <div style="background:var(--bg-card);border:1px solid rgba(34,197,94,.3);border-radius:8px;padding:14px;">
+        <div style="color:var(--green);font-weight:600;margin-bottom:8px;">✓ Confirmed ANE-safe</div>
+        <div style="font-size:.8rem;color:var(--muted);line-height:2;">
+          nn.Linear (in_proj, out_proj)<br>
+          Explicit slice indexing [..., a:b]<br>
+          F.softplus, F.silu, torch.sigmoid<br>
+          torch.exp, torch.tanh<br>
+          torch.cos, torch.sin, torch.rsqrt<br>
+          torch.matmul (batched GEMM)<br>
+          Broadcast multiply, unsqueeze, reshape<br>
+          register_buffer [:] state write
+        </div>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid rgba(249,115,22,.3);border-radius:8px;padding:14px;">
+        <div style="color:var(--orange);font-weight:600;margin-bottom:8px;">⚠ Verify in CoreML Perf Report</div>
+        <div style="font-size:.8rem;color:var(--muted);line-height:2;">
+          RMSNormANE (custom class — verify weight loading)<br>
+          .repeat() on K_norm expand → may fuse or not<br>
+          torch.stack in apply_rope → cat fallback on some firmware<br>
+          ssm_state (1,8,64,64) — 2MB per block, ANE SRAM pressure<br>
+          fp16 accumulation in outer products
+        </div>
+      </div>
+      <div style="background:var(--bg-card);border:1px solid rgba(96,165,250,.3);border-radius:8px;padding:14px;">
+        <div style="color:var(--blue);font-weight:600;margin-bottom:8px;">✓ Removed from original</div>
+        <div style="font-size:.8rem;color:var(--muted);line-height:2;">
+          RMSNormGated (Triton import)<br>
+          apply_rotary_qk_inference_fwd<br>
+          mamba3_step_fn (CuteDSL)<br>
+          mamba3_siso_combined (prefill kernel)<br>
+          Any triton.*, tilelang.*, cute.* import<br>
+          einsum (replaced with matmul+unsqueeze)<br>
+          inference_params dict
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+</section>
+
+<footer style="padding:32px 0;border-top:1px solid var(--border);color:var(--dim);font-size:.78rem;">
+<div class="container">
+  Mamba-3 SISO ANE-Native · Config: d_model=256, d_state=64, nheads=8, headdim=64, num_rope_angles=16 · Batch=1 (inference) ·
+  Source: <code>mamba_ane/modules/mamba3.py</code>
+</div>
+</footer>
+
+<script>
+/* ═══════════════════════════════════════
+   PIPELINE: stage click handler
+═══════════════════════════════════════ */
+let activeStage = null;
+
+function showStage(n) {
+  document.querySelectorAll('.spanel').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('.pnode').forEach(p => p.classList.remove('active'));
+
+  if (activeStage === n) { activeStage = null; return; }
+  activeStage = n;
+
+  const panel = document.getElementById('sp' + n);
+  const node  = document.querySelector('[data-stage="' + n + '"]');
+  if (panel) panel.classList.add('active');
+  if (node)  node.classList.add('active');
+  if (panel) setTimeout(() => panel.scrollIntoView({behavior:'smooth', block:'nearest'}), 50);
+}
+
+showStage(1);
+
+/* ═══════════════════════════════════════
+   ROPE CANVAS
+═══════════════════════════════════════ */
+const ropeCanvas = document.getElementById('ropeCanvas');
+const ropeCtx    = ropeCanvas.getContext('2d');
+const W = 560, H = 340;
+
+function drawRope() {
+  const theta      = parseInt(document.getElementById('ropeTheta').value) / 100;
+  const step       = parseInt(document.getElementById('ropeStep').value);
+  const cumulTheta = theta + step * 0.4;
+
+  document.getElementById('ropeThetaVal').textContent = theta.toFixed(2);
+  document.getElementById('ropeStepVal').textContent  = step;
+
+  ropeCtx.clearRect(0, 0, W, H);
+  ropeCtx.fillStyle = '#070b10';
+  ropeCtx.fillRect(0, 0, W, H);
+
+  const cx = 160, cy = H/2, r = 110;
+  const cos = Math.cos(cumulTheta), sin = Math.sin(cumulTheta);
+
+  ropeCtx.strokeStyle = '#1a2030';
+  ropeCtx.lineWidth = 1;
+  for (let i = -4; i <= 4; i++) {
+    ropeCtx.beginPath(); ropeCtx.moveTo(cx + i*30, cy-120); ropeCtx.lineTo(cx + i*30, cy+120); ropeCtx.stroke();
+    ropeCtx.beginPath(); ropeCtx.moveTo(cx-130, cy + i*30); ropeCtx.lineTo(cx+130, cy + i*30); ropeCtx.stroke();
+  }
+
+  ropeCtx.strokeStyle = '#30363d';
+  ropeCtx.lineWidth = 1.5;
+  ropeCtx.beginPath();
+  ropeCtx.arc(cx, cy, r, 0, Math.PI*2);
+  ropeCtx.stroke();
+
+  ropeCtx.strokeStyle = '#3d444d';
+  ropeCtx.lineWidth = 1.5;
+  ropeCtx.beginPath(); ropeCtx.moveTo(cx-130, cy); ropeCtx.lineTo(cx+130, cy); ropeCtx.stroke();
+  ropeCtx.beginPath(); ropeCtx.moveTo(cx, cy-130); ropeCtx.lineTo(cx, cy+130); ropeCtx.stroke();
+
+  const x0 = r, x1 = 0;
+  ropeCtx.strokeStyle = '#3d6699';
+  ropeCtx.lineWidth = 2;
+  ropeCtx.setLineDash([5, 3]);
+  ropeCtx.beginPath();
+  ropeCtx.moveTo(cx, cy);
+  ropeCtx.lineTo(cx + x0, cy - x1);
+  ropeCtx.stroke();
+  ropeCtx.setLineDash([]);
+  ropeCtx.fillStyle = '#60a5fa80';
+  ropeCtx.beginPath(); ropeCtx.arc(cx + x0, cy - x1, 5, 0, Math.PI*2); ropeCtx.fill();
+
+  const x0r = x0 * cos - x1 * sin;
+  const x1r = x0 * sin + x1 * cos;
+  ropeCtx.strokeStyle = '#22c55e';
+  ropeCtx.lineWidth = 2.5;
+  ropeCtx.beginPath();
+  ropeCtx.moveTo(cx, cy);
+  ropeCtx.lineTo(cx + x0r, cy - x1r);
+  ropeCtx.stroke();
+  const ang2 = Math.atan2(-x1r, x0r);
+  ropeCtx.fillStyle = '#22c55e';
+  ropeCtx.beginPath();
+  ropeCtx.moveTo(cx + x0r, cy - x1r);
+  ropeCtx.lineTo(cx + x0r - 12*Math.cos(ang2-0.4), cy - x1r + 12*Math.sin(ang2-0.4));
+  ropeCtx.lineTo(cx + x0r - 12*Math.cos(ang2+0.4), cy - x1r + 12*Math.sin(ang2+0.4));
+  ropeCtx.closePath(); ropeCtx.fill();
+
+  ropeCtx.strokeStyle = '#f97316';
+  ropeCtx.lineWidth = 1.5;
+  ropeCtx.beginPath();
+  ropeCtx.arc(cx, cy, 35, -cumulTheta, 0);
+  ropeCtx.stroke();
+
+  ropeCtx.fillStyle = '#f97316';
+  ropeCtx.font = '13px monospace';
+  const labelAng = -cumulTheta / 2;
+  ropeCtx.fillText('θ=' + cumulTheta.toFixed(2), cx + 42*Math.cos(labelAng)-16, cy + 42*Math.sin(labelAng)+4);
+
+  const rx = 340;
+  ropeCtx.fillStyle = '#3d444d';
+  ropeCtx.fillRect(rx - 10, 10, 220, 320);
+  ropeCtx.strokeStyle = '#30363d';
+  ropeCtx.strokeRect(rx - 10, 10, 220, 320);
+
+  ropeCtx.fillStyle = '#e6edf3';
+  ropeCtx.font = 'bold 12px monospace';
+  ropeCtx.fillText('apply_rope (Stage 4)', rx, 34);
+
+  ropeCtx.fillStyle = '#7d8590';
+  ropeCtx.font = '11px monospace';
+  ropeCtx.fillText('Per pair (x₂ᵢ, x₂ᵢ₊₁):', rx, 58);
+
+  ropeCtx.fillStyle = '#60a5fa';
+  ropeCtx.font = '11px monospace';
+  ropeCtx.fillText('x\'₂ᵢ   = x₂ᵢ·cos(θᵢ)', rx, 78);
+  ropeCtx.fillText('          − x₂ᵢ₊₁·sin(θᵢ)', rx, 94);
+  ropeCtx.fillStyle = '#22c55e';
+  ropeCtx.fillText('x\'₂ᵢ₊₁ = x₂ᵢ·sin(θᵢ)', rx, 114);
+  ropeCtx.fillText('          + x₂ᵢ₊₁·cos(θᵢ)', rx, 130);
+
+  ropeCtx.fillStyle = '#7d8590';
+  ropeCtx.fillText('Angle accumulation:', rx, 158);
+  ropeCtx.fillStyle = '#f97316';
+  ropeCtx.fillText('Δθ = tanh(ang)·π·Δt', rx, 176);
+  ropeCtx.fillText('θ  = angle_state + Δθ', rx, 192);
+
+  ropeCtx.fillStyle = '#7d8590';
+  ropeCtx.fillText('Scope: dims [0:32] of S=64', rx, 218);
+  ropeCtx.fillText('Dims [32:64]: pass-through', rx, 234);
+  ropeCtx.fillText('16 angles → 16 pairs', rx, 250);
+
+  ropeCtx.fillStyle = '#484f58';
+  ropeCtx.fillText('─────────────────', rx, 270);
+  ropeCtx.fillStyle = '#7d8590';
+  ropeCtx.fillText('Current θ: ' + cumulTheta.toFixed(3) + ' rad', rx, 288);
+  ropeCtx.fillText('Step: ' + step, rx, 304);
+
+  ropeCtx.fillStyle = '#3d6699'; ropeCtx.beginPath(); ropeCtx.arc(rx-2, 321, 4, 0, Math.PI*2); ropeCtx.fill();
+  ropeCtx.fillStyle = '#7d8590'; ropeCtx.font = '10px monospace'; ropeCtx.fillText(' original (x₀, x₁)', rx+4, 325);
+}
+
+let ropeAnim = null;
+function animateRope() {
+  if (ropeAnim) { cancelAnimationFrame(ropeAnim); ropeAnim = null; return; }
+  let step = 0;
+  function frame() {
+    document.getElementById('ropeTheta').value = (step * 31) % 628;
+    document.getElementById('ropeStep').value  = step % 21;
+    drawRope();
+    step++;
+    ropeAnim = requestAnimationFrame(frame);
+  }
+  frame();
+}
+
+document.getElementById('ropeTheta').addEventListener('input', drawRope);
+document.getElementById('ropeStep').addEventListener('input', drawRope);
+drawRope();
+
+/* ═══════════════════════════════════════
+   SSM CANVAS
+═══════════════════════════════════════ */
+const ssmCanvas = document.getElementById('ssmCanvas');
+const ssmCtx    = ssmCanvas.getContext('2d');
+
+function makeVec(n, seed) {
+  const v = [];
+  for (let i = 0; i < n; i++) v.push(Math.sin(seed * 2.3 + i * 0.7) * 0.5 + 0.5);
+  return v;
+}
+
+function drawSSM() {
+  const alpha = parseInt(document.getElementById('alpha').value) / 100;
+  const beta  = parseInt(document.getElementById('beta').value) / 100;
+  const gamma = parseInt(document.getElementById('gamma').value) / 100;
+
+  document.getElementById('alphaVal').textContent = alpha.toFixed(2);
+  document.getElementById('betaVal').textContent  = beta.toFixed(2);
+  document.getElementById('gammaVal').textContent = gamma.toFixed(2);
+
+  ssmCtx.clearRect(0, 0, W, H);
+  ssmCtx.fillStyle = '#070b10';
+  ssmCtx.fillRect(0, 0, W, H);
+
+  const N = 12;
+  const V_prev = makeVec(N, 1.1);
+  const K_prev = makeVec(N, 2.3);
+  const V_curr = makeVec(N, 3.7);
+  const K_curr = makeVec(N, 5.1);
+
+  const H_prev = [];
+  for (let i = 0; i < N; i++) {
+    H_prev.push([]);
+    for (let j = 0; j < N; j++)
+      H_prev[i].push(Math.abs(Math.sin(i * 1.3 + j * 0.9)) * 0.8);
+  }
+
+  const op_prev = [], op_curr = [];
+  for (let i = 0; i < N; i++) {
+    op_prev.push([]); op_curr.push([]);
+    for (let j = 0; j < N; j++) {
+      op_prev[i].push(V_prev[i] * K_prev[j]);
+      op_curr[i].push(V_curr[i] * K_curr[j]);
+    }
+  }
+
+  const H_new = [];
+  for (let i = 0; i < N; i++) {
+    H_new.push([]);
+    for (let j = 0; j < N; j++)
+      H_new[i].push(alpha * H_prev[i][j] + beta * op_prev[i][j] + gamma * op_curr[i][j]);
+  }
+
+  function drawMatrix(mx, x0, y0, sz, title, colorFn) {
+    ssmCtx.fillStyle = '#7d8590';
+    ssmCtx.font = '10px monospace';
+    ssmCtx.fillText(title, x0, y0 - 6);
+    for (let i = 0; i < N; i++) {
+      for (let j = 0; j < N; j++) {
+        const v = Math.min(1, Math.max(0, mx[i][j]));
+        ssmCtx.fillStyle = colorFn(v);
+        ssmCtx.fillRect(x0 + j*sz, y0 + i*sz, sz-1, sz-1);
+      }
+    }
+  }
+
+  const blue   = v => `rgba(${Math.round(30+v*70)},${Math.round(80+v*120)},${Math.round(200+v*55)},${0.3+v*0.7})`;
+  const orange = v => `rgba(${Math.round(150+v*100)},${Math.round(60+v*80)},${Math.round(20)},${0.3+v*0.7})`;
+  const green  = v => `rgba(${Math.round(20+v*50)},${Math.round(120+v*80)},${Math.round(60+v*20)},${0.3+v*0.7})`;
+
+  const sz = 14;
+  drawMatrix(H_prev,   12, 28, sz, 'α·ssm_state', blue);
+  drawMatrix(op_prev, 190, 28, sz, 'β·outer_prev', orange);
+  drawMatrix(op_curr, 370, 28, sz, 'γ·outer_curr', green);
+
+  ssmCtx.fillStyle = '#7d8590';
+  ssmCtx.font = 'bold 20px sans-serif';
+  ssmCtx.fillText('+', 175, 28 + N*sz/2 + 8);
+  ssmCtx.fillText('+', 355, 28 + N*sz/2 + 8);
+
+  drawMatrix(H_new, 185, 210, sz, 'new_h  →  self.ssm_state[:] = new_h', green);
+
+  ssmCtx.fillStyle = '#e6edf3';
+  ssmCtx.font = 'bold 11px monospace';
+  ssmCtx.fillText('=', 170, 210 + N*sz/2 + 8);
+
+  const ex = 370, ey = 215;
+  ssmCtx.fillStyle = '#30363d';
+  ssmCtx.fillRect(ex, ey, 175, 115);
+  ssmCtx.strokeStyle = '#3d444d';
+  ssmCtx.strokeRect(ex, ey, 175, 115);
+
+  ssmCtx.fillStyle = '#60a5fa';
+  ssmCtx.font = '11px monospace';
+  ssmCtx.fillText('α = ' + alpha.toFixed(2) + '  (decay)', ex+10, ey+22);
+  ssmCtx.fillStyle = '#f97316';
+  ssmCtx.fillText('β = ' + beta.toFixed(2)  + '  (past weight)', ex+10, ey+42);
+  ssmCtx.fillStyle = '#22c55e';
+  ssmCtx.fillText('γ = ' + gamma.toFixed(2) + '  (curr weight)', ex+10, ey+62);
+  ssmCtx.fillStyle = '#484f58';
+  ssmCtx.fillText('Shapes (H=1 shown):', ex+10, ey+82);
+  ssmCtx.fillStyle = '#7d8590';
+  ssmCtx.fillText('h: (H,P,S)  V⊗K: (H,P,S)', ex+10, ey+98);
+}
+
+document.getElementById('alpha').addEventListener('input', drawSSM);
+document.getElementById('beta').addEventListener('input', drawSSM);
+document.getElementById('gamma').addEventListener('input', drawSSM);
+drawSSM();
+</script>
+</body>
+</html>

--- a/mamba_ane/models/__init__.py
+++ b/mamba_ane/models/__init__.py
@@ -1,0 +1,3 @@
+from mamba_ane.models.hybrid1d import Hybrid1DBackbone, StatefulMambaHybrid1D
+
+__all__ = ["Hybrid1DBackbone", "StatefulMambaHybrid1D"]

--- a/mamba_ane/models/__init__.py
+++ b/mamba_ane/models/__init__.py
@@ -1,3 +1,7 @@
 from mamba_ane.models.hybrid1d import Hybrid1DBackbone, StatefulMambaHybrid1D
+from mamba_ane.models.hybrid_parallel import ParallelHybridBackbone, StatefulMambaParallelHybrid
 
-__all__ = ["Hybrid1DBackbone", "StatefulMambaHybrid1D"]
+__all__ = [
+    "Hybrid1DBackbone", "StatefulMambaHybrid1D",
+    "ParallelHybridBackbone", "StatefulMambaParallelHybrid",
+]

--- a/mamba_ane/models/hybrid1d.py
+++ b/mamba_ane/models/hybrid1d.py
@@ -1,0 +1,114 @@
+"""
+mamba_ane/models/hybrid1d.py — Hybrid1D models combining Conv1D backbone with MambaBlock.
+"""
+
+import torch
+import torch.nn as nn
+from mamba_ane.modules.mamba3 import MambaBlock
+
+
+class Hybrid1DBackbone(nn.Module):
+    """
+    Conv1D feature extraction → Linear projection. SiLU activations only.
+
+    Two stride-2 Conv1D layers reduce seq_length by 4x, then two Linear
+    layers project to output_dim.
+    """
+
+    def __init__(
+        self,
+        in_channels: int = 3,
+        hidden_dim: int = 256,
+        output_dim: int = 512,
+        seq_length: int = 224,
+    ):
+        super().__init__()
+        self.seq_length = seq_length
+        self.conv1 = nn.Conv1d(in_channels, hidden_dim, kernel_size=5, stride=2, padding=2, bias=True)
+        self.silu1 = nn.SiLU(inplace=True)
+        self.conv2 = nn.Conv1d(hidden_dim, hidden_dim * 2, kernel_size=5, stride=2, padding=2, bias=True)
+        self.silu2 = nn.SiLU(inplace=True)
+        conv_out_length = seq_length // 4
+        self.fc1   = nn.Linear(hidden_dim * 2 * conv_out_length, hidden_dim * 2)
+        self.silu3 = nn.SiLU(inplace=True)
+        self.fc2   = nn.Linear(hidden_dim * 2, output_dim)
+        self.silu4 = nn.SiLU(inplace=True)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """x: (B, in_channels, seq_length) -> (B, output_dim)"""
+        x = self.silu1(self.conv1(x))
+        x = self.silu2(self.conv2(x))
+        x = x.flatten(1)
+        x = self.silu3(self.fc1(x))
+        return self.silu4(self.fc2(x))
+
+
+class StatefulMambaHybrid1D(nn.Module):
+    """
+    Hybrid1DBackbone -> MambaBlock -> Classifier.
+
+    State buffers (angle_state, ssm_state, k_state, v_state inside MambaBlock)
+    persist across inferences via ct.StateType in CoreML export.
+    """
+
+    def __init__(
+        self,
+        num_classes: int = 1000,
+        backbone_in_channels: int = 3,
+        backbone_hidden_dim: int = 256,
+        backbone_output_dim: int = 512,
+        seq_length: int = 224,
+        ema_alpha: float = 0.1,
+        mamba_d_state: int = 64,
+        mamba_headdim: int = 64,
+        mamba_num_heads: int = 8,
+    ):
+        super().__init__()
+        self.backbone = Hybrid1DBackbone(
+            in_channels=backbone_in_channels,
+            hidden_dim=backbone_hidden_dim,
+            output_dim=backbone_output_dim,
+            seq_length=seq_length,
+        )
+        self.mamba = MambaBlock(
+            d_model=backbone_output_dim,
+            d_state=mamba_d_state,
+            headdim=mamba_headdim,
+            num_heads=mamba_num_heads,
+            ema_alpha=ema_alpha,
+        )
+        self.dropout    = nn.Dropout(0.2)
+        self.classifier = nn.Linear(backbone_output_dim, num_classes)
+        self.feature_dim = backbone_output_dim
+        self.ema_alpha   = ema_alpha
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """x: (1, 3, seq_length) -> (1, num_classes)"""
+        features  = self.backbone(x)
+        mamba_out = self.mamba(features)
+        return self.classifier(self.dropout(mamba_out))
+
+
+if __name__ == "__main__":
+    print("=== StatefulMambaHybrid1D — PyTorch sanity check ===\n")
+    model = StatefulMambaHybrid1D(
+        num_classes=1000, backbone_in_channels=3, backbone_hidden_dim=256,
+        backbone_output_dim=512, seq_length=224, ema_alpha=0.1,
+        mamba_d_state=64, mamba_headdim=64, mamba_num_heads=8,
+    )
+    model.eval()
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"Parameters: {n_params / 1e6:.2f}M")
+    print(f"Feature dim: {model.feature_dim}")
+    print(f"Mamba states:")
+    print(f"  angle_state: {model.mamba.angle_state.shape}")
+    print(f"  ssm_state:   {model.mamba.ssm_state.shape}")
+    print(f"  k_state:     {model.mamba.k_state.shape}")
+    print(f"  v_state:     {model.mamba.v_state.shape}\n")
+    print("Simulating 5 frames:")
+    for i in range(5):
+        x = torch.randn(1, 3, 224)
+        with torch.no_grad():
+            logits = model(x)
+        print(f"  Frame {i}: {x.shape} -> {logits.shape} v")
+    print("\nv Forward pass OK")

--- a/mamba_ane/models/hybrid_parallel.py
+++ b/mamba_ane/models/hybrid_parallel.py
@@ -1,0 +1,124 @@
+# mamba_ane/models/hybrid_parallel.py
+"""
+Hybrid parallel models: sequence-preserving Conv1D backbone + Mamba3ParallelPortable.
+
+ParallelHybridBackbone:    (B, C_in, L) → (B, L, d_model)   [stride-1 Conv1D, SiLU]
+StatefulMambaParallelHybrid:  full ANE-exportable model (no state buffers)
+OGStatefulMambaParallelHybrid: golden reference using Mamba3 (CUDA), for GPU parity only
+"""
+import sys
+from pathlib import Path
+import torch
+import torch.nn as nn
+
+from mamba_ane.modules.mamba3_parallel import Mamba3ParallelPortable
+
+
+class ParallelHybridBackbone(nn.Module):
+    """
+    Sequence-preserving Conv1D feature extractor.
+
+    Two stride-1 same-padding Conv1d layers → SiLU.  The sequence length L is
+    unchanged, which is required for Mamba3ParallelPortable to receive (B, L, d_model).
+    At least one Conv1d ensures the ANE workload threshold is met.
+
+    Input:  (B, C_in, L)
+    Output: (B, L, d_model)
+    """
+    def __init__(
+        self,
+        in_channels: int = 3,
+        hidden_dim:  int = 64,
+        d_model:     int = 256,
+    ):
+        super().__init__()
+        self.conv1 = nn.Conv1d(in_channels, hidden_dim, kernel_size=5, padding=2, bias=True)
+        self.act1  = nn.SiLU()
+        self.conv2 = nn.Conv1d(hidden_dim,  d_model,    kernel_size=3, padding=1, bias=True)
+        self.act2  = nn.SiLU()
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """x: (B, C_in, L) → (B, L, d_model)"""
+        x = self.act1(self.conv1(x))    # (B, hidden_dim, L)
+        x = self.act2(self.conv2(x))    # (B, d_model,    L)
+        return x.transpose(-1, -2)      # (B, L, d_model)
+
+
+class StatefulMambaParallelHybrid(nn.Module):
+    """
+    ParallelHybridBackbone → Mamba3ParallelPortable → mean-pool → Linear.
+
+    Stateless: no register_buffer, no ct.StateType.
+    Input:  (B, C_in, seq_length) — seq_length must be fixed at export time.
+    Output: (B, num_classes)
+    """
+    def __init__(
+        self,
+        num_classes:  int   = 1000,
+        in_channels:  int   = 3,
+        hidden_dim:   int   = 64,
+        d_model:      int   = 256,
+        d_state:      int   = 64,
+        headdim:      int   = 64,
+    ):
+        super().__init__()
+        self.backbone   = ParallelHybridBackbone(in_channels, hidden_dim, d_model)
+        self.mamba      = Mamba3ParallelPortable(d_model=d_model, d_state=d_state, headdim=headdim)
+        self.classifier = nn.Linear(d_model, num_classes)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """x: (B, C_in, L) → (B, num_classes)"""
+        feat     = self.backbone(x)         # (B, L, d_model)
+        mamba_out = self.mamba(feat)         # (B, L, d_model)
+        pooled   = mamba_out.mean(dim=1)    # (B, d_model)
+        return self.classifier(pooled)       # (B, num_classes)
+
+
+# ---------------------------------------------------------------------------
+# OG reference model — import mamba_ssm only when available (GPU only)
+# ---------------------------------------------------------------------------
+
+def _build_og_model(d_model, d_state, headdim, num_classes, in_channels, hidden_dim,
+                    device=None, dtype=torch.float32):
+    """Factory that imports mamba_ssm lazily (not available on dorian-mac)."""
+    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    from mamba_ssm.modules.mamba3 import Mamba3
+
+    class OGStatefulMambaParallelHybrid(nn.Module):
+        """
+        Golden reference for GPU parity tests.
+        Same topology as StatefulMambaParallelHybrid but uses Mamba3 (Triton) internally.
+        NOT for CoreML export.
+        """
+        def __init__(self):
+            super().__init__()
+            self.backbone   = ParallelHybridBackbone(in_channels, hidden_dim, d_model)
+            self.mamba      = Mamba3(
+                d_model=d_model, d_state=d_state, expand=2, headdim=headdim,
+                ngroups=1, rope_fraction=0.5, is_mimo=False, is_outproj_norm=False,
+                layer_idx=0, device=device, dtype=dtype,
+            )
+            self.classifier = nn.Linear(d_model, num_classes)
+
+        def forward(self, x: torch.Tensor) -> torch.Tensor:
+            feat      = self.backbone(x)
+            mamba_out = self.mamba(feat)          # (B, L, d_model)
+            pooled    = mamba_out.mean(dim=1)
+            return self.classifier(pooled)
+
+        def load_from_portable(self, src: StatefulMambaParallelHybrid) -> None:
+            """Copy weights from portable model into this OG reference."""
+            with torch.no_grad():
+                self.backbone.load_state_dict(src.backbone.state_dict())
+                self.classifier.load_state_dict(src.classifier.state_dict())
+                self.mamba.in_proj.weight.copy_(src.mamba.in_proj.weight)
+                self.mamba.out_proj.weight.copy_(src.mamba.out_proj.weight)
+                self.mamba.dt_bias.copy_(src.mamba.dt_bias)
+                self.mamba.D.copy_(src.mamba.D)
+                self.mamba.B_norm.weight.copy_(src.mamba.B_norm.weight)
+                self.mamba.C_norm.weight.copy_(src.mamba.C_norm.weight)
+                # portable: (nheads, d_state) → Mamba3: (nheads, 1, d_state)
+                self.mamba.B_bias.copy_(src.mamba.B_bias.unsqueeze(1))
+                self.mamba.C_bias.copy_(src.mamba.C_bias.unsqueeze(1))
+
+    return OGStatefulMambaParallelHybrid()

--- a/mamba_ane/models/stvmamba_hybrid.py
+++ b/mamba_ane/models/stvmamba_hybrid.py
@@ -1,0 +1,153 @@
+import torch
+import torch.nn as nn
+from einops import rearrange
+from typing import Tuple
+
+# Assuming you placed this in mamba_ane/modules/stvmamba_modules.py
+from mamba_ane.modules.stvmamba_modules import STSS_ANE 
+from mamba_ane.models.hybrid_parallel import ParallelHybridBackbone
+
+# ==============================================================================
+# ANE-Safe Unpatchify (Output Layer for Tri-planes)
+# ==============================================================================
+class LinearUnpatchifyANE(nn.Module):
+    """
+    Simplified, CoreML-friendly linear unpatchify layer.
+    Maps (B, L, D) -> (B, C, H, W) where L = grid_h * grid_w.
+    """
+    def __init__(
+        self,
+        model_dim: int,
+        cond_dim: int,         # Dimension of Action/IMU conditioning
+        out_channels: int,     # Usually 64 for ICANSII Tri-planes
+        patch_size: int = 16,  # 16x16 patches
+        grid_h: int = 8,       # 8x8 grid = 64 sequence length
+        grid_w: int = 8,
+    ):
+        super().__init__()
+        self.out_channels = out_channels
+        self.patch_size = patch_size
+        self.grid_h = grid_h
+        self.grid_w = grid_w
+        
+        # Projection outputs all pixels for a single patch
+        output_dim = out_channels * (patch_size * patch_size)
+        
+        self.norm = nn.LayerNorm(model_dim, eps=1e-5) # LayerNorm is highly ANE-optimized
+        
+        # AdaLN Modulation (Action/IMU conditioning)
+        self.modulation = nn.Sequential(
+            nn.SiLU(),
+            nn.Linear(cond_dim, 2 * model_dim),
+        )
+        self.proj = nn.Linear(model_dim, output_dim)
+
+        # Final smoothing using 2D Conv (ANE loves Conv2D)
+        self.final_smooth = nn.Conv2d(
+            out_channels, out_channels,
+            kernel_size=3,
+            padding=1,
+            bias=True
+        )
+        
+        # Initialize modulation and smoothing to zero-impact initially
+        nn.init.zeros_(self.modulation[-1].weight)
+        nn.init.zeros_(self.modulation[-1].bias)
+        nn.init.dirac_(self.final_smooth.weight) # Identity init
+        nn.init.zeros_(self.final_smooth.bias)
+
+    def forward(self, x: torch.Tensor, cond_emb: torch.Tensor) -> torch.Tensor:
+        """
+        x: (B, L, model_dim)
+        cond_emb: (B, cond_dim) - the Action/IMU warp context
+        """
+        # 1. AdaLN Modulation
+        x = self.norm(x)
+        scale, shift = self.modulation(cond_emb).chunk(2, dim=-1)
+        
+        # Explicit unsqueeze for broadcasting on ANE
+        scale = scale.unsqueeze(1)
+        shift = shift.unsqueeze(1)
+        x = x * (1.0 + scale) + shift
+        
+        # 2. Linear Projection
+        x = self.proj(x) # (B, L, out_channels * patch_h * patch_w)
+        
+        # 3. Rearrange to 2D Spatial Grid
+        # CoreML compiles this to standard memory strides perfectly.
+        x = rearrange(
+            x,
+            'b (h w) (c ph pw) -> b c (h ph) (w pw)',
+            h=self.grid_h, w=self.grid_w, 
+            ph=self.patch_size, pw=self.patch_size, 
+            c=self.out_channels
+        )
+
+        # 4. Final spatial smooth
+        x = self.final_smooth(x)
+        
+        return x
+
+# ==============================================================================
+# Full ICANSII STVMamba Hybrid Predictor
+# ==============================================================================
+class STVMambaHybridANE(nn.Module):
+    """
+    End-to-end Tri-plane predictor:
+    Folded Buffer -> Conv1D Backbone -> STSS (4-way Mamba) -> Unpatchify -> Tri-plane
+    """
+    def __init__(
+        self,
+        in_channels: int = 320,  # e.g., 5 frames * 64 channels
+        d_model: int = 256,      # Multiple of 64 for ANE
+        cond_dim: int = 16,      # Size of IMU/Action vector
+        out_channels: int = 64,  # Channels of predicted Tri-plane
+        patch_size: int = 16,
+        grid_size: int = 8,      # 8x8 = seq_len 64
+        **mamba_kwargs
+    ):
+        super().__init__()
+        
+        # 1. Temporal Fold Backbone (STDS Conv equivalent)
+        self.backbone = ParallelHybridBackbone(
+            in_channels=in_channels, 
+            hidden_dim=d_model // 2, 
+            d_model=d_model
+        )
+        
+        # 2. 4-way Spatial-Temporal Selective Scan
+        self.stss = STSS_ANE(
+            d_model=d_model, 
+            grid_h=grid_size, 
+            grid_w=grid_size, 
+            **mamba_kwargs
+        )
+        
+        # 3. Decoder
+        self.decoder = LinearUnpatchifyANE(
+            model_dim=d_model,
+            cond_dim=cond_dim,
+            out_channels=out_channels,
+            patch_size=patch_size,
+            grid_h=grid_size,
+            grid_w=grid_size
+        )
+
+    def forward(self, triplane_buffer: torch.Tensor, cond_emb: torch.Tensor) -> torch.Tensor:
+        """
+        triplane_buffer: (B=1, T*C, L) — The folded input from Phase 1
+        cond_emb: (B=1, cond_dim) — IMU/Action conditioning
+        
+        Returns:
+        next_triplane: (B=1, C, H, W) — The predicted spatial occupancy
+        """
+        # (B, T*C, L) -> (B, L, d_model)
+        feat = self.backbone(triplane_buffer)
+        
+        # (B, L, d_model) -> (B, L, d_model)
+        mamba_out = self.stss(feat)
+        
+        # (B, L, d_model) -> (B, C, H, W)
+        pred_plane = self.decoder(mamba_out, cond_emb)
+        
+        return pred_plane

--- a/mamba_ane/modules/__init__.py
+++ b/mamba_ane/modules/__init__.py
@@ -1,0 +1,3 @@
+from mamba_ane.modules.mamba3 import RMSNormANE, MambaBlock
+
+__all__ = ["RMSNormANE", "MambaBlock"]

--- a/mamba_ane/modules/__init__.py
+++ b/mamba_ane/modules/__init__.py
@@ -1,3 +1,4 @@
 from mamba_ane.modules.mamba3 import RMSNormANE, MambaBlock
+from mamba_ane.modules.mamba3_parallel import Mamba3ParallelPortable
 
-__all__ = ["RMSNormANE", "MambaBlock"]
+__all__ = ["RMSNormANE", "MambaBlock", "Mamba3ParallelPortable"]

--- a/mamba_ane/modules/mamba3.py
+++ b/mamba_ane/modules/mamba3.py
@@ -1,0 +1,164 @@
+"""
+mamba_ane/modules/mamba3.py — ANE-native Mamba3 building blocks.
+
+RMSNormANE: ANE-friendly RMSNorm (no .float() casts; x*x instead of pow(2)).
+MambaBlock:  Full Mamba3 SISO with RoPE, trapezoid discretization, SSM
+             recurrence, and stateful buffers ready for ct.StateType export.
+"""
+
+import math
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+
+class RMSNormANE(nn.Module):
+    """ANE-friendly RMSNorm. No .float() casts; x*x replaces pow(2)."""
+
+    def __init__(self, dim: int, eps: float = 1e-5):
+        super().__init__()
+        self.eps = eps
+        self.weight = nn.Parameter(torch.ones(dim))
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        variance = (x * x).mean(-1, keepdim=True)
+        rms_inv = torch.rsqrt(variance + self.eps)
+        return x * rms_inv * self.weight
+
+
+class MambaBlock(nn.Module):
+    """
+    Mamba3 SISO — ANE-native implementation.
+
+    Stages:
+      1. in_proj + explicit slicing
+      2. Activations (softplus, sigmoid, silu) + dt_bias
+      3. K/Q RMSNorm + head expand + bias
+      4. RoPE angle accumulation
+      5. Trapezoid discretization (alpha/beta/gamma)
+      6. SSM recurrence via outer products; in-place state updates
+      7. Output contraction + D skip connection
+      8. out_proj
+
+    State buffers (angle_state, ssm_state, k_state, v_state) are registered
+    with register_buffer() so CoreML ct.StateType export picks them up.
+
+    Args:
+        d_model:   input/output dimension
+        d_state:   SSM state dimension (default 64)
+        headdim:   head dimension (default 64)
+        num_heads: number of attention heads (default 8)
+        ema_alpha: kept for API compatibility; not used in forward
+    """
+
+    def __init__(
+        self,
+        d_model: int = 512,
+        d_state: int = 64,
+        headdim: int = 64,
+        num_heads: int = 8,
+        ema_alpha: float = 0.1,
+    ):
+        super().__init__()
+        self.d_model = d_model
+        self.d_state = d_state
+        self.headdim = headdim
+        self.num_heads = num_heads
+        self.ema_alpha = ema_alpha
+
+        self.d_inner = num_heads * headdim
+        self.num_rope_angles = 16
+        self.rotary_dim = self.num_rope_angles * 2  # 32
+
+        # Projection slice boundaries
+        self._s0 = self.d_inner
+        self._s1 = self._s0 + self.d_inner
+        self._s2 = self._s1 + d_state
+        self._s3 = self._s2 + d_state
+        self._s4 = self._s3 + num_heads
+        self._s5 = self._s4 + num_heads
+        self._s6 = self._s5 + num_heads
+        self._s7 = self._s6 + self.num_rope_angles
+
+        self.in_proj  = nn.Linear(d_model, self._s7, bias=False)
+        self.out_proj = nn.Linear(self.d_inner, d_model, bias=False)
+
+        self.B_norm = RMSNormANE(d_state)
+        self.C_norm = RMSNormANE(d_state)
+        self.B_bias = nn.Parameter(torch.zeros(1, num_heads, d_state))
+        self.C_bias = nn.Parameter(torch.zeros(1, num_heads, d_state))
+
+        self.dt_bias = nn.Parameter(torch.zeros(num_heads))
+        self.D       = nn.Parameter(torch.ones(num_heads))
+
+        self.register_buffer("angle_state", torch.zeros(1, num_heads, self.num_rope_angles))
+        self.register_buffer("ssm_state",   torch.zeros(1, num_heads, headdim, d_state))
+        self.register_buffer("k_state",     torch.zeros(1, 1, num_heads, d_state))
+        self.register_buffer("v_state",     torch.zeros(1, num_heads, headdim))
+
+    def apply_rope(
+        self, x: torch.Tensor, cos: torch.Tensor, sin: torch.Tensor
+    ) -> torch.Tensor:
+        """Stateless RoPE rotation; x: (1,H,D), cos/sin: (1,H,num_rope_angles)."""
+        x_rot  = x[..., :self.rotary_dim]
+        x_pass = x[..., self.rotary_dim:]
+        x0 = x_rot[..., 0::2]
+        x1 = x_rot[..., 1::2]
+        out_rot = torch.stack([x0 * cos - x1 * sin, x0 * sin + x1 * cos], dim=-1).flatten(-2)
+        return torch.cat([out_rot, x_pass], dim=-1)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # Stage 1: project + slice
+        zxBCdt     = self.in_proj(x)
+        z_raw      = zxBCdt[..., :self._s0]
+        x_raw      = zxBCdt[..., self._s0:self._s1]
+        B_raw      = zxBCdt[..., self._s1:self._s2]
+        C_raw      = zxBCdt[..., self._s2:self._s3]
+        dd_dt      = zxBCdt[..., self._s3:self._s4]
+        dd_A       = zxBCdt[..., self._s4:self._s5]
+        trap_raw   = zxBCdt[..., self._s5:self._s6]
+        angles_raw = zxBCdt[..., self._s6:self._s7]
+
+        # Stage 2: activations
+        A   = -(F.softplus(dd_A) + 1e-4)
+        DT  = F.softplus(dd_dt + self.dt_bias)
+        lam = torch.sigmoid(trap_raw)
+        z   = F.silu(z_raw)
+
+        # Stage 3: K/Q norm + expand + bias
+        K_norm     = self.B_norm(B_raw.view(1, 1, 1, self.d_state))
+        Q_norm     = self.C_norm(C_raw.view(1, 1, 1, self.d_state))
+        K_expanded = K_norm.repeat(1, 1, self.num_heads, 1).squeeze(1)
+        Q_expanded = Q_norm.repeat(1, 1, self.num_heads, 1).squeeze(1)
+        K_pre      = K_expanded + self.B_bias
+        Q_pre      = Q_expanded + self.C_bias
+
+        # Stage 4: RoPE
+        angles      = angles_raw.view(1, 1, self.num_rope_angles).repeat(1, self.num_heads, 1)
+        delta_theta = torch.tanh(angles) * math.pi * DT.unsqueeze(-1)
+        theta       = self.angle_state + delta_theta
+        K_rot       = self.apply_rope(K_pre, torch.cos(theta), torch.sin(theta))
+        Q_rot       = self.apply_rope(Q_pre, torch.cos(theta), torch.sin(theta))
+
+        # Stage 5: trapezoid coefficients
+        alpha = torch.exp(A * DT)
+        beta  = (1.0 - lam) * DT * alpha
+        gamma = lam * DT
+        g4    = gamma[:, :, None, None]
+        b4    = beta[:, :, None, None]
+
+        # Stage 6: SSM recurrence
+        V           = x_raw.reshape(1, self.num_heads, self.headdim)
+        outer_curr  = torch.matmul(V.unsqueeze(-1),              K_rot.unsqueeze(-2))
+        outer_prev  = torch.matmul(self.v_state.unsqueeze(-1),   self.k_state.squeeze(1).unsqueeze(-2))
+        new_h       = alpha[:, :, None, None] * self.ssm_state + b4 * outer_prev + g4 * outer_curr
+
+        self.ssm_state[:]   = new_h
+        self.k_state[:]     = K_rot.unsqueeze(1)
+        self.v_state[:]     = V
+        self.angle_state[:] = theta
+
+        # Stage 7-8: output
+        y_ssm = torch.matmul(new_h, Q_rot.unsqueeze(-1)).squeeze(-1)
+        y_ssm = y_ssm + (V * self.D.view(1, -1, 1))
+        return self.out_proj(y_ssm.reshape(1, self.d_inner) * z)

--- a/mamba_ane/modules/mamba3_parallel.py
+++ b/mamba_ane/modules/mamba3_parallel.py
@@ -100,6 +100,9 @@ class Mamba3ParallelPortable(nn.Module):
         """u: (B, L, d_model) → (B, L, d_model)"""
         B, L, _ = u.shape
 
+        # causal mask (lower-triangular) — constant at trace time
+        causal = torch.tril(torch.ones(L, L, device=u.device, dtype=u.dtype))
+
         # Stage 1: in_proj + explicit slices
         proj       = self.in_proj(u)
         z_raw      = proj[..., :self._s0]                   # (B, L, d_inner)
@@ -128,7 +131,14 @@ class Mamba3ParallelPortable(nn.Module):
         # Stage 4: RoPE — cumulative angle along sequence
         angles      = angles_raw.unsqueeze(2).expand(-1, -1, self.nheads, -1)
         delta_theta = torch.tanh(angles) * math.pi * DT.unsqueeze(-1)
-        theta       = torch.cumsum(delta_theta, dim=1)      # (B, L, H, num_rope_angles)
+        # theta = torch.cumsum(delta_theta, dim=1)      # (B, L, H, num_rope_angles)
+        # ANE doesn't support cumsum, but we can do the same with a matmul of the cumulative sum's defining matrix:
+        # 4D version — flatten trailing dims, matmul, unflatten.
+        B_, L_, H_, S_ = delta_theta.shape
+        theta = torch.matmul(
+            causal, delta_theta.reshape(B_, L_, H_ * S_)
+        ).reshape(B_, L_, H_, S_)
+
         cos_t, sin_t = torch.cos(theta), torch.sin(theta)
         K_rot = self.apply_rope(K_pre, cos_t, sin_t)        # (B, L, H, d_state)
         Q_rot = self.apply_rope(Q_pre, cos_t, sin_t)
@@ -136,21 +146,23 @@ class Mamba3ParallelPortable(nn.Module):
         # Stage 5: discretization coefficients
         gamma     = lam * DT                                # (B, L, H)
         # beta_next[b,r,h] = (1-lam[b,r+1,h]) * DT[b,r+1,h]; zero at last position
-        beta_next = torch.zeros_like(gamma)
-        beta_next[:, :-1, :] = (1.0 - lam[:, 1:, :]) * DT[:, 1:, :]
+        beta_per_pos = (1.0 - lam) * DT                              # (B, L, H)
+        beta_next    = F.pad(beta_per_pos[:, 1:, :], (0, 0, 0, 1))   # shift left, zero-pad tail
 
         # Stage 6: L-matrix (vectorised across all heads)
         # cum_log_alpha: (B, L, H)
-        cum = torch.cumsum(ADT, dim=1)
+        # cum = torch.cumsum(ADT, dim=1) Doesn't work on ANE
+        # Cumsum along dim 1. (L, L) @ (B, L, H) broadcasts cleanly.
+        cum = torch.matmul(causal, ADT)                 # (B, L, H)
 
         # decay_mat[b,t,r,h] = exp(cum[b,t,h] - cum[b,r,h])
         # shape broadcast: (B, L, 1, H) - (B, 1, L, H) = (B, L, L, H)
         log_decay = cum.unsqueeze(2) - cum.unsqueeze(1)
-
-        # causal mask (lower-triangular) — constant at trace time
-        causal = torch.tril(torch.ones(L, L, device=u.device, dtype=u.dtype))
         # apply mask in log-space before exp: prevents inf overflow (exp(+large)*0 = NaN)
-        log_decay = log_decay + (1.0 - causal).unsqueeze(-1) * (-1e9)
+        # exp(-1e4) underflows to 0 in fp16 long before we hit fp16 range limits.
+        # No reason to ever go to -1e9 here.
+        NEG_LARGE = u.new_tensor(-1e4)   # explicit dtype-matched tensor
+        log_decay = log_decay + (1.0 - causal).unsqueeze(-1) * NEG_LARGE
         decay_mat = torch.exp(log_decay) * causal.unsqueeze(-1)        # (B, L, L, H)
 
         # g_col = gamma + beta_next; diagonal needs gamma only

--- a/mamba_ane/modules/mamba3_parallel.py
+++ b/mamba_ane/modules/mamba3_parallel.py
@@ -1,0 +1,197 @@
+# mamba_ane/modules/mamba3_parallel.py
+"""
+Mamba3ParallelPortable — ANE-safe parallel (sequence-in/sequence-out) Mamba-3 SISO.
+
+Algorithm: unchunked SSD via materialised (B, H, L, L) L-matrix.
+No register_buffer, no ct.StateType — stateless, static shapes baked at trace time.
+"""
+import math
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from mamba_ane.modules.mamba3 import RMSNormANE
+
+
+class Mamba3ParallelPortable(nn.Module):
+    """
+    Pure-PyTorch parallel Mamba-3 SISO forward pass.
+
+    forward(u: (B, L, d_model)) -> (B, L, d_model)
+
+    No stateful buffers.  Load weights from an original Mamba3 instance via
+    load_from_original().  Works with any L at runtime; shapes are baked in
+    statically when torch.jit.trace is called for CoreML export.
+
+    ANE constraints observed throughout:
+      - No .float() casts — input dtype is preserved end-to-end.
+      - x * x instead of pow(x, 2) in RMSNormANE.
+      - No torch.split — explicit index slices precomputed in __init__.
+      - Outer products via matmul(unsqueeze(-1), unsqueeze(-2)).
+      - additive A floor: -(softplus(x) + A_floor) instead of clamp.
+    """
+
+    def __init__(
+        self,
+        d_model: int = 256,
+        d_state: int = 64,
+        expand: int = 2,
+        headdim: int = 64,
+        rope_fraction: float = 0.5,
+        A_floor: float = 1e-4,
+        rms_eps: float = 1e-5,
+    ):
+        super().__init__()
+        self.d_model = d_model
+        self.d_state = d_state
+        self.d_inner = d_model * expand
+        assert self.d_inner % headdim == 0
+        self.nheads = self.d_inner // headdim
+        self.headdim = headdim
+        self.A_floor = A_floor
+
+        # RoPE sizing (matches mamba_ssm Mamba3 with rope_fraction=0.5)
+        split_tensor_size = int(d_state * rope_fraction)
+        if split_tensor_size % 2 != 0:
+            split_tensor_size -= 1
+        self.num_rope_angles = split_tensor_size // 2   # 16
+        self.rotary_dim      = split_tensor_size         # 32
+
+        # Projection slice boundaries (no torch.split in forward)
+        self._s0 = self.d_inner                              # z   end
+        self._s1 = self._s0 + self.d_inner                   # x   end
+        self._s2 = self._s1 + d_state                        # B   end
+        self._s3 = self._s2 + d_state                        # C   end
+        self._s4 = self._s3 + self.nheads                    # dd_dt end
+        self._s5 = self._s4 + self.nheads                    # dd_A  end
+        self._s6 = self._s5 + self.nheads                    # trap  end
+        self._s7 = self._s6 + self.num_rope_angles           # angles end
+
+        self.in_proj  = nn.Linear(d_model, self._s7, bias=False)
+        self.out_proj = nn.Linear(self.d_inner, d_model, bias=False)
+
+        self.B_norm = RMSNormANE(d_state, eps=rms_eps)
+        self.C_norm = RMSNormANE(d_state, eps=rms_eps)
+
+        # (nheads, d_state) — squeezed from Mamba3's (nheads, 1, d_state)
+        self.B_bias  = nn.Parameter(torch.zeros(self.nheads, d_state))
+        self.C_bias  = nn.Parameter(torch.zeros(self.nheads, d_state))
+        self.dt_bias = nn.Parameter(torch.zeros(self.nheads))
+        self.D       = nn.Parameter(torch.ones(self.nheads))
+
+    # ------------------------------------------------------------------
+    def apply_rope(
+        self,
+        x:   torch.Tensor,   # (B, L, H, D)
+        cos: torch.Tensor,   # (B, L, H, num_rope_angles)
+        sin: torch.Tensor,
+    ) -> torch.Tensor:
+        """Pairwise RoPE — works for any leading (B, L) dims."""
+        x_rot  = x[..., :self.rotary_dim]   # (B, L, H, 32)
+        x_pass = x[..., self.rotary_dim:]
+        x0 = x_rot[..., 0::2]               # (B, L, H, 16)
+        x1 = x_rot[..., 1::2]
+        out_rot = torch.stack(
+            [x0 * cos - x1 * sin, x0 * sin + x1 * cos], dim=-1
+        ).flatten(-2)                        # (B, L, H, 32)
+        return torch.cat([out_rot, x_pass], dim=-1)
+
+    # ------------------------------------------------------------------
+    def forward(self, u: torch.Tensor) -> torch.Tensor:
+        """u: (B, L, d_model) → (B, L, d_model)"""
+        B, L, _ = u.shape
+
+        # Stage 1: in_proj + explicit slices
+        proj       = self.in_proj(u)
+        z_raw      = proj[..., :self._s0]                   # (B, L, d_inner)
+        x_raw      = proj[..., self._s0:self._s1]
+        B_raw      = proj[..., self._s1:self._s2]           # (B, L, d_state)
+        C_raw      = proj[..., self._s2:self._s3]
+        dd_dt      = proj[..., self._s3:self._s4]           # (B, L, nheads)
+        dd_A       = proj[..., self._s4:self._s5]
+        trap_raw   = proj[..., self._s5:self._s6]
+        angles_raw = proj[..., self._s6:self._s7]           # (B, L, num_rope_angles)
+
+        # Stage 2: activations — no .float() casts
+        A   = -(F.softplus(dd_A)   + self.A_floor)         # (B, L, H)
+        DT  = F.softplus(dd_dt + self.dt_bias)             # (B, L, H)
+        lam = torch.sigmoid(trap_raw)                       # (B, L, H)
+        z   = F.silu(z_raw)                                 # (B, L, d_inner)
+        ADT = A * DT                                        # log(alpha) per position
+
+        # Stage 3: K/Q norm + expand to heads + bias
+        K_norm = self.B_norm(B_raw)                         # (B, L, d_state)
+        Q_norm = self.C_norm(C_raw)
+        # expand: (B, L, 1, d_state) -> (B, L, H, d_state)
+        K_pre = K_norm.unsqueeze(2).expand(-1, -1, self.nheads, -1) + self.B_bias
+        Q_pre = Q_norm.unsqueeze(2).expand(-1, -1, self.nheads, -1) + self.C_bias
+
+        # Stage 4: RoPE — cumulative angle along sequence
+        angles      = angles_raw.unsqueeze(2).expand(-1, -1, self.nheads, -1)
+        delta_theta = torch.tanh(angles) * math.pi * DT.unsqueeze(-1)
+        theta       = torch.cumsum(delta_theta, dim=1)      # (B, L, H, num_rope_angles)
+        cos_t, sin_t = torch.cos(theta), torch.sin(theta)
+        K_rot = self.apply_rope(K_pre, cos_t, sin_t)        # (B, L, H, d_state)
+        Q_rot = self.apply_rope(Q_pre, cos_t, sin_t)
+
+        # Stage 5: discretization coefficients
+        gamma     = lam * DT                                # (B, L, H)
+        # beta_next[b,r,h] = (1-lam[b,r+1,h]) * DT[b,r+1,h]; zero at last position
+        beta_next = torch.zeros_like(gamma)
+        beta_next[:, :-1, :] = (1.0 - lam[:, 1:, :]) * DT[:, 1:, :]
+
+        # Stage 6: L-matrix (vectorised across all heads)
+        # cum_log_alpha: (B, L, H)
+        cum = torch.cumsum(ADT, dim=1)
+
+        # decay_mat[b,t,r,h] = exp(cum[b,t,h] - cum[b,r,h])
+        # shape broadcast: (B, L, 1, H) - (B, 1, L, H) = (B, L, L, H)
+        log_decay = cum.unsqueeze(2) - cum.unsqueeze(1)
+
+        # causal mask (lower-triangular) — constant at trace time
+        causal = torch.tril(torch.ones(L, L, device=u.device, dtype=u.dtype))
+        # apply mask in log-space before exp: prevents inf overflow (exp(+large)*0 = NaN)
+        log_decay = log_decay + (1.0 - causal).unsqueeze(-1) * (-1e9)
+        decay_mat = torch.exp(log_decay) * causal.unsqueeze(-1)        # (B, L, L, H)
+
+        # g_col = gamma + beta_next; diagonal needs gamma only
+        g_col  = gamma + beta_next                          # (B, L, H)
+        L_mat  = decay_mat * g_col.unsqueeze(1)             # (B, L, L, H) — col broadcast
+        # diagonal correction: subtract beta_next from L_mat[t,t,h]
+        eye    = torch.eye(L, device=u.device, dtype=u.dtype)
+        L_mat  = L_mat - eye.unsqueeze(-1) * beta_next.unsqueeze(1)  # (B, L, L, H)
+
+        # Stage 7: attention-like contraction
+        # Permute all to (B, H, L, *) for batch matmul
+        K_bhl    = K_rot.permute(0, 2, 1, 3)               # (B, H, L, d_state)
+        Q_bhl    = Q_rot.permute(0, 2, 1, 3)
+        V        = x_raw.reshape(B, L, self.nheads, self.headdim)
+        V_bhl    = V.permute(0, 2, 1, 3)                   # (B, H, L, headdim)
+        L_bhll   = L_mat.permute(0, 3, 1, 2)               # (B, H, L, L)
+
+        score    = torch.matmul(Q_bhl, K_bhl.transpose(-1, -2))     # (B, H, L, L)
+        Y_bhl    = torch.matmul(L_bhll * score, V_bhl)              # (B, H, L, headdim)
+        Y        = Y_bhl.permute(0, 2, 1, 3)               # (B, L, H, headdim)
+
+        # Stage 8: D skip + gate + out_proj
+        Y     = Y + V * self.D.view(1, 1, -1, 1)
+        y_flat = Y.reshape(B, L, self.d_inner)              # (B, L, d_inner)
+        return self.out_proj(y_flat * z)                    # (B, L, d_model)
+
+    # ------------------------------------------------------------------
+    def load_from_original(self, src: nn.Module) -> None:
+        """
+        Copy weights from a mamba_ssm.modules.mamba3.Mamba3 instance (SISO, ngroups=1).
+
+        Handles the B_bias/C_bias reshape: Mamba3 stores (nheads, 1, d_state),
+        portable stores (nheads, d_state).
+        """
+        with torch.no_grad():
+            self.in_proj.weight.copy_(src.in_proj.weight)
+            self.out_proj.weight.copy_(src.out_proj.weight)
+            self.dt_bias.copy_(src.dt_bias)
+            self.D.copy_(src.D)
+            self.B_norm.weight.copy_(src.B_norm.weight)
+            self.C_norm.weight.copy_(src.C_norm.weight)
+            # Mamba3 B_bias shape: (nheads, 1, d_state) → squeeze dim 1
+            self.B_bias.copy_(src.B_bias.squeeze(1))
+            self.C_bias.copy_(src.C_bias.squeeze(1))

--- a/mamba_ane/modules/stvmamba_modules.py
+++ b/mamba_ane/modules/stvmamba_modules.py
@@ -1,0 +1,51 @@
+import torch
+import torch.nn as nn
+from einops import rearrange
+# Import your new parallel block
+from mamba_ane.modules.mamba3_parallel import Mamba3ParallelPortable
+
+class STSS_ANE(nn.Module):
+    """
+    ANE-native 4-direction Spatial-Temporal Selective Scan.
+    Expects input shape: (B, L, D) where B=1 and L = grid_h * grid_w.
+    """
+    def __init__(self, d_model: int, grid_h: int = 8, grid_w: int = 8, **mamba_kwargs):
+        super().__init__()
+        self.grid_h = grid_h
+        self.grid_w = grid_w
+        self.d_model = d_model
+        
+        # 4 independent parallel Mamba blocks
+        self.scans = nn.ModuleList([
+            Mamba3ParallelPortable(d_model=d_model, **mamba_kwargs)
+            for _ in range(4)
+        ])
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        # x: (B, L, D) - For ANE, B must be 1.
+        
+        # 1. Row Forward (Standard sequence)
+        scan0 = x
+        
+        # 2. Row Reverse (Flip sequence)
+        scan1 = torch.flip(x, dims=[1])
+        
+        # 3. Col Forward (Transpose spatial grid)
+        scan2 = rearrange(x, 'b (h w) c -> b (w h) c', h=self.grid_h, w=self.grid_w)
+        
+        # 4. Col Reverse (Transpose then flip)
+        scan3 = torch.flip(scan2, dims=[1])
+
+        # Execute the 4 Mambas (Sequential in Python, but fast on ANE)
+        out0 = self.scans[0](scan0)
+        out1 = self.scans[1](scan1)
+        out2 = self.scans[2](scan2)
+        out3 = self.scans[3](scan3)
+
+        # Un-flip and un-transpose the outputs to align back to the original grid
+        out1 = torch.flip(out1, dims=[1])
+        out2 = rearrange(out2, 'b (w h) c -> b (h w) c', h=self.grid_h, w=self.grid_w)
+        out3 = rearrange(torch.flip(out3, dims=[1]), 'b (w h) c -> b (h w) c', h=self.grid_h, w=self.grid_w)
+
+        # Sum the 4 directions
+        return out0 + out1 + out2 + out3

--- a/mamba_ane/requirements.txt
+++ b/mamba_ane/requirements.txt
@@ -1,0 +1,6 @@
+# python 3.12
+torch==2.5.1
+torchvision==0.20.1
+timm>=1.0.0
+coremltools==9.0 
+numpy>=1.26,<2.0

--- a/mamba_ane/utils/export.py
+++ b/mamba_ane/utils/export.py
@@ -1,0 +1,129 @@
+"""
+mamba_ane/utils/export.py — Export StatefulMambaHybrid1D to CoreML 9.0 (.mlpackage)
+
+Features:
+  - Hybrid1D backbone (Conv1D + Linear)
+  - MambaBlock state buffers (angle_state, ssm_state, k_state, v_state)
+  - ct.StateType for persistent state across inferences
+  - mlprogram format, iOS18+, FLOAT16 precision
+  - Stateful API: make_state() + predict(state=...)
+  - Optional numerical verification PyTorch vs CoreML
+
+Usage (from repo root):
+  python mamba_ane/utils/export.py
+  python mamba_ane/utils/export.py --num-classes 10 --seq-length 224
+  python mamba_ane/utils/export.py --ema-alpha 0.05 --no-verify
+"""
+
+import argparse
+import os
+import time
+
+import numpy as np
+import torch
+import coremltools as ct
+
+from mamba_ane.models.hybrid1d import StatefulMambaHybrid1D
+
+
+def parse_args():
+    p = argparse.ArgumentParser(description="Export StatefulMambaHybrid1D to CoreML")
+    p.add_argument("--num-classes",         type=int,   default=1000)
+    p.add_argument("--seq-length",          type=int,   default=224)
+    p.add_argument("--backbone-hidden-dim", type=int,   default=256)
+    p.add_argument("--backbone-output-dim", type=int,   default=512)
+    p.add_argument("--mamba-d-state",       type=int,   default=64)
+    p.add_argument("--mamba-headdim",       type=int,   default=64)
+    p.add_argument("--mamba-num-heads",     type=int,   default=8)
+    p.add_argument("--ema-alpha",           type=float, default=0.1)
+    p.add_argument("--out-dir",             default="./exported_model")
+    p.add_argument("--no-verify",           action="store_true")
+    return p.parse_args()
+
+
+def export(args):
+    os.makedirs(args.out_dir, exist_ok=True)
+
+    print("=" * 70)
+    print("StatefulMambaHybrid1D -> CoreML 9.0 Export")
+    print("=" * 70)
+
+    print(f"\n[1/5] Build StatefulMambaHybrid1D")
+    model = StatefulMambaHybrid1D(
+        num_classes=args.num_classes,
+        backbone_in_channels=3,
+        backbone_hidden_dim=args.backbone_hidden_dim,
+        backbone_output_dim=args.backbone_output_dim,
+        seq_length=args.seq_length,
+        ema_alpha=args.ema_alpha,
+        mamba_d_state=args.mamba_d_state,
+        mamba_headdim=args.mamba_headdim,
+        mamba_num_heads=args.mamba_num_heads,
+    )
+    model.eval()
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"      Parameters: {n_params / 1e6:.2f}M")
+
+    print(f"\n[2/5] Verify state buffers")
+    buffers  = dict(model.named_buffers())
+    required = ["mamba.angle_state", "mamba.k_state", "mamba.v_state", "mamba.ssm_state"]
+    for buf in required:
+        assert buf in buffers, f"Missing buffer: {buf}"
+    print(f"      Buffers OK")
+
+    print(f"\n[3/5] torch.jit.trace")
+    shape = (1, 3, args.seq_length)
+    with torch.no_grad():
+        traced = torch.jit.trace(model, (torch.rand(shape),))
+    print(f"      Trace OK")
+
+    print(f"\n[4/5] CoreML 9.0 Conversion")
+    states_list = [
+        ct.StateType(wrapped_type=ct.TensorType(shape=model.mamba.angle_state.shape), name="mamba.angle_state"),
+        ct.StateType(wrapped_type=ct.TensorType(shape=model.mamba.k_state.shape),     name="mamba.k_state"),
+        ct.StateType(wrapped_type=ct.TensorType(shape=model.mamba.v_state.shape),     name="mamba.v_state"),
+        ct.StateType(wrapped_type=ct.TensorType(shape=model.mamba.ssm_state.shape),   name="mamba.ssm_state"),
+    ]
+    t0 = time.time()
+    mlmodel = ct.convert(
+        traced,
+        convert_to="mlprogram",
+        inputs=[ct.TensorType(name="x", shape=shape, dtype=np.float32)],
+        outputs=[ct.TensorType(name="logits", dtype=np.float32)],
+        states=states_list,
+        minimum_deployment_target=ct.target.iOS18,
+        compute_precision=ct.precision.FLOAT16,
+    )
+    print(f"      Conversion OK ({time.time()-t0:.1f}s)")
+
+    print(f"\n[5/5] Save model")
+    model_name = (
+        f"StatefulMambaHybrid1D_seq{args.seq_length}_c{args.num_classes}"
+        f"_alpha{args.ema_alpha}"
+    )
+    out_path = os.path.join(args.out_dir, f"{model_name}.mlpackage")
+    mlmodel.save(out_path)
+    print(f"      Saved -> {out_path}")
+
+    if not args.no_verify:
+        print("\n" + "-" * 70)
+        print("Numerical Verification: PyTorch vs CoreML")
+        print("-" * 70)
+        for buf in ["angle_state", "k_state", "v_state", "ssm_state"]:
+            getattr(model.mamba, buf).zero_()
+        coreml_state = mlmodel.make_state()
+        for i in range(5):
+            x_np = np.random.rand(1, 3, args.seq_length).astype(np.float32)
+            with torch.no_grad():
+                logits_pt = model(torch.from_numpy(x_np)).numpy()
+            logits_cml = mlmodel.predict({"x": x_np}, state=coreml_state)["logits"]
+            diff = np.abs(logits_pt - logits_cml).max()
+            print(f"  Frame {i}: max diff = {diff:.2e}")
+
+    print("\n" + "=" * 70)
+    print("Export complete!")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    export(parse_args())

--- a/mamba_ane/utils/export_parallel.py
+++ b/mamba_ane/utils/export_parallel.py
@@ -1,0 +1,103 @@
+# mamba_ane/utils/export_parallel.py
+"""
+Export StatefulMambaParallelHybrid to CoreML 9.0 (.mlpackage).
+
+No ct.StateType — module is stateless.  Saves:
+  outputs/StatefulMambaParallelHybrid_seq{L}_c{C}.mlpackage
+  outputs/StatefulMambaParallelHybrid_seq{L}_c{C}.pt  (state_dict)
+
+Usage:
+  python mamba_ane/utils/export_parallel.py
+  python mamba_ane/utils/export_parallel.py --seq-length 256 --num-classes 10
+"""
+import argparse, os, time
+import numpy as np
+import torch
+import coremltools as ct
+
+from mamba_ane.models.hybrid_parallel import StatefulMambaParallelHybrid
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    p.add_argument("--num-classes",  type=int, default=1000)
+    p.add_argument("--seq-length",   type=int, default=256)
+    p.add_argument("--in-channels",  type=int, default=3)
+    p.add_argument("--hidden-dim",   type=int, default=64)
+    p.add_argument("--d-model",      type=int, default=256)
+    p.add_argument("--d-state",      type=int, default=64)
+    p.add_argument("--headdim",      type=int, default=64)
+    p.add_argument("--seed",         type=int, default=42)
+    p.add_argument("--out-dir",      default="./outputs")
+    p.add_argument("--no-verify",    action="store_true")
+    return p.parse_args()
+
+
+def export(args):
+    os.makedirs(args.out_dir, exist_ok=True)
+    stem = f"StatefulMambaParallelHybrid_seq{args.seq_length}_c{args.num_classes}"
+    mlpackage_path = os.path.join(args.out_dir, f"{stem}.mlpackage")
+    weights_path   = os.path.join(args.out_dir, f"{stem}.pt")
+
+    print("=" * 70)
+    print(f"StatefulMambaParallelHybrid → CoreML (seq={args.seq_length})")
+    print("=" * 70)
+
+    print(f"\n[1/5] Build model (seed={args.seed})")
+    torch.manual_seed(args.seed)
+    model = StatefulMambaParallelHybrid(
+        num_classes=args.num_classes,
+        in_channels=args.in_channels,
+        hidden_dim=args.hidden_dim,
+        d_model=args.d_model,
+        d_state=args.d_state,
+        headdim=args.headdim,
+    ).eval()
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"      Parameters: {n_params/1e6:.2f}M")
+
+    print(f"\n[2/5] Save weights → {weights_path}")
+    torch.save(model.state_dict(), weights_path)
+
+    print(f"\n[3/5] torch.jit.trace (input: (1, {args.in_channels}, {args.seq_length}))")
+    shape = (1, args.in_channels, args.seq_length)
+    with torch.no_grad():
+        traced = torch.jit.trace(model, (torch.rand(*shape),))
+    print("      Trace OK")
+
+    print(f"\n[4/5] CoreML conversion (FLOAT16, iOS18, CPU_AND_NE)")
+    t0 = time.time()
+    mlmodel = ct.convert(
+        traced,
+        convert_to="mlprogram",
+        inputs=[ct.TensorType(name="x", shape=shape, dtype=np.float32)],
+        outputs=[ct.TensorType(name="logits", dtype=np.float32)],
+        # No states= — stateless model
+        minimum_deployment_target=ct.target.iOS18,
+        compute_precision=ct.precision.FLOAT16,
+    )
+    print(f"      Conversion OK ({time.time()-t0:.1f}s)")
+
+    print(f"\n[5/5] Save → {mlpackage_path}")
+    mlmodel.save(mlpackage_path)
+
+    if not args.no_verify:
+        print("\n" + "-" * 70)
+        print("Quick sanity check: 5 random inputs, PyTorch vs CoreML")
+        print("-" * 70)
+        torch.manual_seed(0)
+        for i in range(5):
+            x_np = np.random.rand(*shape).astype(np.float32)
+            with torch.no_grad():
+                pt_out = model(torch.from_numpy(x_np)).numpy()
+            cml_out = mlmodel.predict({"x": x_np})["logits"]
+            diff = np.abs(pt_out - cml_out).max()
+            print(f"  Input {i}: max_abs = {diff:.2e}")
+
+    print("\n" + "=" * 70)
+    print("Export complete!")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    export(parse_args())

--- a/mamba_ane/utils/export_stvmamba_parallel.py
+++ b/mamba_ane/utils/export_stvmamba_parallel.py
@@ -1,0 +1,125 @@
+# mamba_ane/utils/export_parallel.py
+"""
+Export STVMambaHybridANE to CoreML 9.0 (.mlpackage).
+
+No ct.StateType — module is stateless.  Saves:
+  outputs/STVMambaHybridANE_seq64_out64.mlpackage
+  outputs/STVMambaHybridANE_seq64_out64.pt  (state_dict)
+
+Usage:
+  python mamba_ane/utils/export_parallel.py
+"""
+import argparse, os, time
+import numpy as np
+import torch
+import coremltools as ct
+
+from mamba_ane.models.stvmamba_hybrid import STVMambaHybridANE
+
+
+def parse_args():
+    p = argparse.ArgumentParser()
+    # ICANSII Tri-plane specific arguments
+    p.add_argument("--in-channels",  type=int, default=320) # e.g. 5 frames * 64 channels
+    p.add_argument("--out-channels", type=int, default=64)  # Output tri-plane channels
+    p.add_argument("--cond-dim",     type=int, default=16)  # IMU/Action conditioning vector
+    p.add_argument("--patch-size",   type=int, default=16)  # 16x16 patch
+    p.add_argument("--grid-size",    type=int, default=8)   # 8x8 grid (L = 64)
+    
+    # Mamba / Backbone arguments
+    p.add_argument("--d-model",      type=int, default=256)
+    p.add_argument("--d-state",      type=int, default=64)
+    p.add_argument("--headdim",      type=int, default=64)
+    p.add_argument("--seed",         type=int, default=42)
+    p.add_argument("--out-dir",      default="./outputs")
+    p.add_argument("--no-verify",    action="store_true")
+    return p.parse_args()
+
+
+def export(args):
+    os.makedirs(args.out_dir, exist_ok=True)
+    seq_length = args.grid_size * args.grid_size
+    
+    stem = f"STVMambaHybridANE_seq{seq_length}_out{args.out_channels}"
+    mlpackage_path = os.path.join(args.out_dir, f"{stem}.mlpackage")
+    weights_path   = os.path.join(args.out_dir, f"{stem}.pt")
+
+    print("=" * 70)
+    print(f"STVMambaHybridANE → CoreML (seq={seq_length})")
+    print("=" * 70)
+
+    print(f"\n[1/5] Build model (seed={args.seed})")
+    torch.manual_seed(args.seed)
+    model = STVMambaHybridANE(
+        in_channels=args.in_channels,
+        d_model=args.d_model,
+        cond_dim=args.cond_dim,
+        out_channels=args.out_channels,
+        patch_size=args.patch_size,
+        grid_size=args.grid_size,
+        d_state=args.d_state,
+        headdim=args.headdim,
+    ).eval()
+    n_params = sum(p.numel() for p in model.parameters())
+    print(f"      Parameters: {n_params/1e6:.2f}M")
+
+    print(f"\n[2/5] Save weights → {weights_path}")
+    torch.save(model.state_dict(), weights_path)
+
+    # We now have TWO inputs: the buffer and the action condition
+    shape_x = (1, args.in_channels, seq_length)
+    shape_cond = (1, args.cond_dim)
+    
+    print(f"\n[3/5] torch.jit.trace (inputs: {shape_x} and {shape_cond})")
+    with torch.no_grad():
+        dummy_x = torch.rand(*shape_x)
+        dummy_cond = torch.rand(*shape_cond)
+        traced = torch.jit.trace(model, (dummy_x, dummy_cond))
+    print("      Trace OK")
+
+    print(f"\n[4/5] CoreML conversion (FLOAT16, iOS18, CPU_AND_NE)")
+    t0 = time.time()
+    mlmodel = ct.convert(
+        traced,
+        convert_to="mlprogram",
+        # Explicitly map the two inputs for CoreML
+        inputs=[
+            ct.TensorType(name="triplane_buffer", shape=shape_x, dtype=np.float32),
+            ct.TensorType(name="cond_emb", shape=shape_cond, dtype=np.float32)
+        ],
+        outputs=[ct.TensorType(name="pred_plane", dtype=np.float32)],
+        minimum_deployment_target=ct.target.iOS18,
+        compute_precision=ct.precision.FLOAT16,
+    )
+    print(f"      Conversion OK ({time.time()-t0:.1f}s)")
+
+    print(f"\n[5/5] Save → {mlpackage_path}")
+    mlmodel.save(mlpackage_path)
+
+    if not args.no_verify:
+        print("\n" + "-" * 70)
+        print("Quick sanity check: 5 random inputs, PyTorch vs CoreML")
+        print("-" * 70)
+        torch.manual_seed(0)
+        for i in range(5):
+            x_np = np.random.rand(*shape_x).astype(np.float32)
+            cond_np = np.random.rand(*shape_cond).astype(np.float32)
+            
+            with torch.no_grad():
+                pt_out = model(torch.from_numpy(x_np), torch.from_numpy(cond_np)).numpy()
+                
+            cml_out = mlmodel.predict({
+                "triplane_buffer": x_np, 
+                "cond_emb": cond_np
+            })["pred_plane"]
+            
+            diff = np.abs(pt_out - cml_out).max()
+            print(f"  Input {i}: max_abs = {diff:.2e}")
+
+    print("\n" + "=" * 70)
+    print("Export complete!")
+    print("=" * 70)
+
+
+if __name__ == "__main__":
+    export(parse_args())

--- a/tests/parity_tests/export_for_parity.py
+++ b/tests/parity_tests/export_for_parity.py
@@ -1,0 +1,95 @@
+"""
+export_for_parity.py — Export StatefulMambaHybrid1D with a fixed seed and save weights.
+
+Runs on dorian-mac (needs coremltools). Creates:
+  outputs/StatefulMambaHybrid1D_seq224_c1000_alpha0.1.mlpackage  (overwritten)
+  outputs/StatefulMambaHybrid1D_seq224_c1000_alpha0.1.pt          (state_dict)
+
+Usage: python tests/parity_tests/export_for_parity.py
+"""
+import sys, os, time
+from pathlib import Path
+import numpy as np
+import torch
+import coremltools as ct
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from mamba_ane.models.hybrid1d import StatefulMambaHybrid1D
+
+SEED        = 42
+NUM_CLASSES = 1000
+SEQ_LENGTH  = 224
+EMA_ALPHA   = 0.1
+OUT_DIR     = Path(__file__).resolve().parents[2] / 'outputs'
+STEM        = f"StatefulMambaHybrid1D_seq{SEQ_LENGTH}_c{NUM_CLASSES}_alpha{EMA_ALPHA}"
+
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+MLPACKAGE_PATH = OUT_DIR / f"{STEM}.mlpackage"
+WEIGHTS_PATH   = OUT_DIR / f"{STEM}.pt"
+
+# ── Build model with fixed seed ───────────────────────────────────────────────
+print(f"[1/4] Building model (seed={SEED})")
+torch.manual_seed(SEED)
+model = StatefulMambaHybrid1D(
+    num_classes=NUM_CLASSES,
+    backbone_in_channels=3,
+    backbone_hidden_dim=256,
+    backbone_output_dim=512,
+    seq_length=SEQ_LENGTH,
+    ema_alpha=EMA_ALPHA,
+    mamba_d_state=64,
+    mamba_headdim=64,
+    mamba_num_heads=8,
+).eval()
+print(f"      Parameters: {sum(p.numel() for p in model.parameters())/1e6:.2f}M")
+
+# ── Save state_dict ───────────────────────────────────────────────────────────
+print(f"[2/4] Saving weights → {WEIGHTS_PATH}")
+torch.save(model.state_dict(), WEIGHTS_PATH)
+
+# ── TorchScript trace ─────────────────────────────────────────────────────────
+print(f"[3/4] Tracing + CoreML conversion")
+example_input = torch.rand(1, 3, SEQ_LENGTH)
+with torch.no_grad():
+    traced = torch.jit.trace(model, (example_input,))
+
+states_list = [
+    ct.StateType(wrapped_type=ct.TensorType(shape=model.mamba.angle_state.shape), name="mamba.angle_state"),
+    ct.StateType(wrapped_type=ct.TensorType(shape=model.mamba.k_state.shape),     name="mamba.k_state"),
+    ct.StateType(wrapped_type=ct.TensorType(shape=model.mamba.v_state.shape),     name="mamba.v_state"),
+    ct.StateType(wrapped_type=ct.TensorType(shape=model.mamba.ssm_state.shape),   name="mamba.ssm_state"),
+]
+
+t0 = time.time()
+mlmodel = ct.convert(
+    traced,
+    convert_to="mlprogram",
+    inputs=[ct.TensorType(name="x", shape=(1, 3, SEQ_LENGTH), dtype=np.float32)],
+    outputs=[ct.TensorType(name="logits", dtype=np.float32)],
+    states=states_list,
+    minimum_deployment_target=ct.target.iOS18,
+    compute_precision=ct.precision.FLOAT16,
+)
+print(f"      Conversion OK ({time.time()-t0:.1f}s)")
+
+# ── Save mlpackage ────────────────────────────────────────────────────────────
+print(f"[4/4] Saving mlpackage → {MLPACKAGE_PATH}")
+mlmodel.save(str(MLPACKAGE_PATH))
+
+# ── Quick sanity check: 3 frames, same model vs CoreML ───────────────────────
+print("\nSanity check (3 frames, both starting from zero state):")
+model.mamba.angle_state.zero_()
+model.mamba.k_state.zero_()
+model.mamba.v_state.zero_()
+model.mamba.ssm_state.zero_()
+coreml_state = mlmodel.make_state()
+torch.manual_seed(0)
+for i in range(3):
+    x = torch.rand(1, 3, SEQ_LENGTH)
+    with torch.no_grad():
+        pt_out = model(x).numpy()
+    cml_out = mlmodel.predict({"x": x.numpy()}, state=coreml_state)["logits"]
+    diff = np.abs(pt_out - cml_out).max()
+    print(f"  Frame {i}: max_abs={diff:.2e}")
+
+print("\nDone. Run test_ane_mac.py to get the full parity report.")

--- a/tests/parity_tests/og_model.py
+++ b/tests/parity_tests/og_model.py
@@ -1,0 +1,147 @@
+"""
+og_model.py — OGStatefulMambaHybrid1D
+
+Reference model: Hybrid1DBackbone + Mamba3(expand=1, CUDA FP32).
+Used as the golden reference for ANE parity tests.
+
+Do NOT import from tests/ane/StatefulMobileNet/mamba/model.py to avoid
+circular issues — Hybrid1DBackbone is duplicated here verbatim.
+"""
+import sys
+from pathlib import Path
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+# Allow import of mamba_ssm from repo root
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+from mamba_ssm.modules.mamba3 import Mamba3
+
+try:
+    from mamba_ssm.utils.generation import InferenceParams
+except ImportError:
+    from dataclasses import dataclass, field
+    @dataclass
+    class InferenceParams:
+        max_seqlen: int; max_batch_size: int; seqlen_offset: int = 0
+        batch_size_offset: int = 0
+        key_value_memory_dict: dict = field(default_factory=dict)
+        lengths_per_sample = None
+
+
+class Hybrid1DBackbone(nn.Module):
+    """Exact copy of Hybrid1DBackbone from model.py — do not diverge."""
+    def __init__(self, in_channels=3, hidden_dim=256, output_dim=512, seq_length=224):
+        super().__init__()
+        self.seq_length = seq_length
+        self.conv1 = nn.Conv1d(in_channels, hidden_dim, kernel_size=5, stride=2, padding=2, bias=True)
+        self.silu1 = nn.SiLU(inplace=True)
+        self.conv2 = nn.Conv1d(hidden_dim, hidden_dim * 2, kernel_size=5, stride=2, padding=2, bias=True)
+        self.silu2 = nn.SiLU(inplace=True)
+        conv_out_length = seq_length // 4
+        self.fc1 = nn.Linear(hidden_dim * 2 * conv_out_length, hidden_dim * 2)
+        self.silu3 = nn.SiLU(inplace=True)
+        self.fc2 = nn.Linear(hidden_dim * 2, output_dim)
+        self.silu4 = nn.SiLU(inplace=True)
+
+    def forward(self, x):
+        x = self.silu1(self.conv1(x))
+        x = self.silu2(self.conv2(x))
+        x = x.flatten(1)
+        x = self.silu3(self.fc1(x))
+        x = self.silu4(self.fc2(x))
+        return x
+
+
+class OGStatefulMambaHybrid1D(nn.Module):
+    """
+    Golden reference: same Hybrid1DBackbone as StatefulMambaHybrid1D,
+    but uses Mamba3(expand=1) from mamba_ssm instead of MambaBlock.
+
+    expand=1 → d_inner=512, nheads=8, num_rope_angles=16 — exact match to MambaBlock.
+
+    Autoregressive inference: forward() called with seqlen=1 and
+    seqlen_offset kept at 0 permanently. Requires mamba3.py fix (Input_States).
+    """
+    def __init__(self, num_classes=1000, backbone_in_channels=3,
+                 backbone_hidden_dim=256, backbone_output_dim=512,
+                 seq_length=224, mamba_d_state=64, mamba_headdim=64,
+                 device=None, dtype=torch.float32):
+        super().__init__()
+        self.backbone = Hybrid1DBackbone(
+            in_channels=backbone_in_channels,
+            hidden_dim=backbone_hidden_dim,
+            output_dim=backbone_output_dim,
+            seq_length=seq_length,
+        )
+        self.mamba = Mamba3(
+            d_model=backbone_output_dim,
+            d_state=mamba_d_state,
+            expand=1,                  # d_inner = backbone_output_dim
+            headdim=mamba_headdim,
+            ngroups=1,
+            rope_fraction=0.5,
+            is_mimo=False,
+            is_outproj_norm=False,
+            layer_idx=0,
+            device=device,
+            dtype=dtype,
+        )
+        self.dropout = nn.Dropout(0.2)
+        self.classifier = nn.Linear(backbone_output_dim, num_classes)
+        self._inf_params = None
+
+    def reset_state(self):
+        self._inf_params = InferenceParams(max_seqlen=4096, max_batch_size=1)
+        self._inf_params.seqlen_offset = 0  # NEVER increment — always use forward path
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        """x: (1, 3, seq_length) — one frame at a time."""
+        if self._inf_params is None:
+            self.reset_state()
+        features = self.backbone(x)                              # (1, backbone_output_dim)
+        mamba_in = features.unsqueeze(1)                         # (1, 1, backbone_output_dim)
+        mamba_out = self.mamba(mamba_in, inference_params=self._inf_params)
+        mamba_out = mamba_out.squeeze(1)                         # (1, backbone_output_dim)
+        logits = self.classifier(self.dropout(mamba_out))
+        return logits
+
+    def load_from_stateful(self, src) -> None:
+        """
+        Copy weights from StatefulMambaHybrid1D into this model.
+        src.mamba is a MambaBlock; self.mamba is a Mamba3(expand=1).
+        All backbone and classifier weights are copied directly.
+        The only reshape needed is B_bias / C_bias layout.
+        """
+        with torch.no_grad():
+            # Backbone (same class, same shapes)
+            self.backbone.load_state_dict(src.backbone.state_dict())
+            # Classifier
+            self.classifier.load_state_dict(src.classifier.state_dict())
+            # Mamba3 ← MambaBlock (direct copies)
+            self.mamba.in_proj.weight.copy_(src.mamba.in_proj.weight)
+            self.mamba.out_proj.weight.copy_(src.mamba.out_proj.weight)
+            self.mamba.dt_bias.copy_(src.mamba.dt_bias)
+            self.mamba.D.copy_(src.mamba.D)
+            self.mamba.B_norm.weight.copy_(src.mamba.B_norm.weight)
+            self.mamba.C_norm.weight.copy_(src.mamba.C_norm.weight)
+            # B_bias: MambaBlock (1,8,64) → Mamba3 (8,1,64)
+            self.mamba.B_bias.copy_(src.mamba.B_bias.squeeze(0).unsqueeze(1))
+            # C_bias: same reshape
+            self.mamba.C_bias.copy_(src.mamba.C_bias.squeeze(0).unsqueeze(1))
+
+
+if __name__ == '__main__':
+    # Smoke test
+    from mamba_ane.models.hybrid1d import StatefulMambaHybrid1D
+    torch.manual_seed(42)
+    ref = StatefulMambaHybrid1D().cuda().float().eval()
+    og = OGStatefulMambaHybrid1D().cuda().float().eval()
+    og.load_from_stateful(ref)
+    x = torch.randn(1, 3, 224, device='cuda')
+    with torch.no_grad():
+        out_ref = ref(x)
+        out_og  = og(x)
+    print(f"ref logits norm: {out_ref.norm():.4f}")
+    print(f"og  logits norm: {out_og.norm():.4f}")
+    print("load_from_stateful: OK")

--- a/tests/parity_tests/parity_lib.py
+++ b/tests/parity_tests/parity_lib.py
@@ -1,0 +1,98 @@
+"""
+parity_lib.py — Shared parity metrics and report generation.
+No model imports. Used by test_impl_gpu.py and test_ane_mac.py.
+"""
+import math
+from datetime import datetime
+
+
+def compute_metrics(test, ref):
+    """max_abs, mean_abs, cosine_sim between test and ref tensors."""
+    diff = (test.float() - ref.float()).abs()
+    a = test.float().flatten()
+    b = ref.float().flatten()
+    mask = (a != 0) | (b != 0)
+    if mask.sum() == 0:
+        cos = 1.0
+    else:
+        a, b = a[mask], b[mask]
+        dot = (a * b).sum()
+        cos = (dot / (a.norm() * b.norm()).clamp(min=1e-12)).item()
+    return {'max_abs': diff.max().item(), 'mean_abs': diff.mean().item(), 'cosine_sim': cos}
+
+
+def aggregate_metrics(per_step):
+    """
+    per_step: list of dicts {max_abs, mean_abs, cosine_sim} — one per measurement frame.
+    Returns {max_abs (worst), mean_abs_avg, cosine_sim_min}.
+    """
+    return {
+        'max_abs':        max(m['max_abs']    for m in per_step),
+        'mean_abs_avg':   sum(m['mean_abs']   for m in per_step) / len(per_step),
+        'cosine_sim_min': min(m['cosine_sim'] for m in per_step),
+    }
+
+
+def check_thresholds(agg, tol):
+    """tol: dict with optional keys max_abs, mean_abs, cosine_sim."""
+    fails = []
+    if 'max_abs'    in tol and agg['max_abs']        > tol['max_abs']:
+        fails.append(f"max_abs={agg['max_abs']:.2e} > {tol['max_abs']:.2e}")
+    if 'mean_abs'   in tol and agg['mean_abs_avg']   > tol['mean_abs']:
+        fails.append(f"mean_abs_avg={agg['mean_abs_avg']:.2e} > {tol['mean_abs']:.2e}")
+    if 'cosine_sim' in tol and agg['cosine_sim_min'] < tol['cosine_sim']:
+        fails.append(f"cosine_sim_min={agg['cosine_sim_min']:.6f} < {tol['cosine_sim']}")
+    return {'pass': len(fails) == 0, 'failed_checks': fails}
+
+
+def ascii_histogram(values, n_bins=8, width=30):
+    if not values: return "(no data)"
+    lo, hi = min(values), max(values)
+    if lo == hi: return f"All = {lo:.3e}"
+    bins = [0] * n_bins
+    for v in values:
+        bins[min(int((v - lo) / (hi - lo) * n_bins), n_bins - 1)] += 1
+    mx = max(bins) or 1
+    lines = []
+    for i, c in enumerate(bins):
+        low  = lo + (hi - lo) * i / n_bins
+        high = lo + (hi - lo) * (i + 1) / n_bins
+        lines.append(f"[{low:.2e},{high:.2e}) {c:4d}  {'#' * int(c/mx*width)}")
+    return '\n'.join(lines)
+
+
+def generate_report(title, comparisons, config_str, seq_str):
+    """
+    comparisons: list of dicts:
+      {name, ref_label, test_label, tol, agg, threshold, per_step_max_abs}
+    """
+    ts = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
+    lines = [f"# {title}", f"\nGenerated: {ts}",
+             f"Config: {config_str}", f"Sequence: {seq_str}", ""]
+
+    for c in comparisons:
+        agg = c['agg']
+        thr = c['threshold']
+        status = "**PASS**" if thr['pass'] else "**FAIL**"
+        lines.append(f"## {c['name']}: `{c['ref_label']}` → `{c['test_label']}`")
+        lines.append(f"Tolerances: max_abs < {c['tol'].get('max_abs','—')}, "
+                     f"cosine_sim > {c['tol'].get('cosine_sim','—')}")
+        lines.append("")
+        lines.append("| Metric | Value | Status |")
+        lines.append("|--------|-------|--------|")
+        lines.append(f"| max_abs (worst frame)     | {agg['max_abs']:.3e}    | {status} |")
+        lines.append(f"| mean_abs_avg              | {agg['mean_abs_avg']:.3e} |  |")
+        lines.append(f"| cosine_sim_min            | {agg['cosine_sim_min']:.6f} |  |")
+        lines.append("")
+        if thr['failed_checks']:
+            lines.append("**Failed checks:**")
+            for f in thr['failed_checks']:
+                lines.append(f"- {f}")
+            lines.append("")
+        lines.append("### max_abs distribution across measurement frames")
+        lines.append("```")
+        lines.append(ascii_histogram(c['per_step_max_abs']))
+        lines.append("```")
+        lines.append("")
+
+    return '\n'.join(lines) + '\n'

--- a/tests/parity_tests/parity_report_ane.md
+++ b/tests/parity_tests/parity_report_ane.md
@@ -1,0 +1,27 @@
+# ANE Parity Report: StatefulMambaHybrid1D
+
+Generated: 2026-05-07 10:32:39
+Config: d_model=512, d_state=64, headdim=64, num_heads=8, seq_length=224
+Sequence: warmup=32 + measure=64 frames, seed=42, compute_units=CPU_AND_NE
+
+## ANE: `pytorch FP32 (CPU)` → `CoreML CPU_AND_NE`
+Tolerances: max_abs < 0.03, cosine_sim > 0.999
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| max_abs (worst frame)     | 2.102e-04    | **PASS** |
+| mean_abs_avg              | 2.067e-05 |  |
+| cosine_sim_min            | 0.999998 |  |
+
+### max_abs distribution across measurement frames
+```
+[3.35e-05,5.56e-05)   15  ############################
+[5.56e-05,7.77e-05)   14  ##########################
+[7.77e-05,9.98e-05)   12  ######################
+[9.98e-05,1.22e-04)   16  ##############################
+[1.22e-04,1.44e-04)    2  ###
+[1.44e-04,1.66e-04)    3  #####
+[1.66e-04,1.88e-04)    1  #
+[1.88e-04,2.10e-04)    1  #
+```
+

--- a/tests/parity_tests/parity_report_gpu.md
+++ b/tests/parity_tests/parity_report_gpu.md
@@ -1,0 +1,48 @@
+# GPU Parity Report: StatefulMambaHybrid1D
+
+Generated: 2026-05-07 08:31:15
+Config: d_model=512, d_state=64, expand=1, headdim=64, num_heads=8, seq_length=224
+Sequence: warmup=32 + measure=64 frames, seed=42, batch=1
+
+## IMPL: `OG_FP32 (Mamba3 CUDA)` → `ANE_FP32 (MambaBlock)`
+Tolerances: max_abs < 0.01, cosine_sim > 0.999
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| max_abs (worst frame)     | 6.006e-06    | **PASS** |
+| mean_abs_avg              | 5.389e-07 |  |
+| cosine_sim_min            | 1.000000 |  |
+
+### max_abs distribution across measurement frames
+```
+[6.44e-07,1.31e-06)   14  ######################
+[1.31e-06,1.98e-06)   19  ##############################
+[1.98e-06,2.65e-06)   15  #######################
+[2.65e-06,3.32e-06)    5  #######
+[3.32e-06,4.00e-06)    3  ####
+[4.00e-06,4.67e-06)    4  ######
+[4.67e-06,5.34e-06)    3  ####
+[5.34e-06,6.01e-06)    1  #
+```
+
+## PREC: `ANE_FP32` → `ANE_FP16`
+Tolerances: max_abs < 0.01, cosine_sim > 0.999
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| max_abs (worst frame)     | 3.046e-05    | **PASS** |
+| mean_abs_avg              | 5.252e-06 |  |
+| cosine_sim_min            | 1.000000 |  |
+
+### max_abs distribution across measurement frames
+```
+[2.74e-05,2.78e-05)    5  #######
+[2.78e-05,2.82e-05)    3  ####
+[2.82e-05,2.85e-05)    4  ######
+[2.85e-05,2.89e-05)   11  #################
+[2.89e-05,2.93e-05)   19  ##############################
+[2.93e-05,2.97e-05)    9  ##############
+[2.97e-05,3.01e-05)    8  ############
+[3.01e-05,3.05e-05)    5  #######
+```
+

--- a/tests/parity_tests/parity_report_parallel.md
+++ b/tests/parity_tests/parity_report_parallel.md
@@ -1,0 +1,48 @@
+# Parallel ANE Parity Report: StatefulMambaParallelHybrid
+
+Generated: 2026-05-11 15:53:41
+Config: d_model=256, d_state=64, headdim=64, seq_length=256, num_classes=10
+Sequence: 64 independent inputs, seed=42, compute_units=CPU_AND_NE
+
+## MPS_FP16: `OG_FP32 (golden)` → `Portable_FP16 (mps)`
+Tolerances: max_abs < 0.01, cosine_sim > 0.9999
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| max_abs (worst frame)     | 3.628e-05    | **PASS** |
+| mean_abs_avg              | 8.629e-06 |  |
+| cosine_sim_min            | 1.000000 |  |
+
+### max_abs distribution across measurement frames
+```
+[1.07e-05,1.39e-05)    2  ###
+[1.39e-05,1.71e-05)    1  #
+[1.71e-05,2.03e-05)   11  #################
+[2.03e-05,2.35e-05)   19  ##############################
+[2.35e-05,2.67e-05)   14  ######################
+[2.67e-05,2.99e-05)    9  ##############
+[2.99e-05,3.31e-05)    7  ###########
+[3.31e-05,3.63e-05)    1  #
+```
+
+## CoreML_ANE: `OG_FP32 (golden)` → `CoreML CPU_AND_NE`
+Tolerances: max_abs < 0.03, cosine_sim > 0.999
+
+| Metric | Value | Status |
+|--------|-------|--------|
+| max_abs (worst frame)     | 5.780e-04    | **PASS** |
+| mean_abs_avg              | 1.467e-04 |  |
+| cosine_sim_min            | 0.999973 |  |
+
+### max_abs distribution across measurement frames
+```
+[1.87e-04,2.35e-04)    9  ##############
+[2.35e-04,2.84e-04)   11  #################
+[2.84e-04,3.33e-04)   19  ##############################
+[3.33e-04,3.82e-04)   10  ###############
+[3.82e-04,4.31e-04)    5  #######
+[4.31e-04,4.80e-04)    5  #######
+[4.80e-04,5.29e-04)    4  ######
+[5.29e-04,5.78e-04)    1  #
+```
+

--- a/tests/parity_tests/test_ane_mac.py
+++ b/tests/parity_tests/test_ane_mac.py
@@ -1,0 +1,105 @@
+"""
+test_ane_mac.py — ANE parity: pytorch FP32 vs CoreML CPU_AND_NE.
+Runs on dorian-mac only (requires coremltools + Apple Silicon).
+
+Usage: python tests/parity_tests/test_ane_mac.py
+"""
+import sys, torch, numpy as np
+from pathlib import Path
+import coremltools as ct
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))  # repo root for mamba_ane
+sys.path.insert(0, str(Path(__file__).resolve().parent))       # for parity_lib local import
+
+from mamba_ane.models.hybrid1d import StatefulMambaHybrid1D
+from parity_lib import compute_metrics, aggregate_metrics, check_thresholds, generate_report
+
+# ── Config ──────────────────────────────────────────────────────────────────
+SEED        = 42
+N_WARMUP    = 32
+N_MEASURE   = 64
+SEQ_LENGTH  = 224
+N_TOTAL     = N_WARMUP + N_MEASURE
+
+MLPACKAGE   = Path(__file__).resolve().parents[2] / 'outputs' / \
+              'StatefulMambaHybrid1D_seq224_c1000_alpha0.1.mlpackage'
+WEIGHTS     = Path(__file__).resolve().parents[2] / 'outputs' / \
+              'StatefulMambaHybrid1D_seq224_c1000_alpha0.1.pt'
+
+TOL_ANE = {'max_abs': 3e-2, 'cosine_sim': 0.999}
+
+# ── Load models ──────────────────────────────────────────────────────────────
+
+print(f"Loading .mlpackage from {MLPACKAGE}")
+assert MLPACKAGE.exists(), f"mlpackage not found: {MLPACKAGE}"
+assert WEIGHTS.exists(), f"weights not found: {WEIGHTS} — run export_for_parity.py first"
+
+mlmodel = ct.models.MLModel(str(MLPACKAGE),
+                             compute_units=ct.ComputeUnit.CPU_AND_NE)
+print("CoreML model loaded (CPU_AND_NE)")
+
+pt_model = StatefulMambaHybrid1D().float().eval()
+pt_model.load_state_dict(torch.load(WEIGHTS, map_location='cpu'))
+print(f"PyTorch weights loaded from {WEIGHTS.name}")
+
+# Reset pytorch state buffers
+for buf in ['angle_state', 'ssm_state', 'k_state', 'v_state']:
+    getattr(pt_model.mamba, buf).zero_()
+
+# CoreML state
+coreml_state = mlmodel.make_state()
+
+# ── Generate frames ───────────────────────────────────────────────────────────
+
+g = torch.Generator(); g.manual_seed(SEED)
+frames = torch.randn(N_TOTAL, 1, 3, SEQ_LENGTH, generator=g, dtype=torch.float32)
+
+# ── Run both models ───────────────────────────────────────────────────────────
+
+print(f"Running {N_TOTAL} frames (warmup={N_WARMUP}, measure={N_MEASURE})...")
+
+outs_pt     = []
+outs_coreml = []
+
+with torch.no_grad():
+    for t in range(N_TOTAL):
+        x = frames[t]                                  # (1, 3, 224)
+        x_np = x.numpy().astype(np.float32)
+
+        out_pt = pt_model(x).cpu().float()
+        outs_pt.append(out_pt)
+
+        out_cml = mlmodel.predict({'x': x_np}, state=coreml_state)['logits']
+        outs_coreml.append(torch.from_numpy(out_cml).float())
+
+        if (t + 1) % 16 == 0:
+            print(f"  {t+1}/{N_TOTAL} frames done")
+
+# ── Metrics ───────────────────────────────────────────────────────────────────
+
+per_step = [compute_metrics(outs_coreml[N_WARMUP + i], outs_pt[N_WARMUP + i])
+            for i in range(N_MEASURE)]
+agg  = aggregate_metrics(per_step)
+thr  = check_thresholds(agg, TOL_ANE)
+hist = [m['max_abs'] for m in per_step]
+
+status = 'PASS' if thr['pass'] else 'FAIL'
+print(f"\nANE (CPU_AND_NE): {status}")
+print(f"  max_abs={agg['max_abs']:.3e}  cosine_sim_min={agg['cosine_sim_min']:.6f}")
+if not thr['pass']:
+    for f in thr['failed_checks']: print(f"  x {f}")
+
+# ── Report ────────────────────────────────────────────────────────────────────
+
+cfg_str = f"d_model=512, d_state=64, headdim=64, num_heads=8, seq_length={SEQ_LENGTH}"
+seq_str = f"warmup={N_WARMUP} + measure={N_MEASURE} frames, seed={SEED}, compute_units=CPU_AND_NE"
+
+comparisons = [
+    dict(name='ANE', ref_label='pytorch FP32 (CPU)', test_label='CoreML CPU_AND_NE',
+         tol=TOL_ANE, agg=agg, threshold=thr, per_step_max_abs=hist),
+]
+
+report_path = Path(__file__).parent / 'parity_report_ane.md'
+report_path.write_text(generate_report(
+    'ANE Parity Report: StatefulMambaHybrid1D', comparisons, cfg_str, seq_str))
+print(f"\nReport written to {report_path}")

--- a/tests/parity_tests/test_impl_gpu.py
+++ b/tests/parity_tests/test_impl_gpu.py
@@ -1,0 +1,124 @@
+"""
+test_impl_gpu.py — GPU parity: OG_FP32 vs ANE_FP32, then ANE_FP32 vs ANE_FP16.
+Runs on pc_ia (RTX 4090). Requires mamba3.py fix (Task 1).
+
+Usage: python tests/parity_tests/test_impl_gpu.py
+"""
+import sys, torch
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+
+from mamba_ane.models.hybrid1d import StatefulMambaHybrid1D
+from og_model import OGStatefulMambaHybrid1D
+from parity_lib import compute_metrics, aggregate_metrics, check_thresholds, generate_report
+
+# ── Config ──────────────────────────────────────────────────────────────────
+SEED        = 42
+N_WARMUP    = 32
+N_MEASURE   = 64
+SEQ_LENGTH  = 224
+BATCH       = 1
+DEVICE      = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+
+TOL_IMPL = {'max_abs': 1e-2, 'cosine_sim': 0.999}
+TOL_PREC = {'max_abs': 1e-2, 'cosine_sim': 0.999}
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+def make_frames(n, seed=SEED, dtype=torch.float32):
+    g = torch.Generator(); g.manual_seed(seed)
+    return torch.randn(n, BATCH, 3, SEQ_LENGTH, generator=g, dtype=torch.float32).to(DEVICE, dtype)
+
+
+def run_model(model, frames):
+    """Run model frame by frame. Returns list of logit tensors."""
+    outs = []
+    with torch.no_grad():
+        for t in range(len(frames)):
+            out = model(frames[t])
+            outs.append(out.detach().cpu().float())
+    return outs
+
+
+def reset_model(model):
+    """Reset any accumulated state before a run."""
+    if hasattr(model, 'reset_state'):
+        model.reset_state()
+    elif hasattr(model, 'mamba'):
+        for buf in ['angle_state', 'ssm_state', 'k_state', 'v_state']:
+            b = getattr(model.mamba, buf, None)
+            if b is not None: b.zero_()
+
+# ── Build reference model ────────────────────────────────────────────────────
+
+torch.manual_seed(SEED)
+ref_fp32 = StatefulMambaHybrid1D().to(DEVICE).float().eval()
+
+# OG model gets exact same weights via mapper
+og_fp32 = OGStatefulMambaHybrid1D().to(DEVICE).float().eval()
+og_fp32.load_from_stateful(ref_fp32)
+
+# FP16 model gets same weights (copied from fp32 then cast)
+ref_fp16 = StatefulMambaHybrid1D().to(DEVICE).half().eval()
+with torch.no_grad():
+    for (n1, p1), (n2, p2) in zip(ref_fp16.named_parameters(), ref_fp32.named_parameters()):
+        p1.copy_(p2.half())
+
+# ── All frames ───────────────────────────────────────────────────────────────
+
+N_TOTAL = N_WARMUP + N_MEASURE
+frames_fp32 = make_frames(N_TOTAL, dtype=torch.float32)
+frames_fp16 = make_frames(N_TOTAL, dtype=torch.float16)
+
+# ── Run models ───────────────────────────────────────────────────────────────
+
+print(f"Device: {DEVICE}")
+print(f"Warmup: {N_WARMUP} frames  Measure: {N_MEASURE} frames")
+
+print("\n[1/2] OG_FP32 vs ANE_FP32 (implementation gap)...")
+reset_model(og_fp32); outs_og   = run_model(og_fp32,   frames_fp32)
+reset_model(ref_fp32); outs_fp32 = run_model(ref_fp32, frames_fp32)
+
+print("[2/2] ANE_FP32 vs ANE_FP16 (precision gap)...")
+reset_model(ref_fp32); outs_fp32b = run_model(ref_fp32, frames_fp32)
+reset_model(ref_fp16); outs_fp16  = run_model(ref_fp16, frames_fp16)
+
+# ── Metrics (measurement frames only) ────────────────────────────────────────
+
+def measure(outs_ref, outs_test):
+    per_step = [compute_metrics(outs_test[N_WARMUP + i], outs_ref[N_WARMUP + i])
+                for i in range(N_MEASURE)]
+    return aggregate_metrics(per_step), [m['max_abs'] for m in per_step]
+
+agg_impl, hist_impl = measure(outs_og,    outs_fp32)
+agg_prec, hist_prec = measure(outs_fp32b, outs_fp16)
+
+thr_impl = check_thresholds(agg_impl, TOL_IMPL)
+thr_prec = check_thresholds(agg_prec, TOL_PREC)
+
+# ── Print summary ─────────────────────────────────────────────────────────────
+
+for label, agg, thr in [('IMPL (OG→ANE FP32)', agg_impl, thr_impl),
+                         ('PREC (FP32→FP16)',   agg_prec, thr_prec)]:
+    status = 'PASS' if thr['pass'] else 'FAIL'
+    print(f"\n{label}: {status}")
+    print(f"  max_abs={agg['max_abs']:.3e}  cosine_sim_min={agg['cosine_sim_min']:.6f}")
+    if not thr['pass']:
+        for f in thr['failed_checks']: print(f"  x {f}")
+
+# ── Write report ──────────────────────────────────────────────────────────────
+
+cfg_str = f"d_model=512, d_state=64, expand=1, headdim=64, num_heads=8, seq_length={SEQ_LENGTH}"
+seq_str = f"warmup={N_WARMUP} + measure={N_MEASURE} frames, seed={SEED}, batch={BATCH}"
+
+comparisons = [
+    dict(name='IMPL', ref_label='OG_FP32 (Mamba3 CUDA)', test_label='ANE_FP32 (MambaBlock)',
+         tol=TOL_IMPL, agg=agg_impl, threshold=thr_impl, per_step_max_abs=hist_impl),
+    dict(name='PREC', ref_label='ANE_FP32', test_label='ANE_FP16',
+         tol=TOL_PREC, agg=agg_prec, threshold=thr_prec, per_step_max_abs=hist_prec),
+]
+
+report_path = Path(__file__).parent / 'parity_report_gpu.md'
+report_path.write_text(generate_report(
+    'GPU Parity Report: StatefulMambaHybrid1D', comparisons, cfg_str, seq_str))
+print(f"\nReport written to {report_path}")

--- a/tests/parity_tests/test_parallel_gpu.py
+++ b/tests/parity_tests/test_parallel_gpu.py
@@ -139,12 +139,12 @@ golden = {
     'outputs_fp16':     torch.stack(outs_fp16),
 }
 for L in [64, 256, 1024]:
-    u = torch.randn(1, L, D_MODEL, generator=torch.Generator().manual_seed(SEED))
+    u = torch.randn(1, L, D_MODEL, device=DEVICE, generator=torch.Generator(device=DEVICE).manual_seed(SEED))
     from mamba_ssm.modules.mamba3 import Mamba3 as _Mamba3
     og_raw = _Mamba3(d_model=D_MODEL, d_state=64, expand=2, headdim=64,
                      ngroups=1, rope_fraction=0.5, is_mimo=False,
-                     is_outproj_norm=False, layer_idx=0).float().eval()
-    portable_raw = Mamba3ParallelPortable(d_model=D_MODEL).float().eval()
+                     is_outproj_norm=False, layer_idx=0).to(DEVICE).float().eval()
+    portable_raw = Mamba3ParallelPortable(d_model=D_MODEL).to(DEVICE).float().eval()
     portable_raw.load_from_original(og_raw)
     with torch.no_grad():
         golden[f'raw_input_{L}']  = u.cpu()

--- a/tests/parity_tests/test_parallel_gpu.py
+++ b/tests/parity_tests/test_parallel_gpu.py
@@ -1,0 +1,184 @@
+# tests/parity_tests/test_parallel_gpu.py
+"""
+GPU parity: OGStatefulMambaParallelHybrid (Mamba3 CUDA) vs
+            StatefulMambaParallelHybrid (Mamba3ParallelPortable).
+
+Two comparisons:
+  IMPL: OG_FP32  vs  Portable_FP32  (algorithm gap)
+  PREC: Port_FP32  vs  Port_FP16  (precision gap)
+
+Plus raw module comparison at L in {64, 256, 1024}.
+
+Saves: outputs/golden_parallel.pt
+  keys: config, weights, inputs_{L}, golden_{L} for L in {64, 256, 1024}
+
+Run: python tests/parity_tests/test_parallel_gpu.py
+Requires: CUDA + mamba_ssm (Triton kernels)
+"""
+import sys, os, torch
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mamba_ane.modules.mamba3_parallel import Mamba3ParallelPortable
+from mamba_ane.models.hybrid_parallel import (
+    StatefulMambaParallelHybrid, _build_og_model
+)
+from parity_lib import compute_metrics, aggregate_metrics, check_thresholds, generate_report
+
+SEED        = 42
+N_SAMPLES   = 64          # number of independent (B=1, L=256, 3) inputs to measure
+SEQ_LENGTH  = 256         # primary sequence length for full-model comparison
+D_MODEL     = 256
+IN_CHANNELS = 3
+NUM_CLASSES = 10
+DEVICE      = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+OUT_DIR     = Path(__file__).resolve().parents[2] / 'outputs'
+
+TOL_IMPL = {'max_abs': 1e-4,  'mean_abs': 1e-5,  'cosine_sim': 0.99999}
+TOL_PREC = {'max_abs': 1e-2,  'cosine_sim': 0.999}
+
+OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+torch.manual_seed(SEED)
+
+# ── Build portable model (FP32) ──────────────────────────────────────────────
+print(f"Device: {DEVICE}")
+print("[1/5] Building StatefulMambaParallelHybrid (portable, FP32)")
+portable_fp32 = StatefulMambaParallelHybrid(
+    num_classes=NUM_CLASSES, in_channels=IN_CHANNELS, d_model=D_MODEL
+).to(DEVICE).float().eval()
+print(f"      Parameters: {sum(p.numel() for p in portable_fp32.parameters())/1e6:.2f}M")
+
+# ── Build OG model, copy weights ─────────────────────────────────────────────
+print("[2/5] Building OGStatefulMambaParallelHybrid and copying weights")
+og_fp32 = _build_og_model(
+    d_model=D_MODEL, d_state=64, headdim=64, num_classes=NUM_CLASSES,
+    in_channels=IN_CHANNELS, hidden_dim=64, device=DEVICE, dtype=torch.float32
+).to(DEVICE).float().eval()
+og_fp32.load_from_portable(portable_fp32)
+
+# ── FP16 portable ─────────────────────────────────────────────────────────────
+portable_fp16 = StatefulMambaParallelHybrid(
+    num_classes=NUM_CLASSES, in_channels=IN_CHANNELS, d_model=D_MODEL
+).to(DEVICE).half().eval()
+with torch.no_grad():
+    for (_, p16), (_, p32) in zip(
+        portable_fp16.named_parameters(), portable_fp32.named_parameters()
+    ):
+        p16.copy_(p32.half())
+
+# ── Generate input samples ────────────────────────────────────────────────────
+print("[3/5] Generating input samples")
+g = torch.Generator(device='cpu'); g.manual_seed(SEED)
+# shape: (N_SAMPLES, 1, IN_CHANNELS, SEQ_LENGTH) — batch=1
+inputs_all = torch.randn(N_SAMPLES, 1, IN_CHANNELS, SEQ_LENGTH, generator=g)
+
+def run_samples(model, inputs, dtype=torch.float32):
+    outs = []
+    with torch.no_grad():
+        for i in range(len(inputs)):
+            x = inputs[i].to(DEVICE, dtype)
+            outs.append(model(x).cpu().float())
+    return outs
+
+print("[4/5] Running all models")
+outs_og   = run_samples(og_fp32,       inputs_all, torch.float32)
+outs_fp32 = run_samples(portable_fp32, inputs_all, torch.float32)
+outs_fp16 = run_samples(portable_fp16, inputs_all, torch.float16)
+
+# ── Raw module L-sweep ────────────────────────────────────────────────────────
+print("[5/5] Raw module L-sweep (direct Mamba3 vs Mamba3ParallelPortable)")
+from mamba_ssm.modules.mamba3 import Mamba3
+
+raw_results = {}
+for L in [64, 256, 1024]:
+    torch.manual_seed(SEED)
+    og_raw = Mamba3(d_model=D_MODEL, d_state=64, expand=2, headdim=64,
+                    ngroups=1, rope_fraction=0.5, is_mimo=False, is_outproj_norm=False,
+                    layer_idx=0, dtype=torch.float32).to(DEVICE).float().eval()
+    portable_raw = Mamba3ParallelPortable(d_model=D_MODEL).to(DEVICE).float().eval()
+    portable_raw.load_from_original(og_raw)
+
+    u = torch.randn(1, L, D_MODEL, device=DEVICE, dtype=torch.float32)
+    with torch.no_grad():
+        ref = og_raw(u)
+        tst = portable_raw(u)
+    m = compute_metrics(tst, ref)
+    raw_results[L] = m
+    status = 'PASS' if m['max_abs'] < 1e-4 and m['cosine_sim'] > 0.99999 else 'FAIL'
+    print(f"  L={L:4d}: max_abs={m['max_abs']:.2e}  cos={m['cosine_sim']:.7f}  {status}")
+
+# ── Full model metrics ────────────────────────────────────────────────────────
+per_impl = [compute_metrics(outs_fp32[i], outs_og[i])   for i in range(N_SAMPLES)]
+per_prec = [compute_metrics(outs_fp16[i], outs_fp32[i]) for i in range(N_SAMPLES)]
+
+agg_impl = aggregate_metrics(per_impl)
+agg_prec = aggregate_metrics(per_prec)
+thr_impl = check_thresholds(agg_impl, TOL_IMPL)
+thr_prec = check_thresholds(agg_prec, TOL_PREC)
+
+for label, agg, thr in [('IMPL (OG→Portable FP32)', agg_impl, thr_impl),
+                         ('PREC (FP32→FP16)',        agg_prec, thr_prec)]:
+    st = 'PASS' if thr['pass'] else 'FAIL'
+    print(f"\n{label}: {st}")
+    print(f"  max_abs={agg['max_abs']:.3e}  cosine_sim_min={agg['cosine_sim_min']:.6f}")
+    if not thr['pass']:
+        for f in thr['failed_checks']: print(f"  x {f}")
+
+# ── Save golden ──────────────────────────────────────────────────────────────
+print("\nSaving golden_parallel.pt ...")
+golden = {
+    'config': dict(d_model=D_MODEL, d_state=64, expand=2, headdim=64,
+                   rope_fraction=0.5, num_classes=NUM_CLASSES,
+                   in_channels=IN_CHANNELS, seq_length=SEQ_LENGTH, seed=SEED),
+    'portable_weights': portable_fp32.state_dict(),
+    'inputs': inputs_all,                                  # (N, 1, C, L)
+    'outputs_og_fp32':  torch.stack(outs_og),              # (N, 1, num_classes)
+    'outputs_fp32':     torch.stack(outs_fp32),
+    'outputs_fp16':     torch.stack(outs_fp16),
+}
+for L in [64, 256, 1024]:
+    u = torch.randn(1, L, D_MODEL, generator=torch.Generator().manual_seed(SEED))
+    from mamba_ssm.modules.mamba3 import Mamba3 as _Mamba3
+    og_raw = _Mamba3(d_model=D_MODEL, d_state=64, expand=2, headdim=64,
+                     ngroups=1, rope_fraction=0.5, is_mimo=False,
+                     is_outproj_norm=False, layer_idx=0).float().eval()
+    portable_raw = Mamba3ParallelPortable(d_model=D_MODEL).float().eval()
+    portable_raw.load_from_original(og_raw)
+    with torch.no_grad():
+        golden[f'raw_input_{L}']  = u.cpu()
+        golden[f'raw_golden_{L}'] = og_raw(u).cpu()
+
+torch.save(golden, OUT_DIR / 'golden_parallel.pt')
+print(f"  Saved to {OUT_DIR / 'golden_parallel.pt'}")
+
+# ── Write report ─────────────────────────────────────────────────────────────
+cfg_str = (f"d_model={D_MODEL}, d_state=64, expand=2, headdim=64, "
+           f"rope_fraction=0.5, seq_length={SEQ_LENGTH}")
+seq_str = f"{N_SAMPLES} independent (B=1, C=3, L={SEQ_LENGTH}) inputs, seed={SEED}"
+
+comparisons = [
+    dict(name='IMPL', ref_label='OG_FP32 (Mamba3 CUDA)', test_label='Portable_FP32',
+         tol=TOL_IMPL, agg=agg_impl, threshold=thr_impl,
+         per_step_max_abs=[m['max_abs'] for m in per_impl]),
+    dict(name='PREC', ref_label='Portable_FP32', test_label='Portable_FP16',
+         tol=TOL_PREC, agg=agg_prec, threshold=thr_prec,
+         per_step_max_abs=[m['max_abs'] for m in per_prec]),
+]
+
+raw_section = "\n## Raw module L-sweep (Mamba3 CUDA vs Mamba3ParallelPortable)\n\n"
+raw_section += "| L | max_abs | cosine_sim | Status |\n|---|---------|------------|--------|\n"
+for L, m in raw_results.items():
+    st = '✓' if m['max_abs'] < 1e-4 and m['cosine_sim'] > 0.99999 else '✗'
+    raw_section += f"| {L} | {m['max_abs']:.2e} | {m['cosine_sim']:.7f} | {st} |\n"
+
+report_path = Path(__file__).parent / 'parity_report_parallel.md'
+body = generate_report(
+    'GPU Parity Report: StatefulMambaParallelHybrid', comparisons, cfg_str, seq_str)
+report_path.write_text(body + raw_section)
+print(f"\nReport written to {report_path}")
+
+# Hard exit code for CI
+if not (thr_impl['pass'] and thr_prec['pass']):
+    sys.exit(1)

--- a/tests/parity_tests/test_parallel_mac.py
+++ b/tests/parity_tests/test_parallel_mac.py
@@ -1,0 +1,175 @@
+# tests/parity_tests/test_parallel_mac.py
+"""
+Mac parity test: PyTorch FP16 (MPS) vs CoreML CPU_AND_NE.
+
+Requires:
+  - outputs/golden_parallel.pt  (produced by test_parallel_gpu.py on pc_ia)
+  - coremltools 9.0 (ane_export conda env)
+  - Apple Silicon Mac (dorian-mac)
+
+Steps:
+  1. Load golden_parallel.pt (weights + reference outputs)
+  2. Run StatefulMambaParallelHybrid in FP16 on MPS; compare vs FP32 golden
+  3. Export to CoreML via export_parallel.py logic
+  4. Run CoreML (CPU_AND_NE); compare vs FP32 golden
+  5. Run 64 inputs through CoreML to check for NaN accumulation
+  6. Write parity_report_parallel.md
+
+Run: python tests/parity_tests/test_parallel_mac.py
+"""
+import sys, time
+import numpy as np
+import torch
+import coremltools as ct
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from mamba_ane.models.hybrid_parallel import StatefulMambaParallelHybrid
+from parity_lib import compute_metrics, aggregate_metrics, check_thresholds, generate_report
+
+GOLDEN_PATH = Path(__file__).resolve().parents[2] / 'outputs' / 'golden_parallel.pt'
+OUT_DIR     = Path(__file__).resolve().parents[2] / 'outputs'
+
+TOL_MPS    = {'max_abs': 1e-2,  'cosine_sim': 0.9999}   # PyTorch FP16 vs FP32 golden
+TOL_COREML = {'max_abs': 3e-2,  'cosine_sim': 0.999}    # CoreML vs FP32 golden
+
+assert GOLDEN_PATH.exists(), (
+    f"golden_parallel.pt not found at {GOLDEN_PATH}\n"
+    "Run test_parallel_gpu.py on pc_ia first, then rsync the outputs/ directory."
+)
+
+print(f"Loading golden from {GOLDEN_PATH}")
+golden = torch.load(GOLDEN_PATH, map_location='cpu')
+cfg    = golden['config']
+
+SEQ_LENGTH  = cfg['seq_length']   # 256
+D_MODEL     = cfg['d_model']      # 256
+IN_CHANNELS = cfg['in_channels']  # 3
+NUM_CLASSES = cfg['num_classes']  # 10
+N_SAMPLES   = golden['inputs'].shape[0]  # 64
+
+print(f"Config: d_model={D_MODEL}, seq_length={SEQ_LENGTH}, "
+      f"n_samples={N_SAMPLES}, num_classes={NUM_CLASSES}")
+
+# ── Load portable model ───────────────────────────────────────────────────────
+print("\n[1/5] Loading StatefulMambaParallelHybrid from golden weights")
+pt_model = StatefulMambaParallelHybrid(
+    num_classes=NUM_CLASSES, in_channels=IN_CHANNELS, d_model=D_MODEL
+).eval()
+pt_model.load_state_dict(golden['portable_weights'])
+
+# ── Step 2: FP16 on MPS ───────────────────────────────────────────────────────
+DEVICE = 'mps' if torch.backends.mps.is_available() else 'cpu'
+print(f"\n[2/5] PyTorch FP16 on {DEVICE}")
+pt_fp16 = StatefulMambaParallelHybrid(
+    num_classes=NUM_CLASSES, in_channels=IN_CHANNELS, d_model=D_MODEL
+).to(DEVICE).half().eval()
+with torch.no_grad():
+    for (_, p16), (_, p32) in zip(
+        pt_fp16.named_parameters(), pt_model.named_parameters()
+    ):
+        p16.copy_(p32.half())
+
+outs_fp16 = []
+with torch.no_grad():
+    for i in range(N_SAMPLES):
+        x = golden['inputs'][i].to(DEVICE, torch.float16)
+        outs_fp16.append(pt_fp16(x).cpu().float())
+
+ref_fp32 = [golden['outputs_og_fp32'][i].float() for i in range(N_SAMPLES)]
+
+per_mps = [compute_metrics(outs_fp16[i], ref_fp32[i]) for i in range(N_SAMPLES)]
+agg_mps = aggregate_metrics(per_mps)
+thr_mps = check_thresholds(agg_mps, TOL_MPS)
+st = 'PASS' if thr_mps['pass'] else 'FAIL'
+print(f"  FP16 MPS: {st}  max_abs={agg_mps['max_abs']:.3e}  "
+      f"cosine_sim_min={agg_mps['cosine_sim_min']:.6f}")
+if not thr_mps['pass']:
+    for f in thr_mps['failed_checks']: print(f"  x {f}")
+
+# ── Step 3: Export to CoreML ─────────────────────────────────────────────────
+print(f"\n[3/5] Exporting to CoreML (seq={SEQ_LENGTH})")
+model_cpu = pt_model.float().cpu().eval()
+input_shape = (1, IN_CHANNELS, SEQ_LENGTH)
+with torch.no_grad():
+    traced = torch.jit.trace(model_cpu, (torch.rand(*input_shape),))
+
+t0 = time.time()
+mlmodel = ct.convert(
+    traced,
+    convert_to="mlprogram",
+    inputs=[ct.TensorType(name="x", shape=input_shape, dtype=np.float32)],
+    outputs=[ct.TensorType(name="logits", dtype=np.float32)],
+    minimum_deployment_target=ct.target.iOS18,
+    compute_precision=ct.precision.FLOAT16,
+)
+elapsed = time.time() - t0
+print(f"      Conversion OK ({elapsed:.1f}s)")
+
+stem = f"StatefulMambaParallelHybrid_seq{SEQ_LENGTH}_c{NUM_CLASSES}"
+mlpackage_path = OUT_DIR / f"{stem}.mlpackage"
+mlmodel.save(str(mlpackage_path))
+print(f"      Saved → {mlpackage_path}")
+
+# ── Step 4: CoreML CPU_AND_NE parity ─────────────────────────────────────────
+print(f"\n[4/5] CoreML CPU_AND_NE parity ({N_SAMPLES} inputs)")
+cml_model = ct.models.MLModel(
+    str(mlpackage_path), compute_units=ct.ComputeUnit.CPU_AND_NE
+)
+
+outs_cml = []
+for i in range(N_SAMPLES):
+    x_np = golden['inputs'][i].numpy().astype(np.float32)
+    result = cml_model.predict({"x": x_np})
+    outs_cml.append(torch.from_numpy(result["logits"]).float())
+    if (i + 1) % 16 == 0:
+        print(f"  {i+1}/{N_SAMPLES} done")
+
+per_cml = [compute_metrics(outs_cml[i], ref_fp32[i]) for i in range(N_SAMPLES)]
+agg_cml = aggregate_metrics(per_cml)
+thr_cml = check_thresholds(agg_cml, TOL_COREML)
+st = 'PASS' if thr_cml['pass'] else 'FAIL'
+print(f"  CoreML CPU_AND_NE: {st}  max_abs={agg_cml['max_abs']:.3e}  "
+      f"cosine_sim_min={agg_cml['cosine_sim_min']:.6f}")
+if not thr_cml['pass']:
+    for f in thr_cml['failed_checks']: print(f"  x {f}")
+
+# ── Step 5: NaN check (64 inputs) ─────────────────────────────────────────────
+print(f"\n[5/5] NaN accumulation check (64 inputs)")
+nan_found = False
+for i in range(min(64, N_SAMPLES)):
+    x_np = golden['inputs'][i].numpy().astype(np.float32)
+    result = cml_model.predict({"x": x_np})
+    if np.isnan(result["logits"]).any():
+        print(f"  NaN at input {i}!")
+        nan_found = True
+        break
+if not nan_found:
+    print("  No NaN detected  OK")
+
+# ── Write report ─────────────────────────────────────────────────────────────
+cfg_str = (f"d_model={D_MODEL}, d_state=64, headdim=64, "
+           f"seq_length={SEQ_LENGTH}, num_classes={NUM_CLASSES}")
+seq_str = f"{N_SAMPLES} independent inputs, seed={cfg['seed']}, compute_units=CPU_AND_NE"
+
+comparisons = [
+    dict(name='MPS_FP16',    ref_label='OG_FP32 (golden)',  test_label=f'Portable_FP16 ({DEVICE})',
+         tol=TOL_MPS,    agg=agg_mps, threshold=thr_mps,
+         per_step_max_abs=[m['max_abs'] for m in per_mps]),
+    dict(name='CoreML_ANE',  ref_label='OG_FP32 (golden)',  test_label='CoreML CPU_AND_NE',
+         tol=TOL_COREML, agg=agg_cml, threshold=thr_cml,
+         per_step_max_abs=[m['max_abs'] for m in per_cml]),
+]
+
+report_path = Path(__file__).parent / 'parity_report_parallel.md'
+report = generate_report(
+    'Parallel ANE Parity Report: StatefulMambaParallelHybrid', comparisons, cfg_str, seq_str)
+report_path.write_text(report)
+print(f"\nReport written to {report_path}")
+
+all_pass = thr_mps['pass'] and thr_cml['pass'] and not nan_found
+if not all_pass:
+    sys.exit(1)
+print("\nAll checks PASS")


### PR DESCRIPTION
  # feat: ANE for Mac/iPhone support

  ## Summary

  Introduces ANE (Apple Neural Engine) support for Mamba-3 SISO on Mac and iPhone. This PR includes:

  - **mamba_ane package**: ANE-native Mamba3 port optimized for Apple Silicon
  - **Parity tests**: Comprehensive GPU and ANE numerical equivalence validation
  - **CoreML integration**: Clean PyTorch → CoreML conversion with verified numerical stability
  - **Documentation**: Interactive visualization and usage guides

  ## Key Metrics

  | Metric | Value | Status |
  |--------|-------|--------|
  | **ANE Parity Test** | PASS | ✅ |
  | **max_abs error** | 2.102e-04 | ✅ (< 0.03) |
  | **cosine_sim_min** | 0.999998 | ✅ (> 0.999) |
  | **Model size** ([StatefulMambaHybrid1D](https://github.com/Dorianhgn/mamba/blob/86563099cda846aab118b09730361d2815ea31f1/mamba_ane/models/hybrid1d.py#L46)) | 16.99M params | ✅ |
  | **Neural Engine util** | ~100% | ✅ |

  ## Changes

  - **mamba_ane/**: ANE-native Mamba3 implementation
  - **tests/parity_tests/**: GPU and ANE parity validation
  - **mamba_ane/README.md**: Installation, architecture, and usage guide
  - **mamba_ane/docs/mamba3_siso_viz.html**: Interactive architecture visualization

  ## Testing

  All parity tests pass with excellent numerical margins:
  - GPU ↔ ANE equivalence confirmed (FP32, FP16)
  - PyTorch ↔ CoreML equivalence confirmed (FP16)
  - Numerical differences at float32 rounding noise level

  ## References
  
  See #942  for Neural Engine utilization findings and performance observations.