### PR TITLE
C1: Add Mamba-3 LM layer support. C2: Latency fix for MIMO batched kernel

### DIFF
--- a/mamba_ssm/models/mixer_seq_simple.py
+++ b/mamba_ssm/models/mixer_seq_simple.py
@@ -14,6 +14,7 @@ import torch.nn as nn
 from mamba_ssm.models.config_mamba import MambaConfig
 from mamba_ssm.modules.mamba_simple import Mamba
 from mamba_ssm.modules.mamba2 import Mamba2
+from mamba_ssm.modules.mamba3 import Mamba3
 from mamba_ssm.modules.mha import MHA
 from mamba_ssm.modules.mlp import GatedMLP
 from mamba_ssm.modules.block import Block
@@ -51,10 +52,15 @@ def create_block(
         # Create a copy of the config to modify
         ssm_cfg = copy.deepcopy(ssm_cfg) if ssm_cfg is not None else {}
         ssm_layer = ssm_cfg.pop("layer", "Mamba1")
-        if ssm_layer not in ["Mamba1", "Mamba2"]:
-            raise ValueError(f"Invalid ssm_layer: {ssm_layer}, only support Mamba1 and Mamba2")
+        ssm_layer_map = {
+            "Mamba1": Mamba,
+            "Mamba2": Mamba2,
+            "Mamba3": Mamba3,
+        }
+        if ssm_layer not in ssm_layer_map:
+            raise ValueError(f"Invalid ssm_layer: {ssm_layer}, only support Mamba1, Mamba2, and Mamba3")
         mixer_cls = partial(
-            Mamba2 if ssm_layer == "Mamba2" else Mamba,
+            ssm_layer_map[ssm_layer],
             layer_idx=layer_idx,
             **ssm_cfg,
             **factory_kwargs

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_bwd.py
@@ -1427,10 +1427,10 @@ def mamba_mimo_bwd_combined(
     else:
         dtype_str = dtype
     bwd_fwd_kernel = mamba_mimo_bwd_fwd(
-        T.dynamic("B"),
-        T.dynamic("S"),
-        T.dynamic("H"),
-        T.dynamic("G"),
+        B,
+        S,
+        H,
+        G,
         N, P, R,
         z is not None,
         D is not None,
@@ -1495,10 +1495,10 @@ def mamba_mimo_bwd_combined(
     bwd_bwd_hasZ = (z is not None) and not fuse_pregate_headwise_rms_norm
     bwd_bwd_packed_dout = fuse_pregate_headwise_rms_norm
     bwd_bwd_kernel = mamba_mimo_bwd_bwd(
-        T.dynamic("B"),
-        T.dynamic("S"),
-        T.dynamic("H"),
-        T.dynamic("G"),
+        B,
+        S,
+        H,
+        G,
         N, P, R,
         bwd_bwd_hasZ,
         D is not None,

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd.py
@@ -494,10 +494,10 @@ def mamba_mimo_forward(q, k, v,
             raise ValueError("fuse_pregate_headwise_rms_norm=True requires mimo_o.")
         if z is None or mimo_z is None:
             raise ValueError("fuse_pregate_headwise_rms_norm=True requires z and mimo_z.")
-    kernel = mamba_mimo_fwd(T.dynamic("B"),
-                            T.dynamic("S"), 
-                            T.dynamic("H"), 
-                            T.dynamic("G"), 
+    kernel = mamba_mimo_fwd(B,
+                            S,
+                            H,
+                            G,
                             N, P, R, 
                             z is not None, 
                             D is not None, 


### PR DESCRIPTION
1. Add Mamba-3 support in mixer_seq_simple.py so users can instantiate a Mamba-3 model using mamba_ssm itself.
2. Revert T.dynamic variables (B,S,H,G) for batched MIMO kernels to fix 70x latency regression issues.