### PR TITLE
Fuse gated norm and reduce bwd memory I/O in Mamba-3 MIMO

### DIFF
--- a/mamba_ssm/modules/mamba3.py
+++ b/mamba_ssm/modules/mamba3.py
@@ -58,6 +58,7 @@ class Mamba3(nn.Module):
         is_outproj_norm=False,
         is_mimo=False,
         mimo_rank=4,
+        fuse_pregate_headwise_norm=True,
         #-------------------------------------------
         # Fused kernel and sharding options
         chunk_size=64, # Recommended: 64 for SISO, 64/mimo_rank for MIMO
@@ -80,6 +81,9 @@ class Mamba3(nn.Module):
         self.is_outproj_norm=is_outproj_norm
         self.is_mimo = is_mimo
         self.mimo_rank = mimo_rank
+        self.fuse_pregate_headwise_norm = bool(
+            fuse_pregate_headwise_norm and self.is_mimo and self.is_outproj_norm
+        )
         if not self.is_mimo:
             self.mimo_rank = 1
         else:
@@ -144,6 +148,10 @@ class Mamba3(nn.Module):
                 group_size=self.headdim,
                 **factory_kwargs
             )
+            if self.fuse_pregate_headwise_norm:
+                assert self.norm.weight.numel() == self.nheads * self.headdim, (
+                    "Fused pregate headwise norm expects one norm weight per head/headdim element."
+                )
 
         # Output projection
         self.out_proj = nn.Linear(self.d_inner, self.d_model, bias=False, **factory_kwargs)
@@ -210,15 +218,18 @@ class Mamba3(nn.Module):
                 K_bias=self.B_bias,
                 MIMO_V=self.mimo_x,
                 MIMO_Z=self.mimo_z,
-                MIMO_Out=self.mimo_o if not self.is_outproj_norm else None,
+                MIMO_Out=self.mimo_o if (self.fuse_pregate_headwise_norm or not self.is_outproj_norm) else None,
                 Angles=angles,
                 D=self.D,
-                Z=z if not self.is_outproj_norm else None,
+                Z=z if (self.fuse_pregate_headwise_norm or not self.is_outproj_norm) else None,
                 chunk_size=self.chunk_size,
                 rotary_dim_divisor=self.rotary_dim_divisor,
                 dtype=x.dtype,
                 return_state=ssm_state is not None,
                 cu_seqlens=cu_seqlens,
+                fuse_pregate_headwise_rms_norm=self.fuse_pregate_headwise_norm,
+                outproj_norm_weight=self.norm.weight if self.fuse_pregate_headwise_norm else None,
+                outproj_norm_eps=self.norm.eps if self.fuse_pregate_headwise_norm else 1e-5,
             )
             if ssm_state is not None:
                 y, last_angle, last_state, last_k, last_v, *rest = y
@@ -226,7 +237,7 @@ class Mamba3(nn.Module):
                 ssm_state.copy_(last_state)
                 k_state.copy_(last_k)
                 v_state.copy_(last_v)
-            if self.is_outproj_norm:
+            if self.is_outproj_norm and not self.fuse_pregate_headwise_norm:
                 z = torch.einsum("blhp,hrp->blrhp", z.float(), self.mimo_z)
                 z = rearrange(z, "b l r h p -> b l r (h p)")
                 y = rearrange(y, "b l r h p -> b l r (h p)").float()

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
@@ -44,6 +44,7 @@ class _Mamba3Function(torch.autograd.Function):
         MIMO_V: Tensor,
         MIMO_Z: Tensor,
         MIMO_Out: Union[Tensor, None],
+        Out_Norm_Weight: Union[Tensor, None],
         Angles: Tensor,
         D: Tensor,
         Z: Tensor,
@@ -52,15 +53,19 @@ class _Mamba3Function(torch.autograd.Function):
         dtype: torch.dtype,
         return_state: bool,
         cu_seqlens: Optional[Tensor],
+        fuse_pregate_headwise_rms_norm: bool,
+        outproj_norm_eps: float,
     ) -> Tensor | Tuple[Tensor, Tuple]:
         """Forward pass: call Triton/Tilelang kernel and save tensors for backward."""
         ctx.chunk_size = chunk_size
         ctx.rotary_dim_divisor = rotary_dim_divisor
         ctx.dtype = dtype
-        (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Angles, D, Z) = tuple(
+        ctx.fuse_pregate_headwise_rms_norm = fuse_pregate_headwise_rms_norm
+        ctx.outproj_norm_eps = outproj_norm_eps
+        (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z) = tuple(
             t.contiguous() if t is not None else None
             for t in (
-                Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Angles, D, Z,
+                Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z,
             )
         )
         # Kernels require cu_seqlens as int32; torch.cumsum promotes int32→int64 on CUDA
@@ -87,6 +92,9 @@ class _Mamba3Function(torch.autograd.Function):
                 return_state=return_state,
                 chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor,
                 dtype=dtype,
+                fuse_pregate_headwise_rms_norm=fuse_pregate_headwise_rms_norm,
+                outproj_norm_weight=Out_Norm_Weight,
+                outproj_norm_eps=outproj_norm_eps,
             )
 
         else:
@@ -98,13 +106,16 @@ class _Mamba3Function(torch.autograd.Function):
                 return_state=return_state,
                 chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor,
                 dtype=dtype,
+                fuse_pregate_headwise_rms_norm=fuse_pregate_headwise_rms_norm,
+                outproj_norm_weight=Out_Norm_Weight,
+                outproj_norm_eps=outproj_norm_eps,
             )
 
         ctx.chunk_size = chunk_size
         ctx.save_for_backward(
             Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, Angles_Cumsum,
             D, Z,
-            MIMO_V, MIMO_Out, MIMO_Z,
+            MIMO_V, MIMO_Out, MIMO_Z, Out_Norm_Weight,
             cu_seqlens,
         )
 
@@ -130,7 +141,7 @@ class _Mamba3Function(torch.autograd.Function):
 
         (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, Angles_Cumsum,
             D, Z,
-            MIMO_V, MIMO_Out, MIMO_Z,
+            MIMO_V, MIMO_Out, MIMO_Z, Out_Norm_Weight,
             cu_seqlens
             ) = ctx.saved_tensors
 
@@ -139,7 +150,7 @@ class _Mamba3Function(torch.autograd.Function):
             (dQ, dK, dV,
                 dADT, dDT, dTrap, dQ_bias, dK_bias,
                 dMIMO_V, dMIMO_Z, dMIMO_Out, dAngles_Cumsum,
-                dD, dZ) = mamba_mimo_bwd_combined_varlen(
+                dD, dZ, dOut_Norm_Weight) = mamba_mimo_bwd_combined_varlen(
                     dout,
                     Q,
                     K,
@@ -161,13 +172,16 @@ class _Mamba3Function(torch.autograd.Function):
                     ctx.rotary_dim_divisor,
                     ctx.dtype,
                     cu_seqlens=cu_seqlens,
+                    fuse_pregate_headwise_rms_norm=ctx.fuse_pregate_headwise_rms_norm,
+                    outproj_norm_weight=Out_Norm_Weight,
+                    outproj_norm_eps=ctx.outproj_norm_eps,
                 )
         else:
             DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton(ADT, ctx.chunk_size)
             (dQ, dK, dV,
                 dADT, dDT, dTrap, dQ_bias, dK_bias,
                 dMIMO_V, dMIMO_Z, dMIMO_Out, dAngles_Cumsum,
-                dD, dZ) = mamba_mimo_bwd_combined(
+                dD, dZ, dOut_Norm_Weight) = mamba_mimo_bwd_combined(
                     dout,
                     Q,
                     K,
@@ -188,6 +202,9 @@ class _Mamba3Function(torch.autograd.Function):
                     ctx.chunk_size,
                     ctx.rotary_dim_divisor,
                     ctx.dtype,
+                    fuse_pregate_headwise_rms_norm=ctx.fuse_pregate_headwise_rms_norm,
+                    outproj_norm_weight=Out_Norm_Weight,
+                    outproj_norm_eps=ctx.outproj_norm_eps,
                 )
 
         # Backprop through angle_dt cumsum (varlen-aware)
@@ -200,6 +217,8 @@ class _Mamba3Function(torch.autograd.Function):
             cu_seqlens=cu_seqlens,
         )
         dDT = dDT + dDT_angle
+        if dOut_Norm_Weight is not None and Out_Norm_Weight is not None:
+            dOut_Norm_Weight = dOut_Norm_Weight.reshape_as(Out_Norm_Weight)
 
         return (
             dQ,
@@ -213,10 +232,11 @@ class _Mamba3Function(torch.autograd.Function):
             dMIMO_V,
             dMIMO_Z,
             dMIMO_Out,
+            dOut_Norm_Weight,
             dAngles,
             dD,
             dZ,
-            None, None, None, None, None,
+            None, None, None, None, None, None, None,
         )
 
 
@@ -244,6 +264,9 @@ def mamba3_mimo(
     dtype: torch.dtype,
     return_state: bool = False,
     cu_seqlens: Optional[Tensor] = None,
+    fuse_pregate_headwise_rms_norm: bool = False,
+    outproj_norm_weight: Optional[Tensor] = None,
+    outproj_norm_eps: float = 1e-5,
 ) -> Tensor | Tuple[Tensor, Tuple]:
     """Mamba-3 attention with Tilelang kernels and automatic differentiation.
     
@@ -270,6 +293,10 @@ def mamba3_mimo(
          If provided, should be a tensor of shape (num_seq + 1,) where cu_seqlens[i] is 
          the cumulative sequence length up to sequence i. This is used for efficient processing of 
          variable-length sequences in the kernel.
+        fuse_pregate_headwise_rms_norm: Whether to fuse headwise RMSNorm(y) * silu(z)
+         with MIMO down projection in the dense or varlen forward/backward kernels.
+        outproj_norm_weight: Optional RMSNorm weight, shaped (nheads, headdim_v) or flattened.
+        outproj_norm_eps: Epsilon used by the fused headwise RMSNorm path.
               
     Returns:
         output: (batch, seqlen, nheads, headdim_v) if MIMO_Out is not None
@@ -323,6 +350,7 @@ def mamba3_mimo(
         MIMO_V,
         MIMO_Z,
         MIMO_Out,
+        outproj_norm_weight,
         Angles,
         D,
         Z,
@@ -331,4 +359,6 @@ def mamba3_mimo(
         dtype,
         return_state,
         cu_seqlens,
+        fuse_pregate_headwise_rms_norm,
+        outproj_norm_eps,
     )

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
@@ -19,6 +19,10 @@ import argparse
 from einops import rearrange
 from typing import Optional, Tuple
 
+from mamba_ssm.ops.triton.mamba3.mamba3_mimo_utils import (
+    bwd_dadt_fused_triton,
+    bwd_dtrap_ddt_triton,
+)
 from mamba_ssm.ops.triton.mamba3.grouped_head_reduction import (
     reduce_grouped_qk_grads_and_bias_triton,
 )

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
@@ -19,7 +19,9 @@ import argparse
 from einops import rearrange
 from typing import Optional, Tuple
 
-from mamba_ssm.ops.triton.mamba3.mamba3_mimo_utils import bwd_dadt_fused_triton, bwd_dtrap_ddt_triton
+from mamba_ssm.ops.triton.mamba3.grouped_head_reduction import (
+    reduce_grouped_qk_grads_and_bias_triton,
+)
 
 
 # def get_configs():
@@ -50,11 +52,14 @@ def mamba_mimo_bwd_fwd(
     hasZ,
     hasD,
     reduceO,
+    fuse_pregate_headwise_rms_norm=False,
     chunk_size: int = 16,
     rotary_dim_divisor: int = 4,
     dtype: str = 'float16',
+    outproj_norm_eps: float = 1e-5,
     threads: int = 128,
     num_stages: int = 0,
+    states_dtype = torch.bfloat16,
 ) -> torch.Tensor:
 
     accum_dtype = 'float32'
@@ -67,6 +72,9 @@ def mamba_mimo_bwd_fwd(
         DOUT_shape = (B, S, H, P)
     else:
         DOUT_shape = (B, S, R, H, P)
+    DOUT_PRE_RMS_shape = (B, H, S*R, P) if fuse_pregate_headwise_rms_norm else (1,)
+
+    dtype_states = str(states_dtype).replace("torch.","")
 
     @T.prim_func
     def mamba_mimo_bwd_fwd_kernel(
@@ -78,9 +86,12 @@ def mamba_mimo_bwd_fwd(
             K_BIAS: T.Tensor([H, R, N], T.float32),  # type: ignore
             MIMO_V: T.Tensor([H, R, P], T.float32), # type: ignore
             MIMO_O: T.Tensor([H, R, P], T.float32), # type: ignore
-            
+            OUT_NORM_WEIGHT: T.Tensor([H, P], T.float32), # type: ignore
+
             DMIMO_O: T.Tensor([B, H, R, P], T.float32), # type: ignore
-            STATES: T.Tensor([B, H, nchunks, N, P], dtype), # type: ignore 
+            DOUT_NORM_WEIGHT: T.Tensor([B, H, R, P], T.float32), # type: ignore
+            DOUT_PRE_RMS: T.Tensor(DOUT_PRE_RMS_shape, dtype), # type: ignore
+            STATES: T.Tensor([B, H, nchunks, N, P], dtype_states), # type: ignore
 
             Z: T.Tensor([B, S, H, P], dtype),  # type: ignore
             MIMO_Z: T.Tensor([H, R, P], T.float32), # type: ignore
@@ -94,7 +105,7 @@ def mamba_mimo_bwd_fwd(
             D: T.Tensor([H], T.float32),  # type: ignore
 
             QK_DOT: T.Tensor([B, H, S, R, R], dtype), # type: ignore
-            
+
             SEGSUM: T.Tensor([B, H, nchunks, chunk_size, chunk_size], T.float32), # type: ignore
             ):
         """
