### PR TITLE
fix: fall back to source build when version string is not PEP 440

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import os
 import re
 import ast
 from pathlib import Path
-from packaging.version import parse, Version
+from packaging.version import parse, Version, InvalidVersion
 import platform
 import shutil
 
@@ -337,7 +337,12 @@ class CachedWheelsCommand(_bdist_wheel):
         if FORCE_BUILD:
             return super().run()
 
-        wheel_url, wheel_filename = get_wheel_url()
+        try:
+            wheel_url, wheel_filename = get_wheel_url()
+        except InvalidVersion:
+            print("Non-PEP-440 version string detected. Building from source...")
+            super().run()
+            return
         print("Guessing wheel URL: ", wheel_url)
         try:
             urllib.request.urlretrieve(wheel_url, wheel_filename)


### PR DESCRIPTION
## Bug

`CachedWheelsCommand.run()` calls `get_wheel_url()` without catching `InvalidVersion`. In vendor PyTorch containers (e.g. NGC images with internal build IDs), `torch.__version__` or `torch.version.cuda` can be a non-PEP-440 string such as `gpgpu.<build-id>`. `packaging.version.parse` raises `InvalidVersion` on those strings, which propagates uncaught and aborts the install entirely.

Reported in #947.

## Root cause

```python
# setup.py, CachedWheelsCommand.run()
wheel_url, wheel_filename = get_wheel_url()   # InvalidVersion escapes here
...
except urllib.error.HTTPError:
    # only catches HTTP failures, never reached
    super().run()
```

`get_wheel_url()` calls `parse(torch.__version__)` and `parse(torch.version.cuda)`. Both raise `InvalidVersion` for non-standard version strings. The `except urllib.error.HTTPError` block that falls back to source build is never reached.

## Fix

Import `InvalidVersion` from `packaging.version` and wrap `get_wheel_url()` in a try/except at the call site. When caught, fall back to `super().run()` (source build), consistent with how `urllib.error.HTTPError` is already handled.

```python
try:
    wheel_url, wheel_filename = get_wheel_url()
except InvalidVersion:
    print("Non-PEP-440 version string detected. Building from source...")
    super().run()
    return
```

## Why this fix is correct

The existing `except urllib.error.HTTPError` path already expresses the intent: if the prebuilt wheel cannot be obtained for any reason, fall back to a source build. `InvalidVersion` is another such reason. The fix keeps the same fallback behavior and does not change what wheels are downloaded or how they are built.