### PR TITLE
Fall back to source build when wheel-URL version parsing fails (InvalidVersion)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 import ast
 from pathlib import Path
-from packaging.version import parse, Version
+from packaging.version import parse, Version, InvalidVersion
 import platform
 import shutil
 
@@ -337,9 +337,9 @@ class CachedWheelsCommand(_bdist_wheel):
         if FORCE_BUILD:
             return super().run()
 
-        wheel_url, wheel_filename = get_wheel_url()
-        print("Guessing wheel URL: ", wheel_url)
         try:
+            wheel_url, wheel_filename = get_wheel_url()
+            print("Guessing wheel URL: ", wheel_url)
             urllib.request.urlretrieve(wheel_url, wheel_filename)
 
             # Make the archive
@@ -354,7 +354,7 @@ class CachedWheelsCommand(_bdist_wheel):
             wheel_path = os.path.join(self.dist_dir, archive_basename + ".whl")
             print("Raw wheel path", wheel_path)
             shutil.move(wheel_filename, wheel_path)
-        except urllib.error.HTTPError:
+        except (urllib.error.HTTPError, InvalidVersion):
             print("Precompiled wheel not found. Building from source...")
             # If the wheel could not be downloaded, build from source
             super().run()


### PR DESCRIPTION
## Bug

Installing `mamba-ssm` aborts with `packaging.version.InvalidVersion` instead of falling back to a source build when the environment exposes a non-PEP-440 PyTorch/CUDA build string. Reported in #947, reproducible in vendor PyTorch containers where e.g. `CUDA_VERSION=gpgpu.<build-id>`:

```
File "<string>", line 340, in run
File "<string>", line 315, in get_wheel_url
...
packaging.version.InvalidVersion: Invalid version: 'gpgpu.<build-id>'
```

## Root cause

`CachedWheelsCommand.run()` calls `get_wheel_url()` *before* the `try` block. `get_wheel_url()` runs `packaging.version.parse()` on values such as `CUDA_VERSION` (line 315); a non-PEP-440 string raises `InvalidVersion`, which propagates out of `run()` and aborts the whole install. The existing `except urllib.error.HTTPError` branch already implements the intended behavior — "Precompiled wheel not found. Building from source..." — but it never runs because the exception is raised outside the `try`.

## Fix

Move the wheel-URL resolution inside the `try` and catch `InvalidVersion` alongside `HTTPError`, so a version-parse failure degrades gracefully to the from-source build rather than aborting. This matches the command's documented purpose of short-circuiting to a normal build when a compatible prebuilt wheel can't be determined.

Fixes #947