### PR TITLE
fix: skip duplicate B/C RMSNorm in checkpoint_lvl=1 backward

### DIFF
--- a/mamba_ssm/ops/selective_scan_interface.py
+++ b/mamba_ssm/ops/selective_scan_interface.py
@@ -300,21 +300,6 @@ class MambaInnerFn(torch.autograd.Function):
                 delta = rearrange(delta, "b d l -> (b l) d", l=L).contiguous()
                 delta = rms_norm_forward(delta, ctx.dt_rms_weight, None, ctx.b_c_dt_rms_eps)
                 delta = rearrange(delta, "(b l) d -> b d l", l=L).contiguous()
-            if b_rms_weight is not None:
-                # Recompute & RMSNorm B
-                B = rearrange(B, "b 1 dstate l -> (b l) dstate", l=L).contiguous()
-                B = rms_norm_forward(
-                    B, ctx.b_rms_weight, None, ctx.b_c_dt_rms_eps
-                )
-                B = rearrange(B, "(b l) dstate -> b 1 dstate l", l=L).contiguous()
-            if c_rms_weight is not None:
-                # Recompute & RMSNorm C
-                C = rearrange(C, "b 1 dstate l -> (b l) dstate", l=L).contiguous()
-                C = rms_norm_forward(
-                    C, ctx.c_rms_weight, None, ctx.b_c_dt_rms_eps
-                )
-                C = rearrange(C, "(b l) dstate -> b 1 dstate l", l=L).contiguous()
-            
         # The kernel supports passing in a pre-allocated dz (e.g., in case we want to fuse the
         # backward of selective_scan_cuda with the backward of chunk).
         dxz = torch.empty_like(xz)  # (batch, dim, seqlen)


### PR DESCRIPTION
Fixes #885

## Bug
With `checkpoint_lvl=1` and `b_rms_weight`/`c_rms_weight`, `MambaInnerFn.backward` applies RMSNorm to B and C a second time even though forward already normalized them and saved the post-norm tensors.

## Root cause
`delta` is cleared before `save_for_backward` so it is recomputed once in backward; B and C are saved post-norm but backward still re-ran `rms_norm_forward` on those saved values.

## Why this fix is correct
Drop the redundant B/C RMSNorm block in the `checkpoint_lvl == 1` path so backward uses the same post-norm B/C that forward passed to `selective_scan_cuda.fwd`, matching the intended checkpointing behavior.


Made with [Cursor](https://cursor.com)