### PR TITLE
Fall back to source build when wheel version parsing fails (Fixes #947)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 import ast
 from pathlib import Path
-from packaging.version import parse, Version
+from packaging.version import parse, InvalidVersion, Version
 import platform
 import shutil
 
@@ -337,9 +337,9 @@ class CachedWheelsCommand(_bdist_wheel):
         if FORCE_BUILD:
             return super().run()
 
-        wheel_url, wheel_filename = get_wheel_url()
-        print("Guessing wheel URL: ", wheel_url)
         try:
+            wheel_url, wheel_filename = get_wheel_url()
+            print("Guessing wheel URL: ", wheel_url)
             urllib.request.urlretrieve(wheel_url, wheel_filename)
 
             # Make the archive
@@ -354,7 +354,7 @@ class CachedWheelsCommand(_bdist_wheel):
             wheel_path = os.path.join(self.dist_dir, archive_basename + ".whl")
             print("Raw wheel path", wheel_path)
             shutil.move(wheel_filename, wheel_path)
-        except urllib.error.HTTPError:
+        except (urllib.error.HTTPError, InvalidVersion):
             print("Precompiled wheel not found. Building from source...")
             # If the wheel could not be downloaded, build from source
             super().run()


### PR DESCRIPTION
## Bug

`pip install mamba-ssm` can abort with `packaging.version.InvalidVersion` instead of falling back to a source build. As reported in #947, this happens in vendor PyTorch containers where CUDA/PyTorch build metadata is a non-PEP 440 string (e.g. `CUDA_VERSION=gpgpu.<build-id>`):

```
File "<string>", line 315, in get_wheel_url
  cuda_version = str(parse(ngc_cuda_version).major)
...
packaging.version.InvalidVersion: Invalid version: 'gpgpu.<build-id>'
```

## Root cause

In `CachedWheelsCommand.run()`, `get_wheel_url()` is called **outside** the `try` block:

```python
wheel_url, wheel_filename = get_wheel_url()   # can raise InvalidVersion
print("Guessing wheel URL: ", wheel_url)
try:
    urllib.request.urlretrieve(wheel_url, wheel_filename)
    ...
except urllib.error.HTTPError:
    print("Precompiled wheel not found. Building from source...")
    super().run()
```

`get_wheel_url()` calls `packaging.version.parse()` on `torch.__version__`, `torch.version.cuda`, and the `CUDA_VERSION` env var. When any of those is not PEP 440-compliant, `parse()` raises `InvalidVersion`, which propagates out of `run()` and aborts the build — even though the class is explicitly designed to fall back to a source build (the `HTTPError` branch) when a precompiled wheel can't be obtained.

## Fix

Move `get_wheel_url()` inside the `try` block and catch `InvalidVersion` alongside `HTTPError`. Unparsable version metadata now triggers the same source-build fallback as a missing wheel, instead of failing the install. The change is behavior-preserving for all environments where the version strings are valid.

Fixes #947