### PR TITLE
Catch InvalidVersion in setup.py to fall back to source build

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 import ast
 from pathlib import Path
-from packaging.version import parse, Version
+from packaging.version import parse, InvalidVersion, Version
 import platform
 import shutil
 
@@ -337,7 +337,11 @@ class CachedWheelsCommand(_bdist_wheel):
         if FORCE_BUILD:
             return super().run()
 
-        wheel_url, wheel_filename = get_wheel_url()
+        try:
+            wheel_url, wheel_filename = get_wheel_url()
+        except InvalidVersion:
+            print("Could not determine wheel URL (non-PEP 440 version). Building from source...")
+            return super().run()
         print("Guessing wheel URL: ", wheel_url)
         try:
             urllib.request.urlretrieve(wheel_url, wheel_filename)


### PR DESCRIPTION
## Bug

`get_wheel_url()` in `setup.py` calls `packaging.version.parse()` on `torch.__version__` and `torch.version.cuda`. In vendor PyTorch containers these can be non-PEP 440 strings (e.g. `gpgpu.<build-id>`), causing `parse()` to raise `InvalidVersion`.

Because `CachedWheelsCommand.run()` has no handler for this exception, the install aborts instead of falling back to a source build.

## Root cause

`get_wheel_url()` (line 281/290) passes raw version strings to `packaging.version.parse()` without guarding against `InvalidVersion`. The existing `try/except` in `run()` only catches `urllib.error.HTTPError` from the download step — it never reaches that point.

## Fix

Wrap the `get_wheel_url()` call with `try/except InvalidVersion` so the build falls back to `super().run()` (source compilation) when the version string cannot be parsed. This matches the existing fallback behavior for missing prebuilt wheels.

Fixes #947