### PR TITLE
Stabilize data-dependent A with heavy-tail activation

### DIFF
--- a/mamba_ssm/modules/mamba3.py
+++ b/mamba_ssm/modules/mamba3.py
@@ -23,6 +23,23 @@ try:
 except ImportError:    
     mamba3_step_fn = None
 
+
+def heavy_tail_activation(x: torch.Tensor) -> torch.Tensor:
+    """
+    Heavy-tail activation for data-dependent A.
+
+    Using this activation can improve stability during WSD training and at
+    higher learning rates.
+
+        f(x) = 1 + x        if x >= 0
+            = 1 / (1 - x)  if x < 0
+
+    The function is positive, continuous, and differentiable at x = 0.
+    """
+    neg = x.clamp_max(0)
+    pos = x.clamp_min(0)
+    return pos + torch.reciprocal(1 - neg)
+
 class Mamba3(nn.Module):
     def __init__(
         self,
@@ -166,7 +183,7 @@ class Mamba3(nn.Module):
         trap = rearrange(trap, "b l h -> b h l")
 
         # Compute ADT, DT
-        _A = -F.softplus(dd_A.to(torch.float32)) # (B, L, N)
+        _A = -heavy_tail_activation(dd_A.to(torch.float32)) # (B, L, N)
         _A = torch.clamp(_A, max=-self.A_floor)            
         DT = F.softplus(dd_dt + self.dt_bias) # (B, L, N)
         ADT = _A * DT
@@ -251,7 +268,7 @@ class Mamba3(nn.Module):
     
 
     def _preprocess(self, A_proj, dd_dt, B, C, x, z, trap_proj, angle_proj):
-        _A = -F.softplus(A_proj.to(torch.float32))
+        _A = -heavy_tail_activation(A_proj.to(torch.float32))
         _A = torch.clamp(_A, max=-self.A_floor)
         DT = F.softplus(dd_dt + self.dt_bias)
         trap = torch.sigmoid(trap_proj)


### PR DESCRIPTION
Mamba-3 can become unstable at higher learning rates when using WSD. For example, in a 2B hybrid model at 300B-token scale, lr=0.0014 led to loss explosion.

The issue appears to come from the softplus activation on data-dependent A. Softplus can produce very small A values, which may lead to numerical instability at higher learning rates.

Replace softplus with a heavy-tail activation for data-dependent A:

    f(x) = 1 + x        if x >= 0
         = 1 / (1 - x)  if x < 0

This function has a slower negative tail decay, so A remains relatively larger in regimes (x < 0) where softplus would approach zero, which improves stability.

In tested cosine decay settings with 10% warmup, this change did not show performance regression.