@@ -102,25 +113,33 @@ def mamba_mimo_bwd_fwd(
             Fused backward-forward pass over chunks. Recomputes local forward intermediates,
             accumulates projection gradients (DMIMO_O and optional DMIMO_Z), emits optional DZ,
             stores per-chunk recurrent STATES, and materializes QK_DOT for the second backward pass.
+            When pregate headwise RMSNorm is enabled, this pass also computes DOUT_NORM_WEIGHT
+            and writes DOUT_PRE_RMS in packed [B, H, S*R, P] layout for the reverse pass.
 
         Inputs:
             - Activations and upstream grad: DOUT, Q, K, V.
-            - Projection weights/biases: Q_BIAS, K_BIAS, MIMO_V (Psi), MIMO_O (Phi), optional MIMO_Z (Zeta).
-            - Optional forward modifiers: Z, D.
+            - Projection weights/biases: Q_BIAS, K_BIAS, MIMO_V (Psi), MIMO_O (Phi),
+              optional OUT_NORM_WEIGHT, optional MIMO_Z (Zeta).
+            - Optional forward modifiers: Z and D.
             - Discretization tensors: DA_CS, DA_CS_REV, DT, TRAP, and SEGSUM.
 
         Outputs:
             - MIMO projection grads: DMIMO_O and optional DMIMO_Z.
             - Optional activation grad: DZ.
+            - Pregate RMSNorm grads: optional DOUT_NORM_WEIGHT and DOUT_PRE_RMS.
             - Cached intermediates for pass 2: STATES and QK_DOT.
 
         Notation:
             - Psi: MIMO X projection.
             - Phi: MIMO O projection.
             - Zeta: MIMO Z projection.
+            - raw y: per-rank MIMO output before pregate RMSNorm, gate, and down projection.
+            - xhat: RMS-normalized raw y, equal to raw_y * rstd.
+            - dnorm: gradient wrt xhat before applying the RMSNorm input-gradient formula.
+            - DOUT_PRE_RMS: gradient wrt raw y, materialized for pass 2.
             - Trap: convex-combination modulator used in exponential-trapezoidal discretization.
         """
-        
+
         with T.Kernel(H, B, threads=threads) as (i_h, i_b):
             # --- Kernel Setup ---
             # GQA support: map V head to Q/K head
@@ -141,6 +160,9 @@ def mamba_mimo_bwd_fwd(
             if reduceO:
                 dPhi_shared = T.alloc_shared([R, P], accum_dtype)
                 T.clear(dPhi_shared)
+            if fuse_pregate_headwise_rms_norm:
+                dOutNorm_shared = T.alloc_shared([R, P], accum_dtype)
+                T.clear(dOutNorm_shared)
 
             dout_shared = T.alloc_shared([chunk_size, P], dtype)
 
@@ -202,8 +224,8 @@ def mamba_mimo_bwd_fwd(
                     )
                 shifted_gamma_frag = T.alloc_fragment([chunk_size], dtype)
                 for cs in T.Parallel(chunk_size):
-                    shifted_gamma_frag[cs] = T.if_then_else(chunk_start + cs < (S - 1), 
-                                                            dt_shifted_frag[cs] * (T.sigmoid(-trap_shifted_frag[cs])), 
+                    shifted_gamma_frag[cs] = T.if_then_else(chunk_start + cs < (S - 1),
+                                                            dt_shifted_frag[cs] * (T.sigmoid(-trap_shifted_frag[cs])),
                                                             0.0)
 
                 shifted_gamma_shared = T.alloc_shared([chunk_size], dtype)
@@ -265,7 +287,7 @@ def mamba_mimo_bwd_fwd(
                     q_first_half_frag[cs, r, n] = q_shared[cs*R + r, n]
                     q_second_half_frag[cs, r, n] = q_shared[cs*R + r, N//2 + n]
 
-                # NOTE: angles are casted to fp32 for numerical stability
+                # Cast angles to fp32 for numerical stability.
                 angles_frag = T.alloc_fragment([chunk_size, N//rotary_dim_divisor], T.float32)
                 T.copy(ANGLES[i_b, chunk_start:chunk_start+chunk_size, i_h, :], angles_frag)
 
@@ -279,7 +301,7 @@ def mamba_mimo_bwd_fwd(
                 for cs, r, n in T.Parallel(chunk_size, R, N//rotary_dim_divisor):
                     k_first_half_frag[cs, r, n] = k_shared[cs*R + r, n]
                     k_second_half_frag[cs, r, n] = k_shared[cs*R + r, N//2 + n]
-                
+
                 for cs, r, n in T.Parallel(chunk_size, R, N//rotary_dim_divisor):
                     k_shared[cs*R + r, n] = T.cos(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] - T.sin(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
                     k_shared[cs*R + r, N//2 + n] = T.sin(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] + T.cos(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
@@ -292,8 +314,8 @@ def mamba_mimo_bwd_fwd(
 
                 # --- Interchunk + Intrachunk Output Accumulation ---
                 q_state_out_frag = T.alloc_fragment([fused_chunk_size, P], dtype=accum_dtype)
-                # NOTE: Tilelang unable to infer correct layout when trying to cast
-                # states_frag to 16-bit within rmem
+                # TileLang cannot infer the desired layout when casting states_frag
+                # to 16-bit in register memory, so stage through shared memory.
                 T.copy(states_frag, states_accum_cast_shared)
                 T.gemm(q_shared, states_accum_cast_shared, q_state_out_frag, clear_accum=True)
 
@@ -302,7 +324,7 @@ def mamba_mimo_bwd_fwd(
 
                 # Strictly causal masking over chunk steps (exclude same-step diagonal).
                 da_cs__or__exp_da_cs_shared = T.alloc_shared([chunk_size], T.float32)
-                T.copy(DA_CS[i_b, i_h, chunk_start:chunk_start+chunk_size], da_cs__or__exp_da_cs_shared)       
+                T.copy(DA_CS[i_b, i_h, chunk_start:chunk_start+chunk_size], da_cs__or__exp_da_cs_shared)
                 for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
                     qk_intrachunk_frag[csr_i, csr_j] = T.if_then_else(
                                                 csr_i//R > csr_j//R,
@@ -312,7 +334,7 @@ def mamba_mimo_bwd_fwd(
                 qk_intrachunk_masked_shared = T.alloc_shared([fused_chunk_size, fused_chunk_size], dtype=dtype)
                 for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
                     qk_intrachunk_masked_shared[csr_i, csr_j] = qk_intrachunk_frag[csr_i, csr_j]
-                
+
                 # Exponentiate da_cs__or__exp_da_cs_shared so that later usage does not have to:
                 for cs in T.Parallel(chunk_size):
                     da_cs__or__exp_da_cs_shared[cs] = T.exp(da_cs__or__exp_da_cs_shared[cs])
@@ -348,21 +370,56 @@ def mamba_mimo_bwd_fwd(
                     for csr, p in T.Parallel(fused_chunk_size, P):
                         o_mimo_accum_frag[csr, p] += D_var * PsiV_D_frag[csr, p]
 
-                # --- Project to dMIMO_O and Optional Z Backward Path ---
+                # --- Projection, Optional Gate, and Pregate RMS Side Gradients ---
                 if reduceO:
-                    out_prereduced_shared = T.alloc_shared([fused_chunk_size, P], dtype)
-                    T.copy(o_mimo_accum_frag, out_prereduced_shared)
-                    
+                    if not fuse_pregate_headwise_rms_norm:
+                        out_prereduced_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+                        T.copy(o_mimo_accum_frag, out_prereduced_shared)
+
+                    dout_frag = T.alloc_fragment([chunk_size, P], dtype)
+                    T.copy(DOUT[i_b, chunk_start:chunk_start+chunk_size, i_h, :], dout_shared)
+                    T.copy(dout_shared, dout_frag)
+
                     o_gated_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
-                    if hasZ:
-                        # Apply Z gating to out:
+
+
+                    if fuse_pregate_headwise_rms_norm:
+                        # Reuse o_gated_frag for raw-y squares before it holds the gated output.
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            o_gated_frag[cs, r, p] = o_mimo_accum_frag[cs*R + r, p]
+                            o_gated_frag[cs, r, p] *= o_gated_frag[cs, r, p]
+                        o_rstd_frag = T.alloc_fragment([chunk_size, R], T.float32)
+                        T.reduce_sum(o_gated_frag, o_rstd_frag, dim=-1, clear=True)
+                        # o_rstd_frag = T.view(o_rstd_frag_fused, shape=[chunk_size, R])
+                        for cs, r in T.Parallel(chunk_size, R):
+                            o_rstd_frag[cs, r] = 1.0 / T.sqrt(
+                                o_rstd_frag[cs, r] / P + outproj_norm_eps
+                            )
+
+                        # Apply pregate RMSNorm and SiLU(Z * Zeta) before the down projection.
                         T.copy(Z[i_b, chunk_start:chunk_start+chunk_size, i_h, :], z_shared)
                         z_o_frag = T.alloc_fragment([chunk_size, P], T.float32)
                         T.copy(z_shared, z_o_frag)
                         Zeta_o_frag = T.alloc_fragment([R, P], T.float32)
                         T.copy(MIMO_Z[i_h, :, :], Zeta_o_frag)
                         for cs, r, p in T.Parallel(chunk_size, R, P):
-                            # Apply SiLU to o_gated_frag:
+                            tmp = z_o_frag[cs, p] * Zeta_o_frag[r, p] * 0.5
+                            o_gated_frag[cs, r, p] = tmp * T.tanh(tmp) + tmp
+
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            o_gated_frag[cs, r, p] *= (
+                                o_mimo_accum_frag[cs*R + r, p]
+                                * o_rstd_frag[cs, r]
+                                * OUT_NORM_WEIGHT[i_h, p]
+                            )
+                    elif hasZ:
+                        # Apply SiLU(Z * Zeta) before the down projection.
+                        T.copy(Z[i_b, chunk_start:chunk_start+chunk_size, i_h, :], z_shared)
+                        z_o_frag = T.alloc_fragment([chunk_size, P], T.float32)
+                        T.copy(z_shared, z_o_frag)
+                        Zeta_o_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(MIMO_Z[i_h, :, :], Zeta_o_frag)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
                             tmp = z_o_frag[cs, p] * Zeta_o_frag[r, p] * 0.5
                             o_gated_frag[cs, r, p] = tmp * T.tanh(tmp) + tmp
                         for cs, r, p in T.Parallel(chunk_size, R, P):
@@ -370,20 +427,120 @@ def mamba_mimo_bwd_fwd(
                     else:
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             o_gated_frag[cs, r, p] = out_prereduced_shared[cs*R + r, p]
-                    
-                    # NOTE: keeping dPhi_frag in fp32 for numerical reason
-                    dPhi_frag = T.alloc_fragment([R, P], T.float32)
-                    T.copy(dPhi_shared, dPhi_frag)
-                    dout_frag = T.alloc_fragment([chunk_size, P], dtype)
-                    T.copy(DOUT[i_b, chunk_start:chunk_start+chunk_size, i_h, :], dout_shared)
-                    T.copy(dout_shared, dout_frag)
-                    for r, p in T.Parallel(R, P):
-                        for cs in T.serial(chunk_size):
-                            dPhi_frag[r, p] += o_gated_frag[cs, r, p] * dout_frag[cs, p]
-                    T.copy(dPhi_frag, dPhi_shared)
 
-                    if hasZ:
-                        # Up-project DOUT from SISO to MIMO.
+                    # Keep dPhi accumulation in fp32 for numerical stability.
+                    if fuse_pregate_headwise_rms_norm:
+                        dPhi_prereduce = T.alloc_fragment([chunk_size, R, P], T.float32)
+
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhi_prereduce[cs, r, p] = o_gated_frag[cs, r, p] * dout_frag[cs, p]
+
+                        dPhi_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(dPhi_shared, dPhi_frag)
+                        T.reduce_sum(dPhi_prereduce, dPhi_frag, dim=0, clear=False)
+                        T.copy(dPhi_frag, dPhi_shared)
+                    else:
+                        dPhi_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(dPhi_shared, dPhi_frag)
+                        for r, p in T.Parallel(R, P):
+                            for cs in T.serial(chunk_size):
+                                dPhi_frag[r, p] += o_gated_frag[cs, r, p] * dout_frag[cs, p]
+                        T.copy(dPhi_frag, dPhi_shared)
+
+                    if fuse_pregate_headwise_rms_norm:
+                        Phi_frag = T.alloc_fragment([R, P], dtype)
+                        T.copy(MIMO_O[i_h, :, :], Phi_frag)
+
+                        # Compute gate/Zeta grads and DOUT_PRE_RMS while raw y
+                        # (o_mimo_accum_frag) is still available.
+                        # Reload DOUT in a fresh fragment to avoid TileLang scope inference issues.
+                        dout_frag = T.alloc_fragment([chunk_size, P], dtype)
+                        T.copy(DOUT[i_b, chunk_start:chunk_start+chunk_size, i_h, :], dout_shared)
+                        T.copy(dout_shared, dout_frag)
+
+                        dPhiO_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhiO_frag[cs, r, p] = (
+                                dout_frag[cs, p]
+                                * Phi_frag[r, p]
+                                * o_mimo_accum_frag[cs*R + r, p]
+                                * o_rstd_frag[cs, r]
+                                * OUT_NORM_WEIGHT[i_h, p]
+                            )
+
+                        # Backward of SiLU(u): sigmoid(u) * (1 + u * sigmoid(-u)).
+                        z_frag = T.alloc_fragment([chunk_size, P], T.float32)
+                        T.copy(z_shared, z_frag)
+                        Zeta_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(MIMO_Z[i_h, :, :], Zeta_frag)
+                        dZetaZ_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZetaZ_frag[cs, r, p] = z_frag[cs, p] * Zeta_frag[r, p]
+                            dZetaZ_frag[cs, r, p] = dPhiO_frag[cs, r, p] * T.sigmoid(dZetaZ_frag[cs, r, p]) * \
+                                (1 + dZetaZ_frag[cs, r, p] * (T.sigmoid(-dZetaZ_frag[cs, r, p])))
+
+                        # Reduce over rank to produce DZ without materializing a GMEM MIMO grad.
+                        dZ_frag_prereduce = T.alloc_fragment([chunk_size, R, P], dtype)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZ_frag_prereduce[cs, r, p] = dZetaZ_frag[cs, r, p] * Zeta_frag[r, p]
+                        dZ_frag = T.alloc_fragment([chunk_size, P], dtype)
+                        T.reduce_sum(dZ_frag_prereduce, dZ_frag, clear=True, dim=1)
+                        T.copy(dZ_frag, DZ[i_b, chunk_start:chunk_start+chunk_size, i_h, :])
+
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZetaZ_frag[cs, r, p] *= z_frag[cs, p]
+                        dZeta_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(dZeta_shared, dZeta_frag)
+                        T.reduce_sum(dZetaZ_frag, dZeta_frag, clear=False, dim=0)
+                        T.copy(dZeta_frag, dZeta_shared)
+
+                        # RMSNorm backward:
+                        #   xhat = raw_y * rstd
+                        #   dnorm = dL/dxhat = DOUT * Phi * gate
+                        #   DOUT_PRE_RMS = dL/draw_y
+                        weighted_dot_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            tmp = z_frag[cs, p] * Zeta_frag[r, p] * 0.5
+                            gate = tmp * T.tanh(tmp) + tmp
+                            xhat = (
+                                o_mimo_accum_frag[cs*R + r, p]
+                                * o_rstd_frag[cs, r]
+                            )
+                            dnorm = dout_frag[cs, p] * Phi_frag[r, p] * gate
+                            weighted_dot_frag[cs, r, p] = (
+                                dnorm * xhat
+                            )
+
+                        dOutNorm_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(dOutNorm_shared, dOutNorm_frag)
+                        T.reduce_sum(weighted_dot_frag, dOutNorm_frag, dim=0, clear=False)
+                        T.copy(dOutNorm_frag, dOutNorm_shared)
+
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            weighted_dot_frag[cs, r, p] *= OUT_NORM_WEIGHT[i_h, p]
+
+                        rms_dot_frag = T.alloc_fragment([chunk_size, R], T.float32)
+                        T.reduce_sum(weighted_dot_frag, rms_dot_frag, dim=-1, clear=True)
+                        for cs, r in T.Parallel(chunk_size, R):
+                            rms_dot_frag[cs, r] /= P
+
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            tmp = z_frag[cs, p] * Zeta_frag[r, p] * 0.5
+                            gate = tmp * T.tanh(tmp) + tmp
+                            xhat = (
+                                o_mimo_accum_frag[cs*R + r, p]
+                                * o_rstd_frag[cs, r]
+                            )
+                            dnorm = dout_frag[cs, p] * Phi_frag[r, p] * gate
+                            DOUT_PRE_RMS[i_b, i_h, fused_chunk_start+cs*R+r, p] = (
+                                o_rstd_frag[cs, r]
+                                * (
+                                    dnorm * OUT_NORM_WEIGHT[i_h, p]
+                                    - xhat * rms_dot_frag[cs, r]
+                                )
+                            )
+                    elif hasZ:
+                        # Expand SISO DOUT through Phi, then apply SiLU gate backward.
                         Phi_frag = T.alloc_fragment([R, P], dtype)
                         T.copy(MIMO_O[i_h, :, :], Phi_frag)
                         dPhiO_frag = T.alloc_fragment([chunk_size, R, P], dtype)
@@ -392,12 +549,10 @@ def mamba_mimo_bwd_fwd(
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             dPhiO_frag[cs, r, p] = dout_frag[cs, p] * Phi_frag[r, p]
 
-                        # NOTE: layout issue when trying to reuse o_mimo_accum_frag
-                        # NOTE: note that it uses out_prereduced_shared, which is the pre-Z-gate version
-                        # of out
+                        # Use the raw pre-gate MIMO output saved in shared memory.
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             dPhiO_frag[cs, r, p] *= out_prereduced_shared[cs*R + r, p]
-                        # Backward of SILU(z) is sigmoid(z) * (1 + z * (1 - sigmoid(z)))
+                        # Backward of SiLU(u): sigmoid(u) * (1 + u * sigmoid(-u)).
                         z_frag = T.alloc_fragment([chunk_size, P], T.float32)
                         T.copy(z_shared, z_frag)
                         Zeta_frag = T.alloc_fragment([R, P], T.float32)
@@ -431,7 +586,7 @@ def mamba_mimo_bwd_fwd(
                             dPhiO_frag[cs, r, p] = DOUT[i_b, chunk_start + cs, r, i_h, p]
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             dPhiO_frag[cs, r, p] *= out_prereduced_shared[cs*R + r, p]
-                        # Backward of SILU(z) is sigmoid(z) * (1 + z * (1 - sigmoid(z)))
+                        # Backward of SiLU(u): sigmoid(u) * (1 + u * sigmoid(-u)).
                         z_frag = T.alloc_fragment([chunk_size, P], T.float32)
                         T.copy(z_shared, z_frag)
                         Zeta_frag = T.alloc_fragment([R, P], T.float32)
@@ -441,14 +596,14 @@ def mamba_mimo_bwd_fwd(
                             dZetaZ_frag[cs, r, p] = z_frag[cs, p] * Zeta_frag[r, p]
                             dZetaZ_frag[cs, r, p] = dPhiO_frag[cs, r, p]* T.sigmoid(dZetaZ_frag[cs, r, p]) * \
                                 (1 + dZetaZ_frag[cs, r, p] * (T.sigmoid(-dZetaZ_frag[cs, r, p])))
-                        ## Compute DZ
+                        # Compute DZ.
                         dZ_frag = T.alloc_fragment([chunk_size, P], dtype)
                         T.clear(dZ_frag)
                         for cs, p in T.Parallel(chunk_size, P):
                             for r in T.serial(R):
                                 dZ_frag[cs, p] += dZetaZ_frag[cs, r, p] * Zeta_frag[r, p]
                         T.copy(dZ_frag, DZ[i_b, chunk_start:chunk_start+chunk_size, i_h, :])
-                        ## Compute DMIMO_Z
+                        # Compute DMIMO_Z.
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             dZetaZ_frag[cs, r, p] *= z_frag[cs, p]
                         dZeta_frag = T.alloc_fragment([R, P], T.float32)
@@ -462,8 +617,7 @@ def mamba_mimo_bwd_fwd(
                 # DA_CS_REV scales stepwise K contribution into the new state.
                 dA_cs_rev_frag = T.alloc_fragment([chunk_size], T.float32)
                 T.copy(DA_CS_REV[i_b, i_h, chunk_start:chunk_start+chunk_size], dA_cs_rev_frag)
-                # NOTE: we can recycle k_trap_scaled_frag from earlier, however,
-                # that is slower, so choose to recopy from smem:
+                # Recopy from shared memory; recycling k_trap_scaled_frag was slower here.
                 k_state_frag = T.alloc_fragment([fused_chunk_size, N], dtype)
                 T.copy(k_shared, k_state_frag)
                 for csr, n in T.Parallel(fused_chunk_size, N):
@@ -478,9 +632,11 @@ def mamba_mimo_bwd_fwd(
                 for n, p in T.Parallel(N, P):
                     states_frag[n, p] *= T.exp(da_cs_sum)
                 T.gemm(k_state_frag, PsiV_shared, states_frag, transpose_A=True, clear_accum=False)
-            
+
             if reduceO:
                 T.copy(dPhi_shared, DMIMO_O[i_b, i_h, :, :])
+            if fuse_pregate_headwise_rms_norm:
+                T.copy(dOutNorm_shared, DOUT_NORM_WEIGHT[i_b, i_h, :, :])
             if hasZ:
                 T.copy(dZeta_shared, DMIMO_Z[i_b, i_h, :, :])
 
@@ -513,11 +669,13 @@ def mamba_mimo_bwd_bwd(
     hasZ,
     hasD,
     reduceO,
+    packed_dout=False,
     chunk_size: int = 16,
     rotary_dim_divisor: int = 4,
     dtype: str = 'float16',
     threads: int = 256,
     num_stages: int = 0,
+    states_dtype = torch.bfloat16,
 ) -> torch.Tensor:
 
     accum_dtype = 'float32'
@@ -526,10 +684,14 @@ def mamba_mimo_bwd_bwd(
     tail_len = S % chunk_size
     fused_chunk_size = chunk_size * R
 
-    if reduceO:
+    if packed_dout:
+        DOUT_shape = (B, H, S*R, P)
+    elif reduceO:
         DOUT_shape = (B, S, H, P)
     else:
         DOUT_shape = (B, S, R, H, P)
+
+    dtype_states = str(states_dtype).replace("torch.","")
 
     @T.prim_func
     def mamba_mimo_bwd_bwd_kernel(
@@ -544,7 +706,7 @@ def mamba_mimo_bwd_bwd(
             DK: T.Tensor([B, S*R, H, N], dtype),  # type: ignore
             DV: T.Tensor([B, S, H, P], dtype),  # type: ignore
             DMIMO_V: T.Tensor([B, H, R, P], T.float32), # type: ignore
-            STATES: T.Tensor([B, H, nchunks, N, P], dtype), # type: ignore 
+            STATES: T.Tensor([B, H, nchunks, N, P], dtype_states), # type: ignore
             DQ: T.Tensor([B, S*R, H, N], dtype),  # type: ignore
 
             Z: T.Tensor([B, S, H, P], dtype),  # type: ignore
@@ -572,11 +734,17 @@ def mamba_mimo_bwd_bwd(
         """
         Overview:
             Reverse-chunk backward pass that consumes cached STATES and QK_DOT from the first pass
-            to produce gradients for the fused Mamba3 attention block.
+            to produce gradients for the fused Mamba3 attention block. For pregate headwise
+            RMSNorm, DOUT is the packed DOUT_PRE_RMS tensor produced by bwd_fwd, so this
+            pass does not recompute raw y (the MIMO output before RMSNorm/gate/down-projection),
+            RMSNorm, down-projection, or gate/Zeta gradients.
 
         Inputs:
             - Forward activations/tensors: DOUT, Q, K, V, optional Z, optional D.
-            - Projection weights/biases: Q_BIAS, K_BIAS, MIMO_V (Psi), MIMO_O (Phi), optional MIMO_Z (Zeta).
+              DOUT is [B,S,H,P] when reduceO=True, [B,S,R,H,P] when reduceO=False,
+              or packed [B,H,S*R,P] when packed_dout=True.
+            - Projection weights/biases: Q_BIAS, K_BIAS, MIMO_V (Psi), MIMO_O (Phi),
+              optional MIMO_Z (Zeta).
             - Cached intermediates: STATES and QK_DOT.
             - Discretization grads and factors:
               DA_CS, DA_CS_REV, DT, TRAP, DDA, DSSDA, DDA_CS_REV, DDA_CS, and SEGSUM.
@@ -586,6 +754,8 @@ def mamba_mimo_bwd_bwd(
             - MIMO projection grads: DMIMO_V.
             - Discretization/rotation grads: DANGLES, DFACTOR, DGAMMA_DIAG, DDA_CS_REV, DDA_CS, DDA.
             - Additional grads: optional DD.
+            - DMIMO_O, DMIMO_Z, DZ, and DOUT_NORM_WEIGHT are produced by bwd_fwd in the
+              pregate RMSNorm path.
 
         Notation:
             - Psi: MIMO X projection.
@@ -593,7 +763,7 @@ def mamba_mimo_bwd_bwd(
             - Zeta: MIMO Z projection.
             - Trap: convex-combination modulator used in exponential-trapezoidal discretization.
         """
-        
+
         with T.Kernel(H, B, threads=threads) as (i_h, i_b):
             # --- Kernel Setup ---
             # GQA support: map V head to Q/K head
@@ -610,6 +780,7 @@ def mamba_mimo_bwd_bwd(
 
             k_shared = T.alloc_shared([fused_chunk_size, N], dtype)
             v_shared = T.alloc_shared([chunk_size, P], dtype)
+            PsiV_shared = T.alloc_shared([fused_chunk_size, P], dtype)
 
             states_shared = T.alloc_shared([N, P], dtype)
             lkq_masked__or__dkq_masked_shared = T.alloc_shared([fused_chunk_size, fused_chunk_size], dtype)
@@ -640,6 +811,7 @@ def mamba_mimo_bwd_bwd(
 
                     k_shared: tilelang.layout.make_swizzled_layout(k_shared),
                     v_shared: tilelang.layout.make_swizzled_layout(v_shared),
+                    PsiV_shared: tilelang.layout.make_swizzled_layout(PsiV_shared),
                     states_shared: tilelang.layout.make_swizzled_layout(states_shared),
                     lkq_masked__or__dkq_masked_shared: tilelang.layout.make_swizzled_layout(lkq_masked__or__dkq_masked_shared),
 
@@ -668,7 +840,7 @@ def mamba_mimo_bwd_bwd(
             Psi_frag = T.alloc_fragment([R, P], dtype)
             T.copy(MIMO_V[i_h, :, :], Psi_frag)
 
-            dPsi_acc = T.alloc_fragment([R, P], accum_dtype) # TODO
+            dPsi_acc = T.alloc_fragment([R, P], accum_dtype)
             T.clear(dPsi_acc)
 
             if hasD:
@@ -702,8 +874,8 @@ def mamba_mimo_bwd_bwd(
                     )
                 shifted_gamma_frag = T.alloc_fragment([chunk_size], dtype)
                 for cs in T.Parallel(chunk_size):
-                    shifted_gamma_frag[cs] = T.if_then_else(chunk_start + cs < (S - 1), 
-                                                            dt_shifted_frag[cs] * T.sigmoid(-trap_shifted_frag[cs]), 
+                    shifted_gamma_frag[cs] = T.if_then_else(chunk_start + cs < (S - 1),
+                                                            dt_shifted_frag[cs] * T.sigmoid(-trap_shifted_frag[cs]),
                                                             0.0)
 
                 trap_frag = T.alloc_fragment([chunk_size], T.float32)
@@ -721,7 +893,7 @@ def mamba_mimo_bwd_bwd(
                 trap_scale_shared = T.alloc_shared([chunk_size], dtype)
                 T.copy(trap_scale_frag, trap_scale_shared)
 
-                # --- DOUT Projection and Optional Z / D Paths ---
+                # --- Build dPhiO from reduced, unreduced, or packed pre-RMS DOUT ---
                 dPhiO_frag = T.alloc_fragment([chunk_size, R, P], dtype)
                 if reduceO:
                     for cs, p in T.Parallel(chunk_size, P):
@@ -730,10 +902,17 @@ def mamba_mimo_bwd_bwd(
                         dPhiO_frag[cs, r, p] = dout_shared[cs, p] * Phi_frag[r, p]
                 else:
                     for cs, r, p in T.Parallel(chunk_size, R, P):
-                        dPhiO_frag[cs, r, p] = DOUT[i_b, chunk_start + cs, r, i_h, p]
+                        if packed_dout:
+                            dPhiO_frag[cs, r, p] = DOUT[
+                                i_b, i_h, fused_chunk_start+cs*R+r, p
+                            ]
+                        else:
+                            dPhiO_frag[cs, r, p] = DOUT[
+                                i_b, chunk_start + cs, r, i_h, p
+                            ]
 
                 if hasZ:
-                    ## Backpropagate via *SILU(Z)
+                    # Backpropagate through the SiLU(Z * Zeta) gate.
                     Zeta_frag = T.alloc_fragment([R, P], dtype)
                     T.copy(MIMO_Z[i_h, :, :], Zeta_frag)
                     z_frag = T.alloc_fragment([chunk_size, P], dtype)
@@ -745,7 +924,7 @@ def mamba_mimo_bwd_bwd(
 
                 T.copy(V[i_b, chunk_start:chunk_start+chunk_size, i_h, :], v_shared)
                 if hasD:
-                    # Compute dD via projected DOUT and V/Psi factors.
+                    # Compute dD from dPhiO and Psi(V).
                     v_dD_frag =  T.alloc_fragment([chunk_size, P], accum_dtype)
                     Psi_dD_frag = T.alloc_fragment([R, P], accum_dtype)
                     T.copy(v_shared, v_dD_frag)
@@ -758,7 +937,7 @@ def mamba_mimo_bwd_bwd(
                 # Load q and apply q_bias to it:
                 for cs, r, n in T.Parallel(chunk_size, R, N):
                     q_shared[cs*R + r, n] = Q[i_b, chunk_start+cs, r, i_h_qk, n]
-                
+
                 q_frag = T.alloc_fragment([chunk_size, R, N], dtype)
                 for cs, r, n in T.Parallel(chunk_size, R, N):
                     q_frag[cs, r, n] = q_shared[cs*R + r, n]
@@ -806,6 +985,11 @@ def mamba_mimo_bwd_bwd(
                     k_trap_scaled_frag[csr, n] *= trap_scale_shared[csr//R]
                 T.copy(k_trap_scaled_frag, k_shared)
 
+                v_for_psiv_frag = T.alloc_fragment([chunk_size, P], accum_dtype)
+                T.copy(v_shared, v_for_psiv_frag)
+                for cs, r, p in T.Parallel(chunk_size, R, P):
+                    PsiV_shared[cs*R + r, p] = v_for_psiv_frag[cs, p] * Psi_frag[r, p]
+
                 # Apply the effect of interchunk (state update):
                 dPsiV_frag = T.alloc_fragment([fused_chunk_size, P], accum_dtype)
                 T.gemm(k_shared, dstates_shared, dPsiV_frag, clear_accum=True)
@@ -820,7 +1004,8 @@ def mamba_mimo_bwd_bwd(
                 # Apply the effect of intrachunk:
                 lkq_frag = T.alloc_fragment([fused_chunk_size, fused_chunk_size], accum_dtype)
                 T.gemm(k_shared, q_shared, lkq_frag, transpose_B=True, clear_accum=True)
-                T.copy(lkq_frag, lkq_masked__or__dkq_masked_shared) # NOTE: Save later for the computation of DSSDA, using lkq_masked__or__dkq_masked_shared which has the same shape
+                # Save the unmasked KQ product for DSSDA; reuse this same-shape buffer.
+                T.copy(lkq_frag, lkq_masked__or__dkq_masked_shared)
                 if R == 1: # More smem efficient which is necessary for R=1, but slower due to the need for casting
                     lkq_masked_dtype_buf = T.alloc_fragment([fused_chunk_size, fused_chunk_size], dtype)
                     T.copy(lkq_masked__or__dkq_masked_shared, lkq_masked_dtype_buf)
@@ -855,8 +1040,7 @@ def mamba_mimo_bwd_bwd(
                 else:
                     T.copy(dPsiV_frag, dPsiV_D_fused_frag)
                 # Compute the contribution from the qk_dot term:
-                # NOTE: recomputing qk_dot here is much slower than just loading from
-                # the result of the bwd_fwd kernel
+                # Loading QK_DOT from bwd_fwd is faster than recomputing it here.
                 qk_dot_frag = T.alloc_fragment([chunk_size, R, R], dtype)
                 T.copy(QK_DOT[i_b, i_h, chunk_start:chunk_start+chunk_size, :, :], qk_dot_shared)
                 T.copy(qk_dot_shared, qk_dot_frag)
@@ -894,9 +1078,7 @@ def mamba_mimo_bwd_bwd(
                 for cs, p in T.Parallel(chunk_size, P):
                     for r in T.serial(R):
                         PsiV_frag[cs, r, p] += v_frag[cs, p] * Psi_frag[r, p]
-                # NOTE: Tilelang unable to perform gemm with reshaped PsiV_frag
-                # so have to copy to smem
-                PsiV_shared  = T.alloc_shared([fused_chunk_size, P], dtype)
+                # TileLang cannot use the reshaped PsiV fragment directly in this GEMM.
                 for cs, r, p in T.Parallel(chunk_size, R, P):
                     PsiV_shared[cs*R + r, p] = PsiV_frag[cs, r, p]
 
@@ -995,10 +1177,10 @@ def mamba_mimo_bwd_bwd(
                 T.copy(dk_nodiag_frag, dk_shared)
 
                 # --- State-Passing ddA Terms + Interchunk dQ ---
-                T.copy(STATES[i_b, i_h, chunk_idx, :, :], states_shared) # Load cached states from bwd_fwd
-                # NOTE: Compute the contribution of state passing (part 3 of 4)
                 states_frag = T.alloc_fragment([N, P], T.float32)
-                T.copy(states_shared, states_frag)
+                T.copy(STATES[i_b, i_h, chunk_idx, :, :], states_frag) # Load cached states from bwd_fwd
+                # Contribution from state passing.
+                T.copy(states_frag, states_shared)
                 ddA_state_passing = T.alloc_fragment([1], T.float32)
                 ddA_state_passing_prereduce_frag = T.alloc_fragment([N, P], T.float32)
                 da_cs_sum = T.alloc_var(T.float32)
@@ -1008,8 +1190,8 @@ def mamba_mimo_bwd_bwd(
                     T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum)
                 for n, p in T.Parallel(N, P):
                     ddA_state_passing_prereduce_frag[n, p] = (
-                        states_frag[n, p] 
-                        * dstates_frag[n, p] 
+                        states_frag[n, p]
+                        * dstates_frag[n, p]
                         * T.exp(da_cs_sum)
                     )
                 T.reduce_sum(
@@ -1024,13 +1206,13 @@ def mamba_mimo_bwd_bwd(
 
                 dq_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
                 T.gemm(dPhiO_shared, states_shared, dq_frag, transpose_B=True, clear_accum=True)
-                # NOTE: Compute the contribution to ddA from applying it to q*state (part 4 of 4)
+                # Contribution from applying dA_cs to q * state.
                 dda_cs_prereduce_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
                 T.copy(q_shared, dda_cs_prereduce_frag)
                 for csr, n in T.Parallel(fused_chunk_size, N):
                     dda_cs_prereduce_frag[csr, n] *= dq_frag[csr, n]
                 dda_cs_frag = T.alloc_fragment([chunk_size], accum_dtype)
-                T.reduce_sum(T.view(dda_cs_prereduce_frag, shape=[chunk_size, R*N]), 
+                T.reduce_sum(T.view(dda_cs_prereduce_frag, shape=[chunk_size, R*N]),
                              dda_cs_frag, dim=-1, clear=True)
                 T.copy(dda_cs_frag, DDA_CS[i_b, i_h, chunk_start:chunk_start+chunk_size])
 
@@ -1042,8 +1224,7 @@ def mamba_mimo_bwd_bwd(
                 for csr, n in T.Parallel(fused_chunk_size, N):
                     # DA_CS scales interchunk q-state contribution in backward.
                     dq_frag[csr, n] *= T.exp(dA_cs_dq_frag[csr//R])
-                # NOTE: Unable to reuse dk_intrachunk_frag_dtype due to layout issue
-                # (we do gemm with the transpose of dk_intrachunk_frag_dtype)
+                # Keep a separate buffer; the later GEMM needs the transposed layout.
                 T.copy(dq_frag, dq_shared)
                 dq_combined_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype)
                 T.copy(dq_shared, dq_combined_frag)
@@ -1068,7 +1249,7 @@ def mamba_mimo_bwd_bwd(
                     dangle_dk_frag[cs, r, n] = dk_first_half_frag[cs, r, n] * (-k_prerot_first_half_frag[cs, r, n] * T.sin(angles_dk_frag[cs, n]) - k_prerot_second_half_frag[cs, r, n] * T.cos(angles_dk_frag[cs, n])) +\
                                             dk_second_half_frag[cs, r, n] * (k_prerot_first_half_frag[cs, r, n] * T.cos(angles_dk_frag[cs, n]) - k_prerot_second_half_frag[cs, r, n] * T.sin(angles_dk_frag[cs, n]))
                 T.copy(T.view(dangle_dk_frag, shape=[fused_chunk_size, N//rotary_dim_divisor]), dangle_dk__or__dq_shared)
-                
+
                 # Rotate dk_shared:
                 for cs, r, n in T.Parallel(chunk_size, R, N//rotary_dim_divisor):
                     dk_shared[cs*R + r, n] = T.cos(angles_dk_frag[cs, n]) * dk_first_half_frag[cs, r, n] + T.sin(angles_dk_frag[cs, n]) * dk_second_half_frag[cs, r, n]
@@ -1079,13 +1260,13 @@ def mamba_mimo_bwd_bwd(
 
                 # Compute the effect of dqk_from_diag
                 q_dk_frag = T.alloc_fragment([fused_chunk_size, N], accum_dtype) # Keeping q_dk_frag in accum_dtype to avoid casting instructions
-                T.copy(q_pre_rot_shared, q_dk_frag) # NOTE: we need to use the pre-rotated version of q
+                T.copy(q_pre_rot_shared, q_dk_frag)
                 q_dk_frag_reshaped = T.view(q_dk_frag, [chunk_size, R, N])
                 for csr_in, n in T.Parallel(fused_chunk_size, N):
                     cs = csr_in // R
                     for r_out in T.serial(R):
                         csr_out = cs*R + r_out
-                        dk_combined_frag[csr_in, n] += dqk_from_diag_shared[csr_out, csr_in] * q_dk_frag_reshaped[cs, r_out, n]  
+                        dk_combined_frag[csr_in, n] += dqk_from_diag_shared[csr_out, csr_in] * q_dk_frag_reshaped[cs, r_out, n]
                 # Copy to gmem:
                 T.copy(dk_combined_frag, DK[i_b, fused_chunk_start:fused_chunk_start+fused_chunk_size, i_h, :])
 
@@ -1096,7 +1277,7 @@ def mamba_mimo_bwd_bwd(
                 for cs, r, n in T.Parallel(chunk_size, R, N//rotary_dim_divisor):
                     dq_first_half_frag[cs, r, n] = dq_shared[cs*R + r, n]
                     dq_second_half_frag[cs, r, n] = dq_shared[cs*R + r, N//2 + n]
-                
+
                 # Compute the contribution of dq to dangle:
                 q_prerot_first_half_frag = T.alloc_fragment([chunk_size, R, N//rotary_dim_divisor], dtype)
                 q_prerot_second_half_frag = T.alloc_fragment([chunk_size, R, N//rotary_dim_divisor], dtype)
@@ -1157,12 +1338,12 @@ def mamba_mimo_bwd_bwd(
 
 def mamba_mimo_bwd_combined(
         dout,
-        q, 
-        k, 
-        v, 
+        q,
+        k,
+        v,
         q_bias,
         k_bias,
-        mimo_v, 
+        mimo_v,
         mimo_o,
         z,
         mimo_z,
@@ -1180,15 +1361,54 @@ def mamba_mimo_bwd_combined(
         bf_num_stages=0,
         bb_threads=256,
         bb_num_stages=0,
+        states_dtype=torch.bfloat16,
+        fuse_pregate_headwise_rms_norm=False,
+        outproj_norm_weight=None,
+        outproj_norm_eps=1e-5,
         ):
     # TileLang kernel expects contiguous last-dim strides for DOUT.
     B, S, R, G, N = q.shape
     H, P = v.shape[-2], v.shape[-1]
     reduceO = mimo_o is not None
+    if fuse_pregate_headwise_rms_norm:
+        if not reduceO:
+            raise ValueError("fuse_pregate_headwise_rms_norm=True requires mimo_o.")
+        if z is None or mimo_z is None:
+            raise ValueError("fuse_pregate_headwise_rms_norm=True requires z and mimo_z.")
+    if not fuse_pregate_headwise_rms_norm:
+        outproj_norm_weight_arg = None
+    elif outproj_norm_weight is None:
+        outproj_norm_weight_arg = torch.ones((H, P), dtype=torch.float32, device=q.device)
+    else:
+        if outproj_norm_weight.ndim == 1:
+            if outproj_norm_weight.numel() != H * P:
+                raise ValueError(
+                    f"Expected flattened outproj_norm_weight to have {H * P} elements, "
+                    f"got {outproj_norm_weight.numel()}."
+                )
+            outproj_norm_weight_arg = outproj_norm_weight.reshape(H, P).contiguous()
+        elif outproj_norm_weight.shape == (H, P):
+            outproj_norm_weight_arg = outproj_norm_weight.contiguous()
+        else:
+            raise ValueError(
+                f"Expected outproj_norm_weight to have shape ({H}, {P}) or ({H * P},), "
+                f"got {tuple(outproj_norm_weight.shape)}."
+            )
+        outproj_norm_weight_arg = outproj_norm_weight_arg.to(device=q.device, dtype=torch.float32)
 
     dmimo_o = torch.empty([B, H, R, P], dtype=mimo_v.dtype, device=mimo_v.device) if reduceO else None
-    states = torch.empty([B, H, math.ceil(S/chunk_size), N, P], dtype=v.dtype, device=v.device) # NOTE: states dtype is set to v.dtype
-    
+    dout_norm_weight = (
+        torch.empty([B, H, R, P], dtype=torch.float32, device=v.device)
+        if fuse_pregate_headwise_rms_norm else None
+    )
+    dout_norm_weight_arg = dout_norm_weight
+    dout_pre_rms = (
+        torch.empty([B, H, S*R, P], dtype=dout.dtype, device=dout.device)
+        if fuse_pregate_headwise_rms_norm
+        else None
+    )
+    states = torch.empty([B, H, math.ceil(S/chunk_size), N, P], dtype=states_dtype, device=v.device)
+
     if z is not None:
         dz_tilelang = torch.empty_like(v)
         dmimo_z = torch.empty([B, H, R, P], dtype=mimo_v.dtype, device=mimo_v.device)
@@ -1204,30 +1424,34 @@ def mamba_mimo_bwd_combined(
         dtype_str = dtype
     bwd_fwd_kernel = mamba_mimo_bwd_fwd(
         T.dynamic("B"),
-        T.dynamic("S"), 
-        T.dynamic("H"), 
-        T.dynamic("G"), 
-        N, P, R, 
+        T.dynamic("S"),
+        T.dynamic("H"),
+        T.dynamic("G"),
+        N, P, R,
         z is not None,
         D is not None,
         reduceO,
-        chunk_size, 
+        fuse_pregate_headwise_rms_norm,
+        chunk_size,
         rotary_dim_divisor,
         dtype_str,
+        outproj_norm_eps,
         bf_threads,
-        bf_num_stages
-    )
-
+        bf_num_stages,
+        states_dtype=states_dtype)
     bwd_fwd_kernel(
                     dout,
-                    q, 
-                    k, 
-                    v, 
+                    q,
+                    k,
+                    v,
                     q_bias,
                     k_bias,
-                    mimo_v, 
+                    mimo_v,
                     mimo_o,
+                    outproj_norm_weight_arg,
                     dmimo_o,
+                    dout_norm_weight_arg,
+                    dout_pre_rms,
                     states,
                     z,
                     mimo_z,
@@ -1242,10 +1466,10 @@ def mamba_mimo_bwd_combined(
                     qk_dot,
                     segsum,
                     )
-    if reduceO:
+    if reduceO and not fuse_pregate_headwise_rms_norm:
         dmimo_o = dmimo_o.sum(dim=0)
 
-    
+
     dq_tilelang = torch.empty([B, S, R, H, N], dtype=q.dtype, device=q.device)
     dk_tilelang = torch.empty([B, S, R, H, N], dtype=k.dtype, device=k.device)
     dv_tilelang = torch.empty_like(v)
@@ -1258,34 +1482,41 @@ def mamba_mimo_bwd_combined(
     dSSdA = torch.zeros([B, H, math.ceil(S/chunk_size), chunk_size, chunk_size], dtype=torch.float32, device=dt.device)
     ddA_cs_rev = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
     ddA_cs = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
-    
-    
+
+
+    # Pregate RMSNorm is handled in bwd_fwd. The reverse pass consumes packed
+    # DOUT_PRE_RMS and skips Phi/Z/RMSNorm work.
+    bwd_bwd_dout = dout_pre_rms if fuse_pregate_headwise_rms_norm else dout
+    bwd_bwd_reduceO = reduceO and not fuse_pregate_headwise_rms_norm
+    bwd_bwd_hasZ = (z is not None) and not fuse_pregate_headwise_rms_norm
+    bwd_bwd_packed_dout = fuse_pregate_headwise_rms_norm
     bwd_bwd_kernel = mamba_mimo_bwd_bwd(
         T.dynamic("B"),
-        T.dynamic("S"), 
-        T.dynamic("H"), 
-        T.dynamic("G"), 
-        N, P, R, 
-        z is not None,
+        T.dynamic("S"),
+        T.dynamic("H"),
+        T.dynamic("G"),
+        N, P, R,
+        bwd_bwd_hasZ,
         D is not None,
-        reduceO,
-        chunk_size, 
+        bwd_bwd_reduceO,
+        bwd_bwd_packed_dout,
+        chunk_size,
         rotary_dim_divisor,
         dtype_str,
         bb_threads,
-        bb_num_stages)
-
+        bb_num_stages,
+        states_dtype=states_dtype)
     bwd_bwd_kernel(
-            dout,
-            q, 
+            bwd_bwd_dout,
+            q,
             k,
             v,
             q_bias,
             k_bias,
-            mimo_v, 
+            mimo_v,
             mimo_o,
-            dk_tilelang.view(B, S*R, H, N), 
-            dv_tilelang, 
+            dk_tilelang.view(B, S*R, H, N),
+            dv_tilelang,
             dmimo_v,
             states,
             dq_tilelang.view(B, S*R, H, N),
@@ -1308,23 +1539,18 @@ def mamba_mimo_bwd_combined(
             ddA_cs,
             segsum,
             )
-    
-    if G == 1:
-        dq_bias_tilelang = dq_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
-        dk_bias_tilelang = dk_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
-        dq_tilelang = dq_tilelang.sum(dim=3, keepdim=True)
-        dk_tilelang = dk_tilelang.sum(dim=3, keepdim=True)
-        dmimo_v = dmimo_v.sum(dim=0)
-        dmimo_z = dmimo_z.sum(dim=0) if dmimo_z is not None else None
-        dD = dD.sum(dim=0) if dD is not None else None
-    elif G == H:
-        dq_bias_tilelang = dq_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
-        dk_bias_tilelang = dk_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
-        dmimo_v = dmimo_v.sum(dim=0)
-        dmimo_z = dmimo_z.sum(dim=0) if dmimo_z is not None else None
-        dD = dD.sum(dim=0) if dD is not None else None
+
+    dq_tilelang, dk_tilelang, dq_bias_tilelang, dk_bias_tilelang = (
+        reduce_grouped_qk_grads_and_bias_triton(dq_tilelang, dk_tilelang, G)
+    )
+    dmimo_v = dmimo_v.sum(dim=0)
+    if fuse_pregate_headwise_rms_norm:
+        dmimo_o = dmimo_o.sum(dim=0)
+        dmimo_z = dmimo_z.sum(dim=0)
+        dout_norm_weight = dout_norm_weight.sum(dim=(0, 2))
     else:
-        raise ValueError(f"G value of {G} is not currently supported!")
+        dmimo_z = dmimo_z.sum(dim=0) if dmimo_z is not None else None
+    dD = dD.sum(dim=0) if dD is not None else None
 
     ddt, dtrap = bwd_dtrap_ddt_triton(
         trap, dt, dfactor, dgamma_diag, chunk_size
@@ -1335,7 +1561,7 @@ def mamba_mimo_bwd_combined(
     )
 
 
-    return (dq_tilelang, dk_tilelang, dv_tilelang, 
+    return (dq_tilelang, dk_tilelang, dv_tilelang,
             ddA, ddt, dtrap, dq_bias_tilelang, dk_bias_tilelang,
-            dmimo_v, dmimo_z, dmimo_o, dangles, 
-            dD, dz_tilelang)
+            dmimo_v, dmimo_z, dmimo_o, dangles,
+            dD, dz_tilelang, dout_norm_weight)

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd_varlen.py
@@ -40,6 +40,9 @@ import argparse
 from typing import Optional, Tuple
 
 from mamba_ssm.ops.triton.mamba3.mamba3_mimo_utils import bwd_dadt_fused_triton_varlen, bwd_dtrap_ddt_triton_varlen
+from mamba_ssm.ops.triton.mamba3.grouped_head_reduction import (
+    reduce_grouped_qk_grads_and_bias_triton,
+)
 from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_bwd import mamba_mimo_bwd_combined
 
 # def get_configs():
@@ -69,12 +72,15 @@ def mamba_mimo_bwd_fwd(
     hasZ,
     hasD,
     reduceO,
+    fuse_pregate_headwise_rms_norm=False,
     isVarlen: bool = True,
     chunk_size: int = 16,
     rotary_dim_divisor: int = 4,
     dtype: str = 'float16',
+    outproj_norm_eps: float = 1e-5,
     threads: int = 128,
     num_stages: int = 0,
+    states_dtype = torch.bfloat16,
 ) -> torch.Tensor:
     """
     TileLang kernel factory for the varlen Mamba3 bwd-fwd pass.
@@ -105,6 +111,9 @@ def mamba_mimo_bwd_fwd(
         DOUT_shape = (B, S, H, P)
     else:
         DOUT_shape = (B, S, R, H, P)
+    DOUT_PRE_RMS_shape = (B, H, S * R, P) if fuse_pregate_headwise_rms_norm else (1,)
+
+    dtype_states = str(states_dtype).replace("torch.", "")
 
     @T.prim_func
     def mamba_mimo_bwd_fwd_kernel(
@@ -116,8 +125,11 @@ def mamba_mimo_bwd_fwd(
             K_BIAS: T.Tensor([H, R, N], T.float32),  # type: ignore
             MIMO_V: T.Tensor([H, R, P], T.float32),  # type: ignore
             MIMO_O: T.Tensor([H, R, P], T.float32),  # type: ignore
+            OUT_NORM_WEIGHT: T.Tensor([H, P], T.float32),  # type: ignore
             DMIMO_O: T.Tensor([B, H, NS, R, P], T.float32),  # type: ignore
-            STATES: T.Tensor([B, H, max_nchunks, N, P], dtype),  # type: ignore
+            DOUT_NORM_WEIGHT: T.Tensor([B, H, NS, R, P], T.float32),  # type: ignore
+            DOUT_PRE_RMS: T.Tensor(DOUT_PRE_RMS_shape, dtype),  # type: ignore
+            STATES: T.Tensor([B, H, max_nchunks, N, P], dtype_states),  # type: ignore
             Z: T.Tensor([B, S, H, P], dtype),  # type: ignore
             MIMO_Z: T.Tensor([H, R, P], T.float32),  # type: ignore
             DZ: T.Tensor([B, S, H, P], dtype),  # type: ignore
@@ -130,6 +142,7 @@ def mamba_mimo_bwd_fwd(
             D: T.Tensor([H], T.float32),  # type: ignore
             QK_DOT: T.Tensor([B, H, S, R, R], dtype),  # type: ignore
             SEGSUM: T.Tensor([B, H, max_nchunks, chunk_size, chunk_size], T.float32),  # type: ignore
+            NS_ANCHOR: T.Tensor([NS], dtype=T.int32),  # type: ignore
             CU_SEQLENS: T.Tensor([NS + 1], dtype=T.int32),  # type: ignore
             ):
         """
@@ -142,6 +155,8 @@ def mamba_mimo_bwd_fwd(
             - Z, D: optional gating / skip-connection tensors.
             - ANGLES: rotary angles.
             - DA_CS, DA_CS_REV, DT, TRAP, SEGSUM: discretization tensors.
+            - NS_ANCHOR: unused int32 view with shape ``[NS]``. It lets
+              TileLang infer ``NS`` when optional ``[B,H,NS,R,P]`` outputs are None.
             - CU_SEQLENS: int32 prefix-sum of per-sequence lengths,
               shape ``[NS+1]``.
 
@@ -149,6 +164,8 @@ def mamba_mimo_bwd_fwd(
             - DMIMO_O: gradient of the Phi projection, shape
               ``[B, H, NS, R, P]`` (sum-reduced over NS by the wrapper).
             - DMIMO_Z: gradient of the Zeta projection, same shape.
+            - DOUT_NORM_WEIGHT: per-sequence partial norm-weight gradient.
+            - DOUT_PRE_RMS: packed ``dL/d(raw_y)`` for bwd-bwd.
             - STATES: per-chunk recurrent states cached for the bwd-bwd
               pass, shape ``[B, H, max_nchunks, N, P]``.
             - QK_DOT: per-step Q·K diagonal blocks, shape
@@ -171,6 +188,9 @@ def mamba_mimo_bwd_fwd(
             if reduceO:
                 dPhi_shared = T.alloc_shared([R, P], accum_dtype)
                 T.clear(dPhi_shared)
+            if fuse_pregate_headwise_rms_norm:
+                dOutNorm_shared = T.alloc_shared([R, P], accum_dtype)
+                T.clear(dOutNorm_shared)
 
             dout_shared = T.alloc_shared([chunk_size, P], dtype)
             z_shared = T.alloc_shared([chunk_size, P], dtype)
@@ -212,7 +232,7 @@ def mamba_mimo_bwd_fwd(
             seq_end = T.alloc_var(T.int32)
             full_nchunks = T.alloc_var(T.int32)
             tail_len = T.alloc_var(T.int32)
-            if isVarlen:
+            if NS > 1:
                 start_seq_ind = CU_SEQLENS[i_ns]
                 start_chunk_ind = (start_seq_ind // chunk_size) + i_ns
                 seq_len = CU_SEQLENS[i_ns + 1] - CU_SEQLENS[i_ns]
@@ -394,13 +414,40 @@ def mamba_mimo_bwd_fwd(
                     for csr, p in T.Parallel(fused_chunk_size, P):
                         o_mimo_accum_frag[csr, p] += D_var * PsiV_D_frag[csr, p]
 
-                # --- DMIMO_O / DZ projection ---
+                # --- Projection, optional gate, and pregate RMS side gradients ---
                 if reduceO:
-                    out_prereduced_shared = T.alloc_shared([fused_chunk_size, P], dtype)
-                    T.copy(o_mimo_accum_frag, out_prereduced_shared)
+                    if not fuse_pregate_headwise_rms_norm:
+                        out_prereduced_shared = T.alloc_shared([fused_chunk_size, P], dtype)
+                        T.copy(o_mimo_accum_frag, out_prereduced_shared)
 
                     o_gated_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
-                    if hasZ:
+                    if fuse_pregate_headwise_rms_norm:
+                        # raw_y is the per-rank MIMO output before RMSNorm, gate, and down projection.
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            o_gated_frag[cs, r, p] = o_mimo_accum_frag[cs * R + r, p]
+                            o_gated_frag[cs, r, p] *= o_gated_frag[cs, r, p]
+                        o_rstd_frag = T.alloc_fragment([chunk_size, R], T.float32)
+                        T.reduce_sum(o_gated_frag, o_rstd_frag, dim=-1, clear=True)
+                        for cs, r in T.Parallel(chunk_size, R):
+                            o_rstd_frag[cs, r] = 1.0 / T.sqrt(
+                                o_rstd_frag[cs, r] / P + outproj_norm_eps
+                            )
+
+                        T.copy(Z[i_b, chunk_start:chunk_start + chunk_size, i_h, :], z_shared)
+                        z_o_frag = T.alloc_fragment([chunk_size, P], T.float32)
+                        T.copy(z_shared, z_o_frag)
+                        Zeta_o_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(MIMO_Z[i_h, :, :], Zeta_o_frag)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            tmp = z_o_frag[cs, p] * Zeta_o_frag[r, p] * 0.5
+                            o_gated_frag[cs, r, p] = tmp * T.tanh(tmp) + tmp
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            o_gated_frag[cs, r, p] *= (
+                                o_mimo_accum_frag[cs * R + r, p]
+                                * o_rstd_frag[cs, r]
+                                * OUT_NORM_WEIGHT[i_h, p]
+                            )
+                    elif hasZ:
                         T.copy(Z[i_b, chunk_start:chunk_start + chunk_size, i_h, :], z_shared)
                         z_o_frag = T.alloc_fragment([chunk_size, P], T.float32)
                         T.copy(z_shared, z_o_frag)
@@ -423,12 +470,110 @@ def mamba_mimo_bwd_fwd(
                         for cs, p in T.Parallel(chunk_size, P):
                             dout_shared[cs, p] = T.if_then_else(cs < eff_tail, dout_shared[cs, p], 0.0)
                     T.copy(dout_shared, dout_frag)
-                    for r, p in T.Parallel(R, P):
-                        for cs in T.serial(chunk_size):
-                            dPhi_frag[r, p] += o_gated_frag[cs, r, p] * dout_frag[cs, p]
-                    T.copy(dPhi_frag, dPhi_shared)
 
-                    if hasZ:
+                    if fuse_pregate_headwise_rms_norm:
+                        dPhi_prereduce = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhi_prereduce[cs, r, p] = o_gated_frag[cs, r, p] * dout_frag[cs, p]
+                        T.reduce_sum(dPhi_prereduce, dPhi_frag, dim=0, clear=False)
+                        T.copy(dPhi_frag, dPhi_shared)
+                    else:
+                        for r, p in T.Parallel(R, P):
+                            for cs in T.serial(chunk_size):
+                                dPhi_frag[r, p] += o_gated_frag[cs, r, p] * dout_frag[cs, p]
+                        T.copy(dPhi_frag, dPhi_shared)
+
+                    if fuse_pregate_headwise_rms_norm:
+                        Phi_frag = T.alloc_fragment([R, P], dtype)
+                        T.copy(MIMO_O[i_h, :, :], Phi_frag)
+
+                        # dnorm is dL/d(xhat), where xhat = raw_y * rstd.
+                        dPhiO_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dPhiO_frag[cs, r, p] = (
+                                dout_frag[cs, p]
+                                * Phi_frag[r, p]
+                                * o_mimo_accum_frag[cs * R + r, p]
+                                * o_rstd_frag[cs, r]
+                                * OUT_NORM_WEIGHT[i_h, p]
+                            )
+
+                        z_frag = T.alloc_fragment([chunk_size, P], T.float32)
+                        T.copy(z_shared, z_frag)
+                        Zeta_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(MIMO_Z[i_h, :, :], Zeta_frag)
+                        dZetaZ_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZetaZ_frag[cs, r, p] = z_frag[cs, p] * Zeta_frag[r, p]
+                            dZetaZ_frag[cs, r, p] = dPhiO_frag[cs, r, p] * T.sigmoid(dZetaZ_frag[cs, r, p]) * \
+                                (1 + dZetaZ_frag[cs, r, p] * (T.sigmoid(-dZetaZ_frag[cs, r, p])))
+                        dZ_frag_prereduce = T.alloc_fragment([chunk_size, R, P], dtype)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZ_frag_prereduce[cs, r, p] = dZetaZ_frag[cs, r, p] * Zeta_frag[r, p]
+                        dZ_frag = T.alloc_fragment([chunk_size, P], dtype)
+                        T.reduce_sum(dZ_frag_prereduce, dZ_frag, clear=True, dim=1)
+                        if eff_tail < chunk_size:
+                            for cs, p in T.Parallel(chunk_size, P):
+                                if cs < eff_tail:
+                                    DZ[i_b, chunk_start + cs, i_h, p] = dZ_frag[cs, p]
+                        else:
+                            T.copy(dZ_frag, DZ[i_b, chunk_start:chunk_start + chunk_size, i_h, :])
+
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            dZetaZ_frag[cs, r, p] *= z_frag[cs, p]
+                        dZeta_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(dZeta_shared, dZeta_frag)
+                        T.reduce_sum(dZetaZ_frag, dZeta_frag, clear=False, dim=0)
+                        T.copy(dZeta_frag, dZeta_shared)
+
+                        weighted_dot_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            tmp = z_frag[cs, p] * Zeta_frag[r, p] * 0.5
+                            gate = tmp * T.tanh(tmp) + tmp
+                            xhat = o_mimo_accum_frag[cs * R + r, p] * o_rstd_frag[cs, r]
+                            dnorm = dout_frag[cs, p] * Phi_frag[r, p] * gate
+                            weighted_dot_frag[cs, r, p] = dnorm * xhat
+
+                        dOutNorm_frag = T.alloc_fragment([R, P], T.float32)
+                        T.copy(dOutNorm_shared, dOutNorm_frag)
+                        T.reduce_sum(weighted_dot_frag, dOutNorm_frag, dim=0, clear=False)
+                        T.copy(dOutNorm_frag, dOutNorm_shared)
+
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            weighted_dot_frag[cs, r, p] *= OUT_NORM_WEIGHT[i_h, p]
+                        rms_dot_frag = T.alloc_fragment([chunk_size, R], T.float32)
+                        T.reduce_sum(weighted_dot_frag, rms_dot_frag, dim=-1, clear=True)
+                        for cs, r in T.Parallel(chunk_size, R):
+                            rms_dot_frag[cs, r] /= P
+
+                        if eff_tail < chunk_size:
+                            for cs, r, p in T.Parallel(chunk_size, R, P):
+                                if cs < eff_tail:
+                                    tmp = z_frag[cs, p] * Zeta_frag[r, p] * 0.5
+                                    gate = tmp * T.tanh(tmp) + tmp
+                                    xhat = o_mimo_accum_frag[cs * R + r, p] * o_rstd_frag[cs, r]
+                                    dnorm = dout_frag[cs, p] * Phi_frag[r, p] * gate
+                                    DOUT_PRE_RMS[i_b, i_h, fused_chunk_start + cs * R + r, p] = (
+                                        o_rstd_frag[cs, r]
+                                        * (
+                                            dnorm * OUT_NORM_WEIGHT[i_h, p]
+                                            - xhat * rms_dot_frag[cs, r]
+                                        )
+                                    )
+                        else:
+                            for cs, r, p in T.Parallel(chunk_size, R, P):
+                                tmp = z_frag[cs, p] * Zeta_frag[r, p] * 0.5
+                                gate = tmp * T.tanh(tmp) + tmp
+                                xhat = o_mimo_accum_frag[cs * R + r, p] * o_rstd_frag[cs, r]
+                                dnorm = dout_frag[cs, p] * Phi_frag[r, p] * gate
+                                DOUT_PRE_RMS[i_b, i_h, fused_chunk_start + cs * R + r, p] = (
+                                    o_rstd_frag[cs, r]
+                                    * (
+                                        dnorm * OUT_NORM_WEIGHT[i_h, p]
+                                        - xhat * rms_dot_frag[cs, r]
+                                    )
+                                )
+                    elif hasZ:
                         Phi_frag = T.alloc_fragment([R, P], dtype)
                         T.copy(MIMO_O[i_h, :, :], Phi_frag)
                         dPhiO_frag = T.alloc_fragment([chunk_size, R, P], dtype)
@@ -522,6 +667,8 @@ def mamba_mimo_bwd_fwd(
 
             if reduceO:
                 T.copy(dPhi_shared, DMIMO_O[i_b, i_h, i_ns, :, :])
+            if fuse_pregate_headwise_rms_norm:
+                T.copy(dOutNorm_shared, DOUT_NORM_WEIGHT[i_b, i_h, i_ns, :, :])
             if hasZ:
                 T.copy(dZeta_shared, DMIMO_Z[i_b, i_h, i_ns, :, :])
 
@@ -553,12 +700,14 @@ def mamba_mimo_bwd_bwd(
     hasZ,
     hasD,
     reduceO,
-    isVarlen: bool = False,
+    packed_dout=False,
+    isVarlen: bool = True,
     chunk_size: int = 16,
     rotary_dim_divisor: int = 4,
     dtype: str = 'float16',
     threads: int = 256,
     num_stages: int = 0,
+    states_dtype = torch.bfloat16,
 ) -> torch.Tensor:
     """
     TileLang kernel factory for the varlen Mamba3 bwd-bwd pass.
@@ -584,10 +733,14 @@ def mamba_mimo_bwd_bwd(
     max_nchunks = (S // chunk_size) + NS
     fused_chunk_size = chunk_size * R
 
-    if reduceO:
+    if packed_dout:
+        DOUT_shape = (B, H, S * R, P)
+    elif reduceO:
         DOUT_shape = (B, S, H, P)
     else:
         DOUT_shape = (B, S, R, H, P)
+
+    dtype_states = str(states_dtype).replace("torch.", "")
 
     @T.prim_func
     def mamba_mimo_bwd_bwd_kernel(
@@ -602,7 +755,7 @@ def mamba_mimo_bwd_bwd(
             DK: T.Tensor([B, S * R, H, N], dtype),  # type: ignore
             DV: T.Tensor([B, S, H, P], dtype),  # type: ignore
             DMIMO_V: T.Tensor([B, H, NS, R, P], T.float32),  # type: ignore
-            STATES: T.Tensor([B, H, max_nchunks, N, P], dtype),  # type: ignore
+            STATES: T.Tensor([B, H, max_nchunks, N, P], dtype_states),  # type: ignore
             DQ: T.Tensor([B, S * R, H, N], dtype),  # type: ignore
             Z: T.Tensor([B, S, H, P], dtype),  # type: ignore
             MIMO_Z: T.Tensor([H, R, P], T.float32),  # type: ignore
@@ -629,7 +782,9 @@ def mamba_mimo_bwd_bwd(
         chunk order.
 
         Inputs:
-            - DOUT: upstream gradient.
+            - DOUT: upstream gradient. Shape is ``[B,S,H,P]`` when reduceO,
+              ``[B,S,R,H,P]`` when not reduceO, or packed ``[B,H,S*R,P]``
+              when packed_dout consumes DOUT_PRE_RMS from bwd-fwd.
             - Q, K, V: packed activations.
             - Q_BIAS, K_BIAS, MIMO_V, MIMO_O, MIMO_Z: projection params.
             - Z, D: optional gating / skip-connection tensors.
@@ -724,7 +879,7 @@ def mamba_mimo_bwd_bwd(
             seq_end = T.alloc_var(T.int32)
             full_nchunks = T.alloc_var(T.int32)
             tail_len = T.alloc_var(T.int32)
-            if isVarlen:
+            if NS > 1:
                 start_seq_ind = CU_SEQLENS[i_ns]
                 start_chunk_ind = (start_seq_ind // chunk_size) + i_ns
                 seq_len = CU_SEQLENS[i_ns + 1] - CU_SEQLENS[i_ns]
@@ -815,7 +970,12 @@ def mamba_mimo_bwd_bwd(
                         dPhiO_frag[cs, r, p] = dout_shared[cs, p] * Phi_frag[r, p]
                 else:
                     for cs, r, p in T.Parallel(chunk_size, R, P):
-                        dPhiO_frag[cs, r, p] = DOUT[i_b, chunk_start + cs, r, i_h, p]
+                        if packed_dout:
+                            dPhiO_frag[cs, r, p] = DOUT[
+                                i_b, i_h, fused_chunk_start + cs * R + r, p
+                            ]
+                        else:
+                            dPhiO_frag[cs, r, p] = DOUT[i_b, chunk_start + cs, r, i_h, p]
                     if eff_tail < chunk_size:
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             dPhiO_frag[cs, r, p] = T.if_then_else(cs < eff_tail, dPhiO_frag[cs, r, p], 0.0)
@@ -1066,9 +1226,11 @@ def mamba_mimo_bwd_bwd(
                 T.copy(dk_nodiag_frag, dk_shared)
 
                 # --- State-passing ddA + interchunk dQ ---
-                T.copy(STATES[i_b, i_h, global_chunk_idx, :, :], states_shared)
                 states_frag = T.alloc_fragment([N, P], T.float32)
-                T.copy(states_shared, states_frag)
+                # Match dense bwd_bwd: load cached state through fp32 before
+                # staging into the shared buffer used by GEMM.
+                T.copy(STATES[i_b, i_h, global_chunk_idx, :, :], states_frag)
+                T.copy(states_frag, states_shared)
                 ddA_state_passing = T.alloc_fragment([1], T.float32)
                 ddA_state_passing_prereduce_frag = T.alloc_fragment([N, P], T.float32)
                 da_cs_sum = T.alloc_var(T.float32)
@@ -1249,6 +1411,10 @@ def mamba_mimo_bwd_combined_varlen(
         bf_num_stages=0,
         bb_threads=256,
         bb_num_stages=0,
+        states_dtype=None,
+        fuse_pregate_headwise_rms_norm=False,
+        outproj_norm_weight=None,
+        outproj_norm_eps=1e-5,
         ):
     """
     Varlen combined backward pass (bwd-fwd + bwd-bwd).
@@ -1283,12 +1449,19 @@ def mamba_mimo_bwd_combined_varlen(
         bf_num_stages:    Pipeline stages for the bwd-fwd kernel.
         bb_threads:       Threads for the bwd-bwd kernel.
         bb_num_stages:    Pipeline stages for the bwd-bwd kernel.
+        states_dtype:     Optional dtype for cached recurrent states.
+        fuse_pregate_headwise_rms_norm:
+                          If True, bwd-fwd also backpropagates through
+                          RMSNorm(raw_y) * silu(z) and writes DOUT_PRE_RMS.
+        outproj_norm_weight:
+                          RMSNorm weight, shape ``[H, P]`` or flattened.
+        outproj_norm_eps: RMSNorm epsilon.
 
     Returns:
         Tuple of gradients:
             (dq, dk, dv, ddA, ddt, dtrap,
              dq_bias, dk_bias, dmimo_v, dmimo_z, dmimo_o,
-             dangles, dD, dz)
+             dangles, dD, dz, dout_norm_weight)
     """
     if cu_seqlens is None:
         return mamba_mimo_bwd_combined(
@@ -1296,6 +1469,10 @@ def mamba_mimo_bwd_combined_varlen(
             z, mimo_z, angles, dA_cs, dA_cs_rev, dt, trap, D,
             segsum, chunk_size, rotary_dim_divisor, dtype,
             bf_threads, bf_num_stages, bb_threads, bb_num_stages,
+            states_dtype=states_dtype if states_dtype is not None else v.dtype,
+            fuse_pregate_headwise_rms_norm=fuse_pregate_headwise_rms_norm,
+            outproj_norm_weight=outproj_norm_weight,
+            outproj_norm_eps=outproj_norm_eps,
         )
 
     B, S, R, G, N = q.shape
@@ -1303,6 +1480,34 @@ def mamba_mimo_bwd_combined_varlen(
     NS = cu_seqlens.shape[0] - 1
     reduceO = mimo_o is not None
     max_nchunks = (S // chunk_size) + NS
+    states_dtype = v.dtype if states_dtype is None else states_dtype
+
+    if fuse_pregate_headwise_rms_norm:
+        if not reduceO:
+            raise ValueError("fuse_pregate_headwise_rms_norm=True requires mimo_o.")
+        if z is None or mimo_z is None:
+            raise ValueError("fuse_pregate_headwise_rms_norm=True requires z and mimo_z.")
+
+    if not fuse_pregate_headwise_rms_norm:
+        outproj_norm_weight_arg = None
+    elif outproj_norm_weight is None:
+        outproj_norm_weight_arg = torch.ones((H, P), dtype=torch.float32, device=q.device)
+    else:
+        if outproj_norm_weight.ndim == 1:
+            if outproj_norm_weight.numel() != H * P:
+                raise ValueError(
+                    f"Expected flattened outproj_norm_weight to have {H * P} elements, "
+                    f"got {outproj_norm_weight.numel()}."
+                )
+            outproj_norm_weight_arg = outproj_norm_weight.reshape(H, P).contiguous()
+        elif outproj_norm_weight.shape == (H, P):
+            outproj_norm_weight_arg = outproj_norm_weight.contiguous()
+        else:
+            raise ValueError(
+                f"Expected outproj_norm_weight to have shape ({H}, {P}) or ({H * P},), "
+                f"got {tuple(outproj_norm_weight.shape)}."
+            )
+        outproj_norm_weight_arg = outproj_norm_weight_arg.to(device=q.device, dtype=torch.float32)
 
     if isinstance(dtype, torch.dtype):
         dtype_str = str(dtype).replace("torch.", "")
@@ -1310,7 +1515,17 @@ def mamba_mimo_bwd_combined_varlen(
         dtype_str = dtype
 
     dmimo_o = torch.empty([B, H, NS, R, P], dtype=mimo_v.dtype, device=mimo_v.device) if reduceO else None
-    states = torch.empty([B, H, max_nchunks, N, P], dtype=v.dtype, device=v.device)
+    dout_norm_weight = (
+        torch.empty([B, H, NS, R, P], dtype=torch.float32, device=v.device)
+        if fuse_pregate_headwise_rms_norm else None
+    )
+    dout_norm_weight_arg = dout_norm_weight
+    dout_pre_rms = (
+        torch.empty([B, H, S * R, P], dtype=dout.dtype, device=dout.device)
+        if fuse_pregate_headwise_rms_norm
+        else None
+    )
+    states = torch.empty([B, H, max_nchunks, N, P], dtype=states_dtype, device=v.device)
 
     if z is not None:
         dz_tilelang = torch.empty_like(v)
@@ -1324,18 +1539,22 @@ def mamba_mimo_bwd_combined_varlen(
         B, H, G,
         N, P, R,
         z is not None, D is not None, reduceO,
+        fuse_pregate_headwise_rms_norm,
         isVarlen=cu_seqlens is not None,
         chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor, dtype=dtype_str,
-        threads=bf_threads, num_stages=bf_num_stages)
-
+        outproj_norm_eps=outproj_norm_eps,
+        threads=bf_threads, num_stages=bf_num_stages,
+        states_dtype=states_dtype)
+    ns_anchor = cu_seqlens[:-1]
     bwd_fwd_kernel(
         dout, q, k, v, q_bias, k_bias, mimo_v, mimo_o,
-        dmimo_o, states,
+        outproj_norm_weight_arg,
+        dmimo_o, dout_norm_weight_arg, dout_pre_rms, states,
         z, mimo_z, dz_tilelang, dmimo_z,
         angles, dA_cs, dA_cs_rev, dt, trap, D,
-        qk_dot, segsum, cu_seqlens,
+        qk_dot, segsum, ns_anchor, cu_seqlens,
     )
-    if reduceO:
+    if reduceO and not fuse_pregate_headwise_rms_norm:
         dmimo_o = dmimo_o.sum(dim=(0, 2))
 
     dq_tilelang = torch.empty([B, S, R, H, N], dtype=q.dtype, device=q.device)
@@ -1351,16 +1570,21 @@ def mamba_mimo_bwd_combined_varlen(
     ddA_cs_rev = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
     ddA_cs = torch.zeros([B, H, S], dtype=torch.float32, device=dt.device)
 
+    bwd_bwd_dout = dout_pre_rms if fuse_pregate_headwise_rms_norm else dout
+    bwd_bwd_reduceO = reduceO and not fuse_pregate_headwise_rms_norm
+    bwd_bwd_hasZ = (z is not None) and not fuse_pregate_headwise_rms_norm
+    bwd_bwd_packed_dout = fuse_pregate_headwise_rms_norm
     bwd_bwd_kernel = mamba_mimo_bwd_bwd(
         B, H, G,
         N, P, R,
-        z is not None, D is not None, reduceO,
+        bwd_bwd_hasZ, D is not None, bwd_bwd_reduceO,
+        bwd_bwd_packed_dout,
         isVarlen=cu_seqlens is not None,
         chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor, dtype=dtype_str,
-        threads=bb_threads, num_stages=bb_num_stages)
-
+        threads=bb_threads, num_stages=bb_num_stages,
+        states_dtype=states_dtype)
     bwd_bwd_kernel(
-        dout, q, k, v, q_bias, k_bias, mimo_v, mimo_o,
+        bwd_bwd_dout, q, k, v, q_bias, k_bias, mimo_v, mimo_o,
         dk_tilelang.view(B, S * R, H, N),
         dv_tilelang, dmimo_v, states,
         dq_tilelang.view(B, S * R, H, N),
@@ -1370,22 +1594,17 @@ def mamba_mimo_bwd_combined_varlen(
         segsum, cu_seqlens,
     )
 
-    if G == 1:
-        dq_bias_tilelang = dq_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
-        dk_bias_tilelang = dk_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
-        dq_tilelang = dq_tilelang.sum(dim=3, keepdim=True)
-        dk_tilelang = dk_tilelang.sum(dim=3, keepdim=True)
-        dmimo_v = dmimo_v.sum(dim=(0, 2))
-        dmimo_z = dmimo_z.sum(dim=(0, 2)) if dmimo_z is not None else None
-        dD = dD.sum(dim=(0, 2)) if dD is not None else None
-    elif G == H:
-        dq_bias_tilelang = dq_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
-        dk_bias_tilelang = dk_tilelang.sum(dim=(0, 1)).permute((1, 0, 2))
-        dmimo_v = dmimo_v.sum(dim=(0, 2))
-        dmimo_z = dmimo_z.sum(dim=(0, 2)) if dmimo_z is not None else None
-        dD = dD.sum(dim=(0, 2)) if dD is not None else None
+    dq_tilelang, dk_tilelang, dq_bias_tilelang, dk_bias_tilelang = (
+        reduce_grouped_qk_grads_and_bias_triton(dq_tilelang, dk_tilelang, G)
+    )
+    dmimo_v = dmimo_v.sum(dim=(0, 2))
+    if fuse_pregate_headwise_rms_norm:
+        dmimo_o = dmimo_o.sum(dim=(0, 2))
+        dmimo_z = dmimo_z.sum(dim=(0, 2))
+        dout_norm_weight = dout_norm_weight.sum(dim=(0, 2, 3))
     else:
-        raise ValueError(f"G value of {G} is not currently supported!")
+        dmimo_z = dmimo_z.sum(dim=(0, 2)) if dmimo_z is not None else None
+    dD = dD.sum(dim=(0, 2)) if dD is not None else None
 
     ddt, dtrap = bwd_dtrap_ddt_triton_varlen(trap, dt, dfactor, dgamma_diag, chunk_size, cu_seqlens)
 
@@ -1396,4 +1615,4 @@ def mamba_mimo_bwd_combined_varlen(
     return (dq_tilelang, dk_tilelang, dv_tilelang, 
             ddA, ddt, dtrap, dq_bias_tilelang, dk_bias_tilelang,
             dmimo_v, dmimo_z, dmimo_o, dangles, 
-            dD, dz_tilelang)
+            dD, dz_tilelang, dout_norm_weight)

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd.py
@@ -46,10 +46,12 @@ def mamba_mimo_fwd(
     hasZ,
     hasD,
     reduceO,
+    fuse_pregate_headwise_rms_norm=False,
     return_final_state=False,
     chunk_size: int = 16,
     rotary_dim_divisor = 4,
     dtype: str = 'bfloat16',
+    outproj_norm_eps: float = 1e-5,
     threads: int = 128,
     num_stages: int = 0,
 ) -> torch.Tensor:
@@ -76,6 +78,7 @@ def mamba_mimo_fwd(
             K_BIAS: T.Tensor([H, R, N], T.float32),  # type: ignore
             MIMO_V: T.Tensor([H, R, P], T.float32), # type: ignore
             MIMO_O: T.Tensor([H, R, P], T.float32), # type: ignore
+            OUT_NORM_WEIGHT: T.Tensor([H, P], T.float32), # type: ignore
             Z: T.Tensor([B, S, H, P], dtype),  # type: ignore
             D: T.Tensor([H], T.float32),  # type: ignore
             MIMO_Z: T.Tensor([H, R, P], T.float32), # type: ignore
@@ -95,15 +98,34 @@ def mamba_mimo_fwd(
             Computes interchunk and intrachunk contributions with optional D and Z paths,
             then writes output activations.
 
+            The kernel supports three output modes:
+            - ``reduceO=False``: write the full per-rank MIMO output
+              ``raw_y`` with shape ``[B, S, R, H, P]``.
+            - ``reduceO=True`` and ``fuse_pregate_headwise_rms_norm=False``:
+              apply the MIMO output projection with ``MIMO_O`` inside the
+              kernel and write ``[B, S, H, P]``.
+            - ``reduceO=True`` and ``fuse_pregate_headwise_rms_norm=True``:
+              form each per-rank ``raw_y`` and projected gate ``z_r`` in
+              shared/register memory, apply
+              ``RMSNorm(raw_y) * silu(z_r)`` with the RMS reduction over the
+              headdim ``P``, then apply ``MIMO_O`` and write ``[B, S, H, P]``.
+              This fused path consumes ``Z``, ``MIMO_Z``, ``MIMO_O``, and
+              ``OUT_NORM_WEIGHT`` and avoids materializing full
+              ``[B, S, R, H, P]`` MIMO outputs in global memory.  The public
+              wrapper passes a unit norm weight when no explicit
+              ``outproj_norm_weight`` is provided.
+
         Inputs:
             - Activations: Q, K, V.
-            - Projection parameters/biases: MIMO_V (Psi), MIMO_O (Phi), optional MIMO_Z (Zeta), ANGLES,
-              and Q_BIAS/K_BIAS.
-            - Optional modifiers: Z, and D.
+            - Projection parameters/biases: MIMO_V (Psi), MIMO_O (Phi),
+              optional MIMO_Z (Zeta), optional OUT_NORM_WEIGHT, ANGLES, and
+              Q_BIAS/K_BIAS.
+            - Optional modifiers: Z and D.
             - Discretization tensors: DA_CS, DA_CS_REV, DT, TRAP, and SEGSUM.
 
         Outputs:
-            - O: fused forward output activations.
+            - O: forward output activations. Shape is ``[B, S, H, P]`` when
+              ``reduceO`` is true, otherwise ``[B, S, R, H, P]``.
             - FINAL_STATE: final recurrent states (if return_final_state is True).
             - FINAL_K: final K tensor (if return_state is True, for use in decode)
 
@@ -337,7 +359,27 @@ def mamba_mimo_fwd(
 
                 # --- Optional Z Gating + Down-Projection ---
                 if reduceO:
-                    if hasZ:
+                    if fuse_pregate_headwise_rms_norm:
+                        o_sq_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            o_sq_frag[cs, r, p] = (
+                                o_mimo_accum_frag[cs * R + r, p]
+                                * o_mimo_accum_frag[cs * R + r, p]
+                            )
+                        o_rstd_frag = T.alloc_fragment([chunk_size, R], T.float32)
+                        T.reduce_sum(o_sq_frag, o_rstd_frag, dim=-1, clear=True)
+                        for cs, r in T.Parallel(chunk_size, R):
+                            o_rstd_frag[cs, r] = 1.0 / T.sqrt(
+                                o_rstd_frag[cs, r] / P + outproj_norm_eps
+                            )
+                        z_frag = T.alloc_fragment([chunk_size, P], dtype)
+                        T.copy(Z[i_b, chunk_start:chunk_start+chunk_size, i_h, :], z_frag)
+                        z_expanded_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            # Apply SiLU to z_expanded_frag[cs, r, p]:
+                            o_gated = z_frag[cs, p] * MIMO_Z[i_h, r, p] * 0.5
+                            z_expanded_frag[cs, r, p] = o_gated * T.tanh(o_gated) + o_gated
+                    elif hasZ:
                         z_frag = T.alloc_fragment([chunk_size, P], dtype)
                         T.copy(Z[i_b, chunk_start:chunk_start+chunk_size, i_h, :], z_frag)
                         z_expanded_frag = T.alloc_fragment([chunk_size, R, P], dtype)
@@ -347,7 +389,15 @@ def mamba_mimo_fwd(
                             z_expanded_frag[cs, r, p] = o_gated * T.tanh(o_gated) + o_gated
 
                     lqk_PsiV_reshaped_frag = T.view(o_mimo_accum_frag, shape=[chunk_size, R, P])
-                    if hasZ:
+                    if fuse_pregate_headwise_rms_norm:
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            lqk_PsiV_reshaped_frag[cs, r, p] *= (
+                                o_rstd_frag[cs, r]
+                                * OUT_NORM_WEIGHT[i_h, p]
+                                * phi_frag_intrachunk[r, p]
+                                * z_expanded_frag[cs, r, p]
+                            )
+                    elif hasZ:
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             lqk_PsiV_reshaped_frag[cs, r, p] *= phi_frag_intrachunk[r, p] * z_expanded_frag[cs, r, p]
                     else:
@@ -427,6 +477,9 @@ def mamba_mimo_forward(q, k, v,
                        segsum,
                        chunk_size, rotary_dim_divisor, dtype, 
                        return_state=False,
+                       fuse_pregate_headwise_rms_norm=False,
+                       outproj_norm_weight=None,
+                       outproj_norm_eps=1e-5,
                        threads=128, 
                        num_stages=0):
     B, S, R, G, N = q.shape
@@ -436,6 +489,11 @@ def mamba_mimo_forward(q, k, v,
     else:
         tl_dtype = dtype
     reduceO = mimo_o is not None
+    if fuse_pregate_headwise_rms_norm:
+        if not reduceO:
+            raise ValueError("fuse_pregate_headwise_rms_norm=True requires mimo_o.")
+        if z is None or mimo_z is None:
+            raise ValueError("fuse_pregate_headwise_rms_norm=True requires z and mimo_z.")
     kernel = mamba_mimo_fwd(T.dynamic("B"),
                             T.dynamic("S"), 
                             T.dynamic("H"), 
@@ -444,10 +502,12 @@ def mamba_mimo_forward(q, k, v,
                             z is not None, 
                             D is not None, 
                             reduceO,
+                            fuse_pregate_headwise_rms_norm,
                             return_final_state=return_state,
                             chunk_size=chunk_size, 
                             rotary_dim_divisor=rotary_dim_divisor, 
                             dtype=tl_dtype, 
+                            outproj_norm_eps=outproj_norm_eps,
                             threads=threads, 
                             num_stages=num_stages)
     # print(kernel.get_kernel_source()) # NOTE: prints compiled CUDA code
@@ -455,11 +515,31 @@ def mamba_mimo_forward(q, k, v,
         o = torch.empty((B, S, H, P), device='cuda', dtype=dtype)
     else:
         o = torch.empty((B, S, R, H, P), device='cuda', dtype=dtype)
-    # Kernel always declares all tensor parameters; pass dummies for None args
-    mimo_o_arg = mimo_o if reduceO else torch.empty((H, R, P), device=q.device, dtype=torch.float32)
-    z_arg = z if z is not None else torch.empty((B, S, H, P), device=q.device, dtype=dtype)
-    D_arg = D if D is not None else torch.empty((H,), device=q.device, dtype=torch.float32)
-    mimo_z_arg = mimo_z if mimo_z is not None else torch.empty((H, R, P), device=q.device, dtype=torch.float32)
+    # TileLang accepts None for tensor arguments that are compile-time unused.
+    mimo_o_arg = mimo_o if reduceO else None
+    if not fuse_pregate_headwise_rms_norm:
+        outproj_norm_weight_arg = None
+    elif outproj_norm_weight is None:
+        outproj_norm_weight_arg = torch.ones((H, P), device=q.device, dtype=torch.float32)
+    else:
+        if outproj_norm_weight.ndim == 1:
+            if outproj_norm_weight.numel() != H * P:
+                raise ValueError(
+                    f"Expected flattened outproj_norm_weight to have {H * P} elements, "
+                    f"got {outproj_norm_weight.numel()}."
+                )
+            outproj_norm_weight_arg = outproj_norm_weight.reshape(H, P).contiguous()
+        elif outproj_norm_weight.shape == (H, P):
+            outproj_norm_weight_arg = outproj_norm_weight.contiguous()
+        else:
+            raise ValueError(
+                f"Expected outproj_norm_weight to have shape ({H}, {P}) or ({H * P},), "
+                f"got {tuple(outproj_norm_weight.shape)}."
+            )
+        outproj_norm_weight_arg = outproj_norm_weight_arg.to(device=q.device, dtype=torch.float32)
+    z_arg = z
+    D_arg = D
+    mimo_z_arg = mimo_z
 
     h = torch.empty((B, H, N, P), device='cuda', dtype=torch.float32) if return_state else None
     k_final = torch.empty((B, R, H, N), device='cuda', dtype=dtype) if return_state else None
@@ -469,6 +549,7 @@ def mamba_mimo_forward(q, k, v,
             v, o,
             q_bias, k_bias,
             mimo_v, mimo_o_arg,
+            outproj_norm_weight_arg,
             z_arg, D_arg, mimo_z_arg,
             angles,
             dA_cs,

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
@@ -66,11 +66,13 @@ def mamba_mimo_fwd(
     hasZ,
     hasD,
     reduceO,
+    fuse_pregate_headwise_rms_norm=False,
     isVarlen: bool = True,
     return_final_state=False,
     chunk_size: int = 16,
     rotary_dim_divisor = 4,
     dtype: str = 'bfloat16',
+    outproj_norm_eps: float = 1e-5,
     threads: int = 128,
     num_stages: int = 0,
 ) -> torch.Tensor:
@@ -87,6 +89,17 @@ def mamba_mimo_fwd(
     * SEGSUM shape becomes ``[B, H, max_nchunks, C, C]``.
     * FINAL_STATE shape is ``(NS, H, N, P)`` (vs. ``(B, H, N, P)``).
     * FINAL_K shape is ``(NS, R, H, N)`` (vs. ``(B, R, H, N)``).
+
+    Output modes match the dense kernel:
+
+    * ``reduceO=False`` writes the full per-rank MIMO output
+      ``raw_y`` with shape ``[B, S, R, H, P]``.
+    * ``reduceO=True`` applies the MIMO output projection inside the kernel.
+    * ``reduceO=True`` with ``fuse_pregate_headwise_rms_norm=True`` applies
+      ``RMSNorm(raw_y) * silu(z_r)`` per valid token/rank/head before the
+      MIMO output projection.  The RMS reduction is over headdim ``P``, not
+      sequence lanes, so chunk-tail padding used for varlen execution does not
+      enter the RMS mean.
 
     When NS == 1 (or cu_seqlens is None) the kernel degenerates to the
     non-varlen behaviour.
@@ -125,6 +138,7 @@ def mamba_mimo_fwd(
             K_BIAS: T.Tensor([H, R, N], T.float32),  # type: ignore
             MIMO_V: T.Tensor([H, R, P], T.float32), # type: ignore
             MIMO_O: T.Tensor([H, R, P], T.float32), # type: ignore
+            OUT_NORM_WEIGHT: T.Tensor([H, P], T.float32), # type: ignore
             Z: T.Tensor([B, S, H, P], dtype),  # type: ignore
             D: T.Tensor([H], T.float32),  # type: ignore
             MIMO_Z: T.Tensor([H, R, P], T.float32), # type: ignore
@@ -154,17 +168,31 @@ def mamba_mimo_fwd(
               ``start_chunk_ind + i`` where
               ``start_chunk_ind = (CU_SEQLENS[i_ns] // chunk_size) + i_ns``.
 
+            Output handling is the same as the dense MIMO kernel:
+            - ``reduceO=False`` writes per-rank ``raw_y`` to
+              ``[B, S, R, H, P]``.
+            - ``reduceO=True`` applies ``MIMO_O`` in-kernel and writes
+              ``[B, S, H, P]``.
+            - ``reduceO=True`` and ``fuse_pregate_headwise_rms_norm=True``
+              applies ``RMSNorm(raw_y) * silu(z_r)`` in-kernel before
+              ``MIMO_O``.  The RMS mean is over ``P`` for each valid token,
+              rank, and head; varlen tail padding is only used to execute
+              full chunks and does not contribute sequence elements to the
+              RMS reduction.
+
         Inputs:
             - Activations: Q, K, V.
             - Projection parameters/biases: MIMO_V (Psi), MIMO_O (Phi),
-              optional MIMO_Z (Zeta), ANGLES, and Q_BIAS/K_BIAS.
+              optional MIMO_Z (Zeta), optional OUT_NORM_WEIGHT, ANGLES, and
+              Q_BIAS/K_BIAS.
             - Optional modifiers: Z and D.
             - Discretization tensors: DA_CS, DA_CS_REV, DT, TRAP, and SEGSUM.
             - CU_SEQLENS: int32 prefix-sum of per-sequence lengths, shape
               ``[NS+1]``.
 
         Outputs:
-            - O: fused forward output activations.
+            - O: forward output activations. Shape is ``[B, S, H, P]`` when
+              ``reduceO`` is true, otherwise ``[B, S, R, H, P]``.
             - FINAL_STATE: final recurrent states per sequence (shape
               ``[NS, H, N, P]`` when NS > 1; written only when
               return_final_state is True).
@@ -178,7 +206,7 @@ def mamba_mimo_fwd(
             - Trap: convex-combination modulator used in
               exponential-trapezoidal discretization.
         """
-        
+
         with T.Kernel(H, NS, B, threads=threads) as (i_h, i_ns, i_b):
             # --- Kernel Setup ---
             # GQA support: map V head to Q/K head
@@ -272,8 +300,8 @@ def mamba_mimo_fwd(
                     T.copy(DT[i_b, i_h, chunk_start+1: chunk_start+chunk_size+1], dt_shifted_frag)
                 shifted_gamma_frag = T.alloc_fragment([chunk_size], dtype)
                 for cs in T.Parallel(chunk_size):
-                    shifted_gamma_frag[cs] = T.if_then_else(chunk_start + cs < (seq_end - 1), 
-                                                            dt_shifted_frag[cs] * T.sigmoid(-trap_shifted_frag[cs]), 
+                    shifted_gamma_frag[cs] = T.if_then_else(chunk_start + cs < (seq_end - 1),
+                                                            dt_shifted_frag[cs] * T.sigmoid(-trap_shifted_frag[cs]),
                                                             0.0)
                 shifted_gamma_shared = T.alloc_shared([chunk_size], dtype)
                 T.copy(shifted_gamma_frag, shifted_gamma_shared)
@@ -361,7 +389,7 @@ def mamba_mimo_fwd(
                 for cs, r, n in T.Parallel(chunk_size, R, N//rotary_dim_divisor):
                     k_first_half_frag[cs, r, n] = k_shared[cs*R + r, n]
                     k_second_half_frag[cs, r, n] = k_shared[cs*R + r, N//2 + n]
-                
+
                 for cs, r, n in T.Parallel(chunk_size, R, N//rotary_dim_divisor):
                     k_shared[cs*R + r, n] = T.cos(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] - T.sin(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
                     k_shared[cs*R + r, N//2 + n] = T.sin(angles_frag[cs, n]) * k_first_half_frag[cs, r, n] + T.cos(angles_frag[cs, n]) * k_second_half_frag[cs, r, n]
@@ -393,7 +421,7 @@ def mamba_mimo_fwd(
                 for csr_i, csr_j in T.Parallel(fused_chunk_size, fused_chunk_size):
                     qk_intrachunk_masked_frag[csr_i, csr_j] = T.if_then_else(
                                                 csr_i//R > csr_j//R, # NOTE: we do indeed want to exclude the diagonal
-                                                qk_intrachunk_frag[csr_i, csr_j] 
+                                                qk_intrachunk_frag[csr_i, csr_j]
                                                 * T.exp(SEGSUM[i_b, i_h, start_chunk_ind+i, csr_i//R, csr_j//R]),
                                                 0.0
                                             )
@@ -419,7 +447,7 @@ def mamba_mimo_fwd(
                 T.clear(qkdot_psiv_frag)
                 for cs, r_out, p in T.Parallel(chunk_size, R, P):
                     for r_in in T.serial(R):
-                        qkdot_psiv_frag[cs, r_out, p] += qk_dot_full_shared[cs * R + r_out, cs * R + r_in] * PsiV_shared[cs * R + r_in, p]                    
+                        qkdot_psiv_frag[cs, r_out, p] += qk_dot_full_shared[cs * R + r_out, cs * R + r_in] * PsiV_shared[cs * R + r_in, p]
                     qkdot_psiv_frag[cs, r_out, p] *= gamma_frag[cs] # Apply shifted gamma
 
                 if hasD:
@@ -436,7 +464,27 @@ def mamba_mimo_fwd(
 
                 # --- Optional Z Gating + Down-Projection ---
                 if reduceO:
-                    if hasZ:
+                    if fuse_pregate_headwise_rms_norm:
+                        o_sq_frag = T.alloc_fragment([chunk_size, R, P], T.float32)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            o_sq_frag[cs, r, p] = (
+                                o_mimo_accum_frag[cs * R + r, p]
+                                * o_mimo_accum_frag[cs * R + r, p]
+                            )
+                        o_rstd_frag = T.alloc_fragment([chunk_size, R], T.float32)
+                        T.reduce_sum(o_sq_frag, o_rstd_frag, dim=-1, clear=True)
+                        for cs, r in T.Parallel(chunk_size, R):
+                            o_rstd_frag[cs, r] = 1.0 / T.sqrt(
+                                o_rstd_frag[cs, r] / P + outproj_norm_eps
+                            )
+                        z_frag = T.alloc_fragment([chunk_size, P], dtype)
+                        T.copy(Z[i_b, chunk_start:chunk_start+chunk_size, i_h, :], z_frag)
+                        z_expanded_frag = T.alloc_fragment([chunk_size, R, P], dtype)
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            # Apply SiLU to z_expanded_frag[cs, r, p]:
+                            o_gated = z_frag[cs, p] * MIMO_Z[i_h, r, p] * 0.5
+                            z_expanded_frag[cs, r, p] = o_gated * T.tanh(o_gated) + o_gated
+                    elif hasZ:
                         z_frag = T.alloc_fragment([chunk_size, P], dtype)
                         T.copy(Z[i_b, chunk_start:chunk_start+chunk_size, i_h, :], z_frag)
                         z_expanded_frag = T.alloc_fragment([chunk_size, R, P], dtype)
@@ -446,7 +494,15 @@ def mamba_mimo_fwd(
                             z_expanded_frag[cs, r, p] = o_gated * T.tanh(o_gated) + o_gated
 
                     lqk_PsiV_reshaped_frag = T.view(o_mimo_accum_frag, shape=[chunk_size, R, P])
-                    if hasZ:
+                    if fuse_pregate_headwise_rms_norm:
+                        for cs, r, p in T.Parallel(chunk_size, R, P):
+                            lqk_PsiV_reshaped_frag[cs, r, p] *= (
+                                o_rstd_frag[cs, r]
+                                * OUT_NORM_WEIGHT[i_h, p]
+                                * phi_frag_intrachunk[r, p]
+                                * z_expanded_frag[cs, r, p]
+                            )
+                    elif hasZ:
                         for cs, r, p in T.Parallel(chunk_size, R, P):
                             lqk_PsiV_reshaped_frag[cs, r, p] *= phi_frag_intrachunk[r, p] * z_expanded_frag[cs, r, p]
                     else:
@@ -510,23 +566,23 @@ def mamba_mimo_fwd(
                         k_state_frag[csr, n] = T.if_then_else(csr < tail_len * R, k_state_frag[csr, n], 0.0)
                 else:
                     T.copy(DA_CS[i_b, i_h, chunk_start+chunk_size-1], da_cs_sum)
-                
+
                 for n, p in T.Parallel(N, P):
                     states_frag[n, p] *= T.exp(da_cs_sum)
                 T.gemm(k_state_frag, PsiV_shared, states_frag, transpose_A=True, clear_accum=False)
-            
+
             # --- Save Last State (if applicable) ---
             if return_final_state:
                 if isVarlen:
                     T.copy(states_frag, FINAL_STATE[i_ns, i_h, :, :])
                 else:
                     T.copy(states_frag, FINAL_STATE[i_b, i_h, :, :])
-                
+
 
     return mamba_mimo_fwd_kernel
 
 
-def mamba_mimo_forward_varlen(q, k, v, 
+def mamba_mimo_forward_varlen(q, k, v,
                        q_bias, k_bias,
                        mimo_v, mimo_o,
                        z, D,
@@ -540,6 +596,9 @@ def mamba_mimo_forward_varlen(q, k, v,
                        chunk_size, rotary_dim_divisor, dtype,
                        cu_seqlens=None,
                        return_state=False,
+                       fuse_pregate_headwise_rms_norm=False,
+                       outproj_norm_weight=None,
+                       outproj_norm_eps=1e-5,
                        threads=128,
                        num_stages=0):
     """
@@ -572,6 +631,16 @@ def mamba_mimo_forward_varlen(q, k, v,
         cu_seqlens:    Optional int32 tensor of shape ``[NS+1]`` with
                        per-sequence token offsets.  None → dense mode.
         return_state:  If True, also return the final recurrent state and K.
+        fuse_pregate_headwise_rms_norm: If True, fuse headwise
+                       ``RMSNorm(raw_y) * silu(z_r)`` with MIMO down
+                       projection in the forward kernel.  Requires ``mimo_o``,
+                       ``z``, and ``mimo_z``.  Uses ``outproj_norm_weight`` when
+                       supplied, otherwise a unit RMSNorm weight.  The RMS
+                       reduction is over ``P`` and is unaffected by varlen
+                       chunk-tail padding.
+        outproj_norm_weight: Optional RMSNorm weight, shaped ``[H, P]`` or
+                       flattened to ``[H * P]``.
+        outproj_norm_eps: Epsilon for the fused RMSNorm path.
         threads:       Number of GPU threads per thread-block.
         num_stages:    Software-pipeline stages (0 = auto).
 
@@ -600,28 +669,55 @@ def mamba_mimo_forward_varlen(q, k, v,
         NS = 1
 
     reduceO = mimo_o is not None
-    kernel = mamba_mimo_fwd(B, H, G, 
-                            N, P, R, 
-                            z is not None, 
-                            D is not None, 
-                            reduceO,
-                            isVarlen=cu_seqlens is not None,
-                            return_final_state=return_state,
-                            chunk_size=chunk_size, 
-                            rotary_dim_divisor=rotary_dim_divisor, 
-                            dtype=tl_dtype,
-                            threads=threads,
-                            num_stages=num_stages)
+    if fuse_pregate_headwise_rms_norm:
+        if not reduceO:
+            raise ValueError("fuse_pregate_headwise_rms_norm=True requires mimo_o.")
+        if z is None or mimo_z is None:
+            raise ValueError("fuse_pregate_headwise_rms_norm=True requires z and mimo_z.")
+    kernel = mamba_mimo_fwd(B, H, G,
+                                       N, P, R,
+                                       z is not None,
+                                       D is not None,
+                                       reduceO,
+                                       fuse_pregate_headwise_rms_norm,
+                                       isVarlen=cu_seqlens is not None,
+                                       return_final_state=return_state,
+                                       chunk_size=chunk_size,
+                                       rotary_dim_divisor=rotary_dim_divisor,
+                                       dtype=tl_dtype,
+                                       outproj_norm_eps=outproj_norm_eps,
+                                       threads=threads,
+                                       num_stages=num_stages)
     # print(kernel.get_kernel_source()) # NOTE: prints compiled CUDA code
     if reduceO:
         o = torch.empty((B, S, H, P), device='cuda', dtype=dtype)
     else:
         o = torch.empty((B, S, R, H, P), device='cuda', dtype=dtype)
-    # Kernel always declares all tensor parameters; pass dummies for None args
-    mimo_o_arg = mimo_o if reduceO else torch.empty((H, R, P), device=q.device, dtype=torch.float32)
-    z_arg = z if z is not None else torch.empty((B, S, H, P), device=q.device, dtype=dtype)
-    D_arg = D if D is not None else torch.empty((H,), device=q.device, dtype=torch.float32)
-    mimo_z_arg = mimo_z if mimo_z is not None else torch.empty((H, R, P), device=q.device, dtype=torch.float32)
+    # TileLang accepts None for tensor arguments that are compile-time unused.
+    mimo_o_arg = mimo_o if reduceO else None
+    if not fuse_pregate_headwise_rms_norm:
+        outproj_norm_weight_arg = None
+    elif outproj_norm_weight is None:
+        outproj_norm_weight_arg = torch.ones((H, P), device=q.device, dtype=torch.float32)
+    else:
+        if outproj_norm_weight.ndim == 1:
+            if outproj_norm_weight.numel() != H * P:
+                raise ValueError(
+                    f"Expected flattened outproj_norm_weight to have {H * P} elements, "
+                    f"got {outproj_norm_weight.numel()}."
+                )
+            outproj_norm_weight_arg = outproj_norm_weight.reshape(H, P).contiguous()
+        elif outproj_norm_weight.shape == (H, P):
+            outproj_norm_weight_arg = outproj_norm_weight.contiguous()
+        else:
+            raise ValueError(
+                f"Expected outproj_norm_weight to have shape ({H}, {P}) or ({H * P},), "
+                f"got {tuple(outproj_norm_weight.shape)}."
+            )
+        outproj_norm_weight_arg = outproj_norm_weight_arg.to(device=q.device, dtype=torch.float32)
+    z_arg = z
+    D_arg = D
+    mimo_z_arg = mimo_z
 
     if cu_seqlens is not None:
         h = torch.empty((NS, H, N, P), device='cuda', dtype=torch.float32) if return_state else None
@@ -635,6 +731,7 @@ def mamba_mimo_forward_varlen(q, k, v,
             v, o,
             q_bias, k_bias,
             mimo_v, mimo_o_arg,
+            outproj_norm_weight_arg,
             z_arg, D_arg, mimo_z_arg,
             angles,
             dA_cs,

--- a/mamba_ssm/ops/triton/mamba3/grouped_head_reduction.py
+++ b/mamba_ssm/ops/triton/mamba3/grouped_head_reduction.py
@@ -1,0 +1,229 @@
+"""Utilities for reducing per-head backward outputs to grouped Q/K heads."""
+
+from __future__ import annotations
+
+import torch
+import triton
+import triton.language as tl
+
+
+def reduce_grouped_qk_grads(qk_grads: torch.Tensor, num_qk_groups: int) -> torch.Tensor:
+    """Collapse per-head Q/K grads from ``H`` heads back to ``G`` grouped heads.
+
+    The TileLang backward kernels materialize Q/K gradients per value head with shape
+    ``[B, S, R, H, N]``. The forward kernels map each value head ``i_h`` to a Q/K
+    group via ``i_h // (H // G)``, so the corresponding grouped reduction must sum
+    contiguous blocks of ``H // G`` heads.
+    """
+    if qk_grads.ndim != 5:
+        raise ValueError(
+            f"Expected qk_grads to have shape [B, S, R, H, N], got {tuple(qk_grads.shape)}."
+        )
+
+    num_heads = qk_grads.shape[3]
+    if num_heads % num_qk_groups != 0:
+        raise ValueError(
+            f"Expected H ({num_heads}) to be divisible by G ({num_qk_groups})."
+        )
+
+    group_size = num_heads // num_qk_groups
+    return qk_grads.reshape(
+        *qk_grads.shape[:3],
+        num_qk_groups,
+        group_size,
+        qk_grads.shape[-1],
+    ).sum(dim=4)
+
+
+@triton.jit
+def _reduce_grouped_qk_grads_and_bias_partial_kernel(
+    dq_raw,
+    dk_raw,
+    dq_out,
+    dk_out,
+    dq_bias_partial,
+    dk_bias_partial,
+    TOTAL_ROWS: tl.constexpr,
+    R: tl.constexpr,
+    H: tl.constexpr,
+    G: tl.constexpr,
+    N: tl.constexpr,
+    GROUP_SIZE: tl.constexpr,
+    N_BLOCKS: tl.constexpr,
+    BLOCK_M: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+    STORE_GROUPED: tl.constexpr,
+):
+    pid_m = tl.program_id(0)
+    pid_r = tl.program_id(1)
+    pid_gn = tl.program_id(2)
+    pid_g = pid_gn // N_BLOCKS
+    pid_n = pid_gn - pid_g * N_BLOCKS
+
+    offs_m = pid_m * BLOCK_M + tl.arange(0, BLOCK_M)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    mask = (offs_m[:, None] < TOTAL_ROWS) & (offs_n[None, :] < N)
+
+    grouped_dq = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+    grouped_dk = tl.zeros((BLOCK_M, BLOCK_N), tl.float32)
+
+    for h_in_group in range(0, GROUP_SIZE):
+        h = pid_g * GROUP_SIZE + h_in_group
+        raw_offsets = ((offs_m[:, None] * R + pid_r) * H + h) * N + offs_n[None, :]
+        dq_vals = tl.load(dq_raw + raw_offsets, mask=mask, other=0.0).to(tl.float32)
+        dk_vals = tl.load(dk_raw + raw_offsets, mask=mask, other=0.0).to(tl.float32)
+
+        grouped_dq += dq_vals
+        grouped_dk += dk_vals
+
+        bias_offsets = ((pid_m * H + h) * R + pid_r) * N + offs_n
+        tl.store(
+            dq_bias_partial + bias_offsets,
+            tl.sum(dq_vals, axis=0),
+            mask=offs_n < N,
+        )
+        tl.store(
+            dk_bias_partial + bias_offsets,
+            tl.sum(dk_vals, axis=0),
+            mask=offs_n < N,
+        )
+
+    if STORE_GROUPED:
+        out_offsets = ((offs_m[:, None] * R + pid_r) * G + pid_g) * N + offs_n[None, :]
+        tl.store(dq_out + out_offsets, grouped_dq, mask=mask)
+        tl.store(dk_out + out_offsets, grouped_dk, mask=mask)
+
+
+@triton.jit
+def _finalize_qk_bias_kernel(
+    dq_bias_partial,
+    dk_bias_partial,
+    dq_bias,
+    dk_bias,
+    NUM_ROW_BLOCKS: tl.constexpr,
+    H: tl.constexpr,
+    R: tl.constexpr,
+    N: tl.constexpr,
+    BLOCK_B: tl.constexpr,
+    BLOCK_N: tl.constexpr,
+):
+    pid_h = tl.program_id(0)
+    pid_r = tl.program_id(1)
+    pid_n = tl.program_id(2)
+
+    offs_b = tl.arange(0, BLOCK_B)
+    offs_n = pid_n * BLOCK_N + tl.arange(0, BLOCK_N)
+    acc_dq = tl.zeros((BLOCK_N,), tl.float32)
+    acc_dk = tl.zeros((BLOCK_N,), tl.float32)
+
+    for block_start in range(0, NUM_ROW_BLOCKS, BLOCK_B):
+        block_ids = block_start + offs_b
+        offsets = ((block_ids[:, None] * H + pid_h) * R + pid_r) * N + offs_n[None, :]
+        mask = (block_ids[:, None] < NUM_ROW_BLOCKS) & (offs_n[None, :] < N)
+        dq_vals = tl.load(dq_bias_partial + offsets, mask=mask, other=0.0)
+        dk_vals = tl.load(dk_bias_partial + offsets, mask=mask, other=0.0)
+        acc_dq += tl.sum(dq_vals, axis=0)
+        acc_dk += tl.sum(dk_vals, axis=0)
+
+    out_offsets = (pid_h * R + pid_r) * N + offs_n
+    tl.store(dq_bias + out_offsets, acc_dq, mask=offs_n < N)
+    tl.store(dk_bias + out_offsets, acc_dk, mask=offs_n < N)
+
+
+def _next_power_of_2(value: int) -> int:
+    return 1 << (value - 1).bit_length()
+
+
+def reduce_grouped_qk_grads_and_bias_triton(
+    dq_raw: torch.Tensor,
+    dk_raw: torch.Tensor,
+    num_qk_groups: int,
+    block_m: int = 64,
+    block_n: int | None = None,
+) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Reduce raw per-value-head Q/K grads and compute Q/K bias grads in one pass.
+
+    ``dq_raw`` and ``dk_raw`` are TileLang outputs shaped ``[B, S, R, H, N]``.
+    This returns grouped Q/K grads shaped ``[B, S, R, G, N]`` and bias grads
+    shaped ``[H, R, N]`` while avoiding separate full-tensor reads for the bias
+    and grouped-head reductions.
+    """
+    if dq_raw.shape != dk_raw.shape:
+        raise ValueError(
+            f"Expected dq_raw and dk_raw to have the same shape, got "
+            f"{tuple(dq_raw.shape)} and {tuple(dk_raw.shape)}."
+        )
+    if dq_raw.ndim != 5:
+        raise ValueError(
+            f"Expected raw Q/K grads to have shape [B, S, R, H, N], got {tuple(dq_raw.shape)}."
+        )
+    if not dq_raw.is_contiguous() or not dk_raw.is_contiguous():
+        raise ValueError("Expected raw Q/K grads to be contiguous.")
+
+    B, S, R, H, N = dq_raw.shape
+    if H % num_qk_groups != 0:
+        raise ValueError(f"Expected H ({H}) to be divisible by G ({num_qk_groups}).")
+
+    total_rows = B * S
+    group_size = H // num_qk_groups
+    num_row_blocks = triton.cdiv(total_rows, block_m)
+    if block_n is None:
+        block_n = min(16, _next_power_of_2(N))
+    block_n = max(1, block_n)
+
+    dq_bias_partial = torch.empty(
+        (num_row_blocks, H, R, N), dtype=torch.float32, device=dq_raw.device
+    )
+    dk_bias_partial = torch.empty_like(dq_bias_partial)
+
+    if num_qk_groups == H:
+        dq_out = dq_raw
+        dk_out = dk_raw
+        store_grouped = False
+    else:
+        dq_out = torch.empty(
+            (B, S, R, num_qk_groups, N), dtype=dq_raw.dtype, device=dq_raw.device
+        )
+        dk_out = torch.empty_like(dq_out)
+        store_grouped = True
+
+    n_blocks = triton.cdiv(N, block_n)
+    grid = (num_row_blocks, R, num_qk_groups * n_blocks)
+    _reduce_grouped_qk_grads_and_bias_partial_kernel[grid](
+        dq_raw,
+        dk_raw,
+        dq_out,
+        dk_out,
+        dq_bias_partial,
+        dk_bias_partial,
+        total_rows,
+        R,
+        H,
+        num_qk_groups,
+        N,
+        group_size,
+        n_blocks,
+        block_m,
+        block_n,
+        store_grouped,
+        num_warps=8,
+    )
+
+    dq_bias = torch.empty((H, R, N), dtype=torch.float32, device=dq_raw.device)
+    dk_bias = torch.empty_like(dq_bias)
+    block_b = min(1024, _next_power_of_2(num_row_blocks))
+    _finalize_qk_bias_kernel[(H, R, n_blocks)](
+        dq_bias_partial,
+        dk_bias_partial,
+        dq_bias,
+        dk_bias,
+        num_row_blocks,
+        H,
+        R,
+        N,
+        block_b,
+        block_n,
+        num_warps=8,
+    )
+
+    return dq_out, dk_out, dq_bias, dk_bias

--- a/tests/ops/tilelang/test_mamba3_mimo.py
+++ b/tests/ops/tilelang/test_mamba3_mimo.py
@@ -19,6 +19,9 @@ pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k "fwd_varle
 pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k "bwd_varlen"
 pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k "smoke_forward_backward_varlen"
 
+# Tests with headwise pregate norm fused:
+pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k fused_norm
+
 # (Remove the -s flag for less verbose output).
 """
 
@@ -57,6 +60,11 @@ CASE_GRID = [
     pytest.param(128, 64, 8, 8, 256, id="N128_P64_R8_C8_BB256"),
     pytest.param(128, 64, 2, 32, 256, id="N128_P64_R2_C32_BB256"),
     pytest.param(128, 64, 1, 64, 256, id="N128_P64_R1_C64_BB256"),
+]
+
+FUSED_NORM_CASE_GRID = [
+    pytest.param(32, 64, 4, 16, 256, id="N32_P64_R4_C16_BB256"),
+    pytest.param(128, 64, 4, 16, 256, id="N128_P64_R4_C16_BB256"),
 ]
 
 
@@ -163,6 +171,7 @@ def build_inputs(
     dA_cs, dA_cs_rev, segsum = mods.utils.compute_dacs_segsum_triton(dA, chunk_size)
     trap = torch.rand((b, h, s), device="cuda", dtype=dtype)
     dout = torch.randn_like(v)
+    outproj_norm_weight = torch.randn((h, p), device="cuda", dtype=torch.float32)
 
     return {
         "q": q,
@@ -183,6 +192,7 @@ def build_inputs(
         "segsum": segsum,
         "trap": trap,
         "dout": dout,
+        "outproj_norm_weight": outproj_norm_weight,
         "chunk_size": chunk_size,
         "rotary_dim_divisor": rotary_dim_divisor,
     }
@@ -329,6 +339,9 @@ def mamba3_MIMO_step_ref(
     Z: Optional[torch.Tensor] = None,
     MIMO_Z: Optional[torch.Tensor] = None,
     Input_States: Optional[Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]] = None,
+    fused_norm: bool = False,
+    outproj_norm_weight: Optional[torch.Tensor] = None,
+    outproj_norm_eps: float = 1e-5,
 ) -> Tuple[torch.Tensor, Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]]:
     """Reference implementation of Mamba-3 MIMO in recurrent (step) mode.
 
@@ -436,7 +449,17 @@ def mamba3_MIMO_step_ref(
         if D is not None:
             out = out + D[None, :, None, None] * v
 
-        if z is not None:
+        if fused_norm:
+            if z is None:
+                raise ValueError("fused_norm=True requires Z and MIMO_Z.")
+            out = out.float()
+            out = out * torch.rsqrt(
+                out.square().mean(dim=-1, keepdim=True) + outproj_norm_eps
+            )
+            if outproj_norm_weight is not None:
+                out = out * outproj_norm_weight[None, :, None, :].float()
+            out = out * torch.nn.functional.silu(z.float())
+        elif z is not None:
             out = out * z * torch.sigmoid(z)
 
         out = torch.einsum("bhrp,hrp->bhp", out, MIMO_O)
@@ -484,6 +507,9 @@ def mamba3_MIMO_chunk_ref(
     rotate_pairwise: bool = False,
     contract_mimo_out: bool = True,
     cu_seqlens: Optional[Tensor] = None,
+    fused_norm: bool = False,
+    outproj_norm_weight: Optional[Tensor] = None,
+    outproj_norm_eps: float = 1e-5,
 ) -> tuple[Tensor, Optional[Tensor], Optional[Tensor]]:
     # Local copy of the reference program so tests remain valid even if module-level
     # debug/reference helpers are removed from shipped kernels.
@@ -511,9 +537,18 @@ def mamba3_MIMO_chunk_ref(
                 rotate_pairwise=rotate_pairwise,
                 contract_mimo_out=contract_mimo_out,
                 cu_seqlens=None,
+                fused_norm=fused_norm,
+                outproj_norm_weight=outproj_norm_weight,
+                outproj_norm_eps=outproj_norm_eps,
             )
             out_parts.append(out_i[:, :seq_len])
         return torch.cat(out_parts, dim=1), None, None
+
+    if fused_norm:
+        if not contract_mimo_out:
+            raise ValueError("fused_norm=True requires contract_mimo_out=True.")
+        if z is None or mimo_z is None:
+            raise ValueError("fused_norm=True requires z and mimo_z.")
 
     # --- Single-sequence path ---
     # Pad to the next multiple of chunk_size so the chunked rearranges are valid
@@ -543,6 +578,9 @@ def mamba3_MIMO_chunk_ref(
     if contract_mimo_out:
         assert mimo_o is not None
         mimo_o = mimo_o.to(dtype)
+    outproj_norm_weight = (
+        outproj_norm_weight.float() if outproj_norm_weight is not None else None
+    )
     if dA_cs is not None:
         dA_cs, dA_cs_rev = dA_cs.to(dtype), dA_cs_rev.to(dtype)
         dA_cs = rearrange(dA_cs, "b h (n c) -> b h n c", c=chunk_size)
@@ -674,6 +712,39 @@ def mamba3_MIMO_chunk_ref(
         vd = rearrange(vd, "b h (n c) r d -> b h n c r d", c=chunk_size)
         o += vd
 
+    if fused_norm:
+        raw_y = rearrange(o, "b h n c r p -> b (n c) r h p").float()
+        z_gate = torch.einsum(
+            "b l h p,h r p->b l r h p",
+            z.float(),
+            mimo_z.float(),
+        )
+        raw_y = raw_y * torch.rsqrt(
+            raw_y.square().mean(dim=-1, keepdim=True) + outproj_norm_eps
+        )
+        if outproj_norm_weight is not None:
+            if outproj_norm_weight.ndim == 1:
+                if outproj_norm_weight.numel() != nheads * raw_y.shape[-1]:
+                    raise ValueError(
+                        f"Expected flattened outproj_norm_weight to have "
+                        f"{nheads * raw_y.shape[-1]} elements, got "
+                        f"{outproj_norm_weight.numel()}."
+                    )
+                outproj_norm_weight = rearrange(
+                    outproj_norm_weight, "(h p) -> h p", h=nheads
+                )
+            elif outproj_norm_weight.shape != (nheads, raw_y.shape[-1]):
+                raise ValueError(
+                    f"Expected outproj_norm_weight to have shape "
+                    f"({nheads}, {raw_y.shape[-1]}) or "
+                    f"({nheads * raw_y.shape[-1]},), got "
+                    f"{tuple(outproj_norm_weight.shape)}."
+                )
+            raw_y = raw_y * outproj_norm_weight[None, None, None, :, :]
+        raw_y = raw_y * torch.nn.functional.silu(z_gate)
+        out = torch.einsum("b l r h p,h r p->b l h p", raw_y, mimo_o.float())
+        return out[:, :orig_seqlen], final_state, final_k
+
     if z is not None:
         z = torch.einsum("bthd,hrd->btrhd", z, mimo_z)
         z = rearrange(z, "b (n c) r h d -> b h n c r d", c=chunk_size)
@@ -695,6 +766,8 @@ def run_ref_backward_fp32(
     *,
     contract_mimo_out: bool = True,
     grad_output: Optional[Tensor] = None,
+    fused_norm: bool = False,
+    outproj_norm_eps: float = 1e-5,
 ) -> dict:
     ref_dtype = torch.float32
     q = inputs["q"].detach().to(ref_dtype).requires_grad_(True)
@@ -706,6 +779,11 @@ def run_ref_backward_fp32(
     mimo_o = (
         inputs["mimo_o"].detach().to(ref_dtype).requires_grad_(True)
         if contract_mimo_out
+        else None
+    )
+    outproj_norm_weight = (
+        inputs["outproj_norm_weight"].detach().to(ref_dtype).requires_grad_(True)
+        if fused_norm
         else None
     )
     z = (
@@ -749,6 +827,9 @@ def run_ref_backward_fp32(
         rotary_dim_divisor=inputs["rotary_dim_divisor"],
         dtype=ref_dtype,
         contract_mimo_out=contract_mimo_out,
+        fused_norm=fused_norm,
+        outproj_norm_weight=outproj_norm_weight,
+        outproj_norm_eps=outproj_norm_eps,
     )
 
     grad_input_items = [
@@ -771,6 +852,8 @@ def run_ref_backward_fp32(
         grad_input_items.append(("mimo_z", mimo_z))
     if contract_mimo_out:
         grad_input_items.append(("mimo_o", mimo_o))
+    if fused_norm:
+        grad_input_items.append(("outproj_norm_weight", outproj_norm_weight))
 
     if grad_output is None:
         grad_output = inputs["dout"]
@@ -799,6 +882,7 @@ def run_ref_backward_fp32(
         "dangles": grad_map["angles"],
         "dD": grad_map["dD"],
         "dz": grad_map.get("z"),
+        "dout_norm_weight": grad_map.get("outproj_norm_weight"),
     }
 
 
@@ -878,6 +962,92 @@ def test_mamba3_MIMO_chunk_ref_matches_step_ref() -> None:
         chunk_out,
         step_out,
         label="chunk_ref_vs_step_ref",
+        cfg=f"B={B}, S={S}, H={H}, P={P}, N={N}, R={R}, C={chunk_size}",
+        rel_tol=0.02,
+    )
+
+
+def test_mamba3_MIMO_chunk_ref_fused_norm_matches_step_ref() -> None:
+    # Lightweight deterministic ref-vs-ref consistency test for fused RMSNorm + gate.
+    B, S, H, G, P, N, R, chunk_size = 1, 128, 8, 1, 32, 64, 4, 16
+    dtype = torch.float32
+    device = "cpu"
+    torch.manual_seed(1)
+
+    q = torch.randn((B, S, R, G, N), device=device, dtype=dtype)
+    k = torch.randn((B, S, R, G, N), device=device, dtype=dtype)
+    v = torch.randn((B, S, H, P), device=device, dtype=dtype)
+
+    q_bias = torch.randn((H, R, N), device=device, dtype=dtype)
+    k_bias = torch.randn((H, R, N), device=device, dtype=dtype)
+    mimo_v = torch.rand((H, R, P), device=device, dtype=dtype)
+    mimo_o = torch.rand((H, R, P), device=device, dtype=dtype)
+    outproj_norm_weight = torch.randn((H, P), device=device, dtype=dtype)
+
+    z = torch.randn_like(v)
+    mimo_z = torch.rand_like(mimo_v)
+    D = torch.randn((H,), device=device, dtype=dtype)
+
+    angles = torch.rand((B, S, H, N // 2), device=device, dtype=dtype)
+    dt = F.softplus(-3.0 + torch.randn(B, H, S, device=device, dtype=torch.float32))
+    A_neg = -F.softplus(torch.randn((B, H, S), device=device, dtype=torch.float32))
+    A_neg = torch.clamp(A_neg, max=-1e-4)
+    ADT = A_neg * dt
+    trap = torch.rand(B, H, S, device=device, dtype=dtype) * 0.5
+
+    dA_cs = torch.cumsum(rearrange(ADT, "b h (n c) -> b h n c", c=chunk_size), dim=-1)
+    dA_cs_rev = dA_cs[..., -1:] - dA_cs
+    angles_prerotated = apply_angle_dt_reference(angles, dt.permute(0, 2, 1))
+
+    chunk_out, _, _ = mamba3_MIMO_chunk_ref(
+        q,
+        k,
+        v,
+        q_bias,
+        k_bias,
+        mimo_v,
+        mimo_o,
+        z,
+        mimo_z,
+        angles_prerotated,
+        dA_cs.view(B, H, S),
+        dA_cs_rev.view(B, H, S),
+        dt,
+        trap,
+        D,
+        chunk_size=chunk_size,
+        rotary_dim_divisor=2,
+        return_final_state=True,
+        dtype=dtype,
+        rotate_pairwise=True,
+        fused_norm=True,
+        outproj_norm_weight=outproj_norm_weight,
+    )
+
+    step_out, _ = mamba3_MIMO_step_ref(
+        q,
+        k,
+        v,
+        ADT,
+        dt,
+        trap,
+        q_bias,
+        k_bias,
+        angles,
+        mimo_v,
+        mimo_o,
+        D=D,
+        Z=z,
+        MIMO_Z=mimo_z,
+        fused_norm=True,
+        outproj_norm_weight=outproj_norm_weight,
+    )
+
+    assert chunk_out.shape == step_out.shape
+    assert_stable_rel(
+        chunk_out,
+        step_out,
+        label="chunk_ref_fused_norm_vs_step_ref",
         cfg=f"B={B}, S={S}, H={H}, P={P}, N={N}, R={R}, C={chunk_size}",
         rel_tol=0.02,
     )
@@ -1124,6 +1294,7 @@ def test_mamba_mimo_bwd_combined_relative_errors_lt_10pct(
         dangles,
         dD,
         dz,
+        dout_norm_weight,
     ) = mods.bwd.mamba_mimo_bwd_combined(
         inputs["dout"],
         inputs["q"],
@@ -1147,6 +1318,7 @@ def test_mamba_mimo_bwd_combined_relative_errors_lt_10pct(
         FIXED_DTYPE,
         bb_threads=bb_threads,
     )
+    assert dout_norm_weight is None
 
     comparisons = {
         "dq": (dq, ref_grads["dq"]),
@@ -1212,6 +1384,7 @@ def test_mamba_mimo_bwd_combined_prereduce_relative_errors_lt_10pct(
         dangles,
         dD,
         dz,
+        dout_norm_weight,
     ) = mods.bwd.mamba_mimo_bwd_combined(
         dout_prereduce,
         inputs["q"],
@@ -1238,6 +1411,7 @@ def test_mamba_mimo_bwd_combined_prereduce_relative_errors_lt_10pct(
     assert dmimo_o is None
     assert dmimo_z is None
     assert dz is None
+    assert dout_norm_weight is None
 
     comparisons = {
         "dq_prereduce": (dq, ref_grads["dq"]),
@@ -1258,6 +1432,163 @@ def test_mamba_mimo_bwd_combined_prereduce_relative_errors_lt_10pct(
             ours,
             ref,
             label=name,
+            cfg=f"N={n}, P={p}, R={r}, chunk={chunk_size}, bb_threads={bb_threads}",
+        )
+
+
+@pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", FUSED_NORM_CASE_GRID)
+def test_fused_norm_fwd_relative_error_lt_10pct(
+    mods: SimpleNamespace, n: int, p: int, r: int, chunk_size: int, bb_threads: int
+) -> None:
+    del bb_threads
+    inputs = build_inputs(
+        mods=mods,
+        n=n,
+        p=p,
+        r=r,
+        chunk_size=chunk_size,
+        seed=7901 + n + p + r + chunk_size,
+    )
+
+    out_tilelang, _, _ = mods.fwd.mamba_mimo_forward(
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["q_bias"],
+        inputs["k_bias"],
+        inputs["mimo_v"],
+        inputs["mimo_o"],
+        inputs["z"],
+        inputs["D"],
+        inputs["mimo_z"],
+        inputs["angles"],
+        inputs["dA_cs"],
+        inputs["dA_cs_rev"],
+        inputs["dt"],
+        inputs["trap"],
+        inputs["segsum"],
+        chunk_size=chunk_size,
+        rotary_dim_divisor=inputs["rotary_dim_divisor"],
+        dtype=FIXED_DTYPE,
+        fuse_pregate_headwise_rms_norm=True,
+        outproj_norm_weight=inputs["outproj_norm_weight"],
+    )
+
+    out_ref_fp32, _, _ = mamba3_MIMO_chunk_ref(
+        inputs["q"].clone(),
+        inputs["k"].clone(),
+        inputs["v"].clone(),
+        inputs["q_bias"].clone(),
+        inputs["k_bias"].clone(),
+        inputs["mimo_v"].clone(),
+        inputs["mimo_o"].clone(),
+        inputs["z"].clone(),
+        inputs["mimo_z"].clone(),
+        inputs["angles"].clone(),
+        inputs["dA_cs"].clone(),
+        inputs["dA_cs_rev"].clone(),
+        inputs["dt"].clone(),
+        inputs["trap"].clone(),
+        inputs["D"].clone(),
+        chunk_size=chunk_size,
+        rotary_dim_divisor=inputs["rotary_dim_divisor"],
+        dtype=torch.float32,
+        fused_norm=True,
+        outproj_norm_weight=inputs["outproj_norm_weight"].clone(),
+    )
+
+    assert_stable_rel(
+        out_tilelang,
+        out_ref_fp32,
+        label="fused_norm_forward",
+        cfg=f"N={n}, P={p}, R={r}, chunk={chunk_size}",
+    )
+
+
+@pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", FUSED_NORM_CASE_GRID)
+def test_fused_norm_bwd_relative_errors_lt_10pct(
+    mods: SimpleNamespace, n: int, p: int, r: int, chunk_size: int, bb_threads: int
+) -> None:
+    inputs = build_inputs(
+        mods=mods,
+        n=n,
+        p=p,
+        r=r,
+        chunk_size=chunk_size,
+        seed=7902 + n + p + r + chunk_size,
+    )
+
+    ref_grads = run_ref_backward_fp32(
+        mods,
+        inputs,
+        fused_norm=True,
+    )
+
+    (
+        dq,
+        dk,
+        dv,
+        dA,
+        ddt,
+        dtrap,
+        dq_bias,
+        dk_bias,
+        dmimo_v,
+        dmimo_z,
+        dmimo_o,
+        dangles,
+        dD,
+        dz,
+        dout_norm_weight,
+    ) = mods.bwd.mamba_mimo_bwd_combined(
+        inputs["dout"],
+        inputs["q"],
+        inputs["k"],
+        inputs["v"],
+        inputs["q_bias"],
+        inputs["k_bias"],
+        inputs["mimo_v"],
+        inputs["mimo_o"],
+        inputs["z"],
+        inputs["mimo_z"],
+        inputs["angles"],
+        inputs["dA_cs"],
+        inputs["dA_cs_rev"],
+        inputs["dt"],
+        inputs["trap"],
+        inputs["D"],
+        inputs["segsum"],
+        chunk_size,
+        inputs["rotary_dim_divisor"],
+        FIXED_DTYPE,
+        bb_threads=bb_threads,
+        fuse_pregate_headwise_rms_norm=True,
+        outproj_norm_weight=inputs["outproj_norm_weight"],
+    )
+
+    comparisons = {
+        "dq": (dq, ref_grads["dq"]),
+        "dk": (dk, ref_grads["dk"]),
+        "dv": (dv, ref_grads["dv"]),
+        "dA": (dA, ref_grads["dA"]),
+        "ddt": (ddt, ref_grads["ddt"]),
+        "dtrap": (dtrap, ref_grads["dtrap"]),
+        "dq_bias": (dq_bias, ref_grads["dq_bias"]),
+        "dk_bias": (dk_bias, ref_grads["dk_bias"]),
+        "dmimo_v": (dmimo_v, ref_grads["dmimo_v"]),
+        "dmimo_z": (dmimo_z, ref_grads["dmimo_z"]),
+        "dmimo_o": (dmimo_o, ref_grads["dmimo_o"]),
+        "dangles": (dangles, ref_grads["dangles"]),
+        "dD": (dD, ref_grads["dD"]),
+        "dz": (dz, ref_grads["dz"]),
+        "dout_norm_weight": (dout_norm_weight, ref_grads["dout_norm_weight"]),
+    }
+
+    for name, (ours, ref) in comparisons.items():
+        assert_stable_rel(
+            ours,
+            ref,
+            label=f"fused_norm_bwd_{name}",
             cfg=f"N={n}, P={p}, R={r}, chunk={chunk_size}, bb_threads={bb_threads}",
         )
 
@@ -1493,6 +1824,7 @@ def build_inputs_varlen(
     )
     trap = torch.rand((b, h, s_total), device="cuda", dtype=dtype)
     dout = torch.randn_like(v)
+    outproj_norm_weight = torch.randn((h, p), device="cuda", dtype=torch.float32)
 
     return {
         "q": q, "k": k, "v": v,
@@ -1503,6 +1835,7 @@ def build_inputs_varlen(
         "dA": dA,
         "dA_cs": dA_cs, "dA_cs_rev": dA_cs_rev,
         "segsum": segsum, "trap": trap, "dout": dout,
+        "outproj_norm_weight": outproj_norm_weight,
         "cu_seqlens": cu_seqlens, "seqlens": seqlens,
         "chunk_size": chunk_size,
         "rotary_dim_divisor": rotary_dim_divisor,
@@ -1514,6 +1847,8 @@ def run_ref_backward_fp32_varlen(
     *,
     contract_mimo_out: bool = True,
     grad_output: Optional[Tensor] = None,
+    fused_norm: bool = False,
+    outproj_norm_eps: float = 1e-5,
 ) -> dict:
     """Per-sequence fp32 autograd reference for the varlen backward pass.
 
@@ -1534,6 +1869,9 @@ def run_ref_backward_fp32_varlen(
     mimo_v_base = inputs["mimo_v"].detach().to(ref_dtype)
     mimo_o_base = (
         inputs["mimo_o"].detach().to(ref_dtype) if contract_mimo_out else None
+    )
+    outproj_norm_weight_base = (
+        inputs["outproj_norm_weight"].detach().to(ref_dtype) if fused_norm else None
     )
     z_base = (
         inputs["z"].detach().to(ref_dtype) if inputs["z"] is not None else None
@@ -1561,6 +1899,9 @@ def run_ref_backward_fp32_varlen(
     dk_bias = torch.zeros_like(k_bias_base)
     dmimo_v = torch.zeros_like(mimo_v_base)
     dmimo_o = torch.zeros_like(mimo_o_base) if contract_mimo_out else None
+    dout_norm_weight = (
+        torch.zeros_like(outproj_norm_weight_base) if fused_norm else None
+    )
     dz = torch.zeros_like(v_base) if z_base is not None else None
     dmimo_z = torch.zeros_like(mimo_z_base) if mimo_z_base is not None else None
     dD = torch.zeros_like(d_base)
@@ -1585,6 +1926,10 @@ def run_ref_backward_fp32_varlen(
         kb_i       = k_bias_base.clone().requires_grad_()
         mv_i       = mimo_v_base.clone().requires_grad_()
         mo_i       = mimo_o_base.clone().requires_grad_() if contract_mimo_out else None
+        onw_i      = (
+            outproj_norm_weight_base.clone().requires_grad_()
+            if fused_norm else None
+        )
         z_i_leaf   = (
             z_base[:, start:end].detach().requires_grad_()
             if z_base is not None else None
@@ -1607,6 +1952,9 @@ def run_ref_backward_fp32_varlen(
             rotary_dim_divisor=inputs["rotary_dim_divisor"],
             dtype=ref_dtype,
             contract_mimo_out=contract_mimo_out,
+            fused_norm=fused_norm,
+            outproj_norm_weight=onw_i,
+            outproj_norm_eps=outproj_norm_eps,
         )
         # out_i is already [:, :seq_len] — mamba3_MIMO_chunk_ref slices internally.
 
@@ -1623,6 +1971,8 @@ def run_ref_backward_fp32_varlen(
             grad_input_items.append(("mimo_z", mz_i))
         if contract_mimo_out:
             grad_input_items.append(("mimo_o", mo_i))
+        if fused_norm:
+            grad_input_items.append(("outproj_norm_weight", onw_i))
 
         grads = torch.autograd.grad(
             outputs=out_i,
@@ -1651,6 +2001,8 @@ def run_ref_backward_fp32_varlen(
             dmimo_z += gmap["mimo_z"]
         if dmimo_o is not None and "mimo_o" in gmap:
             dmimo_o += gmap["mimo_o"]
+        if dout_norm_weight is not None and "outproj_norm_weight" in gmap:
+            dout_norm_weight += gmap["outproj_norm_weight"]
 
     # Convert per-sequence ddA_cs / ddA_cs_rev -> ddA using the same formula
     # as grads_to_dA, applied independently to each sequence.
@@ -1673,6 +2025,7 @@ def run_ref_backward_fp32_varlen(
         "dmimo_v": dmimo_v, "dmimo_o": dmimo_o,
         "dmimo_z": dmimo_z, "dangles": dangles,
         "dD": dD, "dz": dz,
+        "dout_norm_weight": dout_norm_weight,
     }
 
 
@@ -1819,6 +2172,7 @@ def test_bwd_varlen_relative_errors_lt_10pct(
         dq_bias, dk_bias,
         dmimo_v, dmimo_z, dmimo_o,
         dangles, dD, dz,
+        dout_norm_weight,
     ) = mods_varlen.bwd_varlen.mamba_mimo_bwd_combined_varlen(
         inputs["dout"],
         inputs["q"], inputs["k"], inputs["v"],
@@ -1834,6 +2188,7 @@ def test_bwd_varlen_relative_errors_lt_10pct(
         cu_seqlens=inputs["cu_seqlens"],
         bb_threads=bb_threads,
     )
+    assert dout_norm_weight is None
 
     comparisons = {
         "dq": (dq, ref_grads["dq"]),
@@ -1857,6 +2212,123 @@ def test_bwd_varlen_relative_errors_lt_10pct(
         if ours is None and ref is None:
             continue
         assert_stable_rel(ours, ref, label=f"bwd_varlen_{name}", cfg=cfg)
+
+
+@pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", FUSED_NORM_CASE_GRID)
+def test_fused_norm_fwd_varlen_relative_error_lt_10pct(
+    mods_varlen: SimpleNamespace,
+    n: int, p: int, r: int, chunk_size: int, bb_threads: int,
+) -> None:
+    del bb_threads
+    seqlens = _varlen_seqlens(chunk_size)
+    inputs = build_inputs_varlen(
+        mods_varlen=mods_varlen,
+        n=n, p=p, r=r, chunk_size=chunk_size, seqlens=seqlens,
+        seed=9101 + n + p + r + chunk_size,
+    )
+
+    out_tilelang, _, _ = mods_varlen.fwd_varlen.mamba_mimo_forward_varlen(
+        inputs["q"], inputs["k"], inputs["v"],
+        inputs["q_bias"], inputs["k_bias"],
+        inputs["mimo_v"], inputs["mimo_o"],
+        inputs["z"], inputs["D"], inputs["mimo_z"],
+        inputs["angles"],
+        inputs["dA_cs"], inputs["dA_cs_rev"],
+        inputs["dt"], inputs["trap"], inputs["segsum"],
+        chunk_size=chunk_size,
+        rotary_dim_divisor=inputs["rotary_dim_divisor"],
+        dtype=FIXED_DTYPE,
+        cu_seqlens=inputs["cu_seqlens"],
+        fuse_pregate_headwise_rms_norm=True,
+        outproj_norm_weight=inputs["outproj_norm_weight"],
+    )
+
+    out_ref_fp32, _, _ = mamba3_MIMO_chunk_ref(
+        inputs["q"].clone(), inputs["k"].clone(), inputs["v"].clone(),
+        inputs["q_bias"].clone(), inputs["k_bias"].clone(),
+        inputs["mimo_v"].clone(), inputs["mimo_o"].clone(),
+        inputs["z"].clone(), inputs["mimo_z"].clone(),
+        inputs["angles"].clone(),
+        inputs["dA_cs"].clone(), inputs["dA_cs_rev"].clone(),
+        inputs["dt"].clone(), inputs["trap"].clone(),
+        inputs["D"].clone(),
+        chunk_size=chunk_size,
+        rotary_dim_divisor=inputs["rotary_dim_divisor"],
+        dtype=torch.float32,
+        cu_seqlens=inputs["cu_seqlens"],
+        fused_norm=True,
+        outproj_norm_weight=inputs["outproj_norm_weight"].clone(),
+    )
+
+    assert_stable_rel(
+        out_tilelang, out_ref_fp32,
+        label="fused_norm_fwd_varlen",
+        cfg=f"N={n}, P={p}, R={r}, chunk={chunk_size}, seqlens={seqlens}",
+    )
+
+
+@pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", FUSED_NORM_CASE_GRID)
+def test_fused_norm_bwd_varlen_relative_errors_lt_10pct(
+    mods_varlen: SimpleNamespace,
+    n: int, p: int, r: int, chunk_size: int, bb_threads: int,
+) -> None:
+    seqlens = _varlen_seqlens(chunk_size)
+    inputs = build_inputs_varlen(
+        mods_varlen=mods_varlen,
+        n=n, p=p, r=r, chunk_size=chunk_size, seqlens=seqlens,
+        seed=9102 + n + p + r + chunk_size,
+    )
+
+    ref_grads = run_ref_backward_fp32_varlen(
+        inputs,
+        fused_norm=True,
+    )
+
+    (
+        dq, dk, dv, dA, ddt, dtrap,
+        dq_bias, dk_bias,
+        dmimo_v, dmimo_z, dmimo_o,
+        dangles, dD, dz,
+        dout_norm_weight,
+    ) = mods_varlen.bwd_varlen.mamba_mimo_bwd_combined_varlen(
+        inputs["dout"],
+        inputs["q"], inputs["k"], inputs["v"],
+        inputs["q_bias"], inputs["k_bias"],
+        inputs["mimo_v"], inputs["mimo_o"],
+        inputs["z"], inputs["mimo_z"],
+        inputs["angles"],
+        inputs["dA_cs"], inputs["dA_cs_rev"],
+        inputs["dt"], inputs["trap"],
+        inputs["D"], inputs["segsum"],
+        chunk_size, inputs["rotary_dim_divisor"],
+        FIXED_DTYPE,
+        cu_seqlens=inputs["cu_seqlens"],
+        bb_threads=bb_threads,
+        fuse_pregate_headwise_rms_norm=True,
+        outproj_norm_weight=inputs["outproj_norm_weight"],
+    )
+
+    comparisons = {
+        "dq": (dq, ref_grads["dq"]),
+        "dk": (dk, ref_grads["dk"]),
+        "dv": (dv, ref_grads["dv"]),
+        "dA": (dA, ref_grads["dA"]),
+        "ddt": (ddt, ref_grads["ddt"]),
+        "dtrap": (dtrap, ref_grads["dtrap"]),
+        "dq_bias": (dq_bias, ref_grads["dq_bias"]),
+        "dk_bias": (dk_bias, ref_grads["dk_bias"]),
+        "dmimo_v": (dmimo_v, ref_grads["dmimo_v"]),
+        "dmimo_z": (dmimo_z, ref_grads["dmimo_z"]),
+        "dmimo_o": (dmimo_o, ref_grads["dmimo_o"]),
+        "dangles": (dangles, ref_grads["dangles"]),
+        "dD": (dD, ref_grads["dD"]),
+        "dz": (dz, ref_grads["dz"]),
+        "dout_norm_weight": (dout_norm_weight, ref_grads["dout_norm_weight"]),
+    }
+
+    cfg = f"N={n}, P={p}, R={r}, chunk={chunk_size}, seqlens={seqlens}, bb_threads={bb_threads}"
+    for name, (ours, ref) in comparisons.items():
+        assert_stable_rel(ours, ref, label=f"fused_norm_bwd_varlen_{name}", cfg=cfg)
 
 
 @pytest.mark.parametrize("n,p,r,chunk_size,bb_threads", VARLEN_CASE_GRID)
@@ -1888,6 +2360,7 @@ def test_bwd_varlen_prereduce_relative_errors_lt_10pct(
         dq_bias, dk_bias,
         dmimo_v, dmimo_z, dmimo_o,
         dangles, dD, dz,
+        dout_norm_weight,
     ) = mods_varlen.bwd_varlen.mamba_mimo_bwd_combined_varlen(
         dout_prereduce,
         inputs["q"], inputs["k"], inputs["v"],
@@ -1907,6 +2380,7 @@ def test_bwd_varlen_prereduce_relative_errors_lt_10pct(
     assert dmimo_o is None
     assert dmimo_z is None
     assert dz is None
+    assert dout_norm_weight is None
 
     comparisons = {
         "dq": (dq, ref_grads["dq"]),


### PR DESCRIPTION
## Summary

Fuse Mamba-3 MIMO pregate headwise RMSNorm with MIMO out projection and update `Q`/`K` (equivalently, `C`/`B`) gradient handling to reduce memory I/O and allow for arbitrary valid `G`.

## Changes

- Add `fuse_pregate_headwise_norm` to `Mamba3`, enabled by default when `is_mimo=True` and `is_outproj_norm=True`.
- Fuse `RMSNorm(y) * silu(z)` with MIMO out projection in dense and varlen forward kernels.
- Update dense and varlen backward kernels to support the fused norm path, including `dout_norm_weight`.
- Add Triton grouped-head Q/K reduction utilities that support arbitrary valid `G` values.
- Add fused-norm reference and TileLang tests for dense and varlen forward/backward paths.

## Testing

Added `fused_norm` coverage in `tests/ops/tilelang/test_mamba3_mimo.py`:

```bash
PYTHONPATH=. pytest -q -s -p no:warnings tests/ops/tilelang/test_mamba3_mimo.py -k fused_norm