### PR TITLE
Latency HotFix: Only keep num sequences and sequence length as dynamic variables

### DIFF
--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
@@ -60,6 +60,9 @@ from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_bwd import mamba_mimo_bwd_combine
         tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
     })
 def mamba_mimo_bwd_fwd(
+    B,
+    H,
+    G,
     N,
     P,
     R,
@@ -91,10 +94,7 @@ def mamba_mimo_bwd_fwd(
     * STATES shape: ``[B, H, max_nchunks, N, P]`` with
       ``max_nchunks = (S // chunk_size) + NS``.
     """
-    B = T.dynamic("B")
     S = T.dynamic("S")
-    H = T.dynamic("H")
-    G = T.dynamic("G")
     NS = T.dynamic("NS")
 
     accum_dtype = 'float32'
@@ -544,6 +544,9 @@ def mamba_mimo_bwd_fwd(
         tilelang.PassConfigKey.TL_ENABLE_FAST_MATH: True,
     })
 def mamba_mimo_bwd_bwd(
+    B,
+    H,
+    G,
     N,
     P,
     R,
@@ -574,10 +577,7 @@ def mamba_mimo_bwd_bwd(
     * DSSDA shape: ``[B, H, max_nchunks, C, C]`` with
       ``max_nchunks = (S // chunk_size) + NS``.
     """
-    B = T.dynamic("B")
     S = T.dynamic("S")
-    H = T.dynamic("H")
-    G = T.dynamic("G")
     NS = T.dynamic("NS")
 
     accum_dtype = 'float32'
@@ -1321,6 +1321,7 @@ def mamba_mimo_bwd_combined_varlen(
     qk_dot = torch.zeros([B, H, S, R, R], dtype=q.dtype, device=q.device)
 
     bwd_fwd_kernel = mamba_mimo_bwd_fwd(
+        B, H, G,
         N, P, R,
         z is not None, D is not None, reduceO,
         isVarlen=cu_seqlens is not None,
@@ -1351,6 +1352,7 @@ def mamba_mimo_bwd_combined_varlen(
     ddA_cs = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
 
     bwd_bwd_kernel = mamba_mimo_bwd_bwd(
+        B, H, G,
         N, P, R,
         z is not None, D is not None, reduceO,
         isVarlen=cu_seqlens is not None,

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
@@ -58,7 +58,6 @@ from typing import Optional, Tuple
     })
 def mamba_mimo_fwd(
     B,
-    S,
     H,
     G,
     N,
@@ -67,7 +66,6 @@ def mamba_mimo_fwd(
     hasZ,
     hasD,
     reduceO,
-    NS: int = 1,
     isVarlen: bool = True,
     return_final_state=False,
     chunk_size: int = 16,
@@ -93,10 +91,7 @@ def mamba_mimo_fwd(
     When NS == 1 (or cu_seqlens is None) the kernel degenerates to the
     non-varlen behaviour.
     """
-    B = T.dynamic("B")
     S = T.dynamic("S")
-    H = T.dynamic("H")
-    G = T.dynamic("G")
     NS = T.dynamic("NS")
 
     accum_dtype = 'float32'
@@ -605,7 +600,8 @@ def mamba_mimo_forward_varlen(q, k, v,
         NS = 1
 
     reduceO = mimo_o is not None
-    kernel = mamba_mimo_fwd(N, P, R, 
+    kernel = mamba_mimo_fwd(B, H, G, 
+                            N, P, R, 
                             z is not None, 
                             D is not None, 
                             reduceO,


### PR DESCRIPTION
Setting batch size, num heads and num groups increased latency by ~2.5x compared to static kernels.

Only keep num sequences and sequence length as dynamic variables. This removes regression in latency.