### PR TITLE
Remove host syncs from `compute_dacs_segsum_triton_varlen`

### DIFF
--- a/mamba_ssm/ops/triton/mamba3/mamba3_mimo_utils.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_mimo_utils.py
@@ -648,28 +648,25 @@ def compute_dacs_segsum_triton_varlen(
     da_cs_rev = torch.empty_like(da)
     segsum = torch.zeros(B, H, nchunks, chunk_size, chunk_size, device=da.device, dtype=da.dtype)
 
-    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-    chunks_per_seq = (seq_lens // chunk_size) + 1
-
     # Build mapping tensors: both have length nchunks_global.
     # Inactive (padding) slots are given a sentinel local-chunk index that
     # places chunk_start >= seq_end, making the kernel mask all-False.
-    state_seq_mapping  = torch.zeros(nchunks, dtype=torch.int32, device=da.device)
-    state_chunk_in_seq = torch.zeros(nchunks, dtype=torch.int32, device=da.device)
-    default_seq_len = int(seq_lens[0].item()) if num_sequences > 0 else 0
-    default_inactive_local_chunk = (default_seq_len + chunk_size - 1) // chunk_size
-    state_chunk_in_seq.fill_(default_inactive_local_chunk)
 
-    for i in range(num_sequences):
-        start = int(cu_seqlens[i].item())
-        n = int(chunks_per_seq[i].item())
-        chunk_start = (start // chunk_size) + i
-        chunk_end = chunk_start + n
-        assert chunk_end <= nchunks, (
-            f"Chunk mapping overflow for seq {i}: [{chunk_start}, {chunk_end}) vs nchunks={nchunks}"
-        )
-        state_seq_mapping[chunk_start:chunk_end] = i
-        state_chunk_in_seq[chunk_start:chunk_end] = torch.arange(n, dtype=torch.int32, device=da.device)
+    range_starts = cu_seqlens[:-1] // chunk_size + seq_idx
+    range_ends = range_starts + seq_lens // chunk_size + 1
+    g = torch.arange(nchunks, dtype=cu_seqlens.dtype, device=da.device)
+    owner = torch.searchsorted(range_starts, g, right=True) - 1
+    active = g < range_ends[owner]
+    # Sentinel for inactive slots: ceil(len_0 / C), matching the original.
+    default_inactive_local_chunk = (
+        (seq_lens[0] + chunk_size - 1) // chunk_size
+    )
+    state_seq_mapping = torch.where(
+        active, owner, torch.zeros_like(owner)
+    ).to(torch.int32)
+    state_chunk_in_seq = torch.where(
+        active, g - range_starts[owner], default_inactive_local_chunk
+    ).to(torch.int32)
 
     grid = (B, H, nchunks)
     dacs_segsum_kernel_varlen[grid](


### PR DESCRIPTION
## Problem

The chunk-mapping construction loops over packed sequences reading scalars
from GPU tensors element by element:

```python
for i in range(num_sequences):
    start = int(cu_seqlens[i].item())          # GPU->CPU sync
    n = int(chunks_per_seq[i].item())          # GPU->CPU sync
    state_seq_mapping[chunk_start:chunk_end] = i                  # kernel
    state_chunk_in_seq[chunk_start:chunk_end] = torch.arange(...) # kernel
```

That is `2*num_sequences + 1` GPU→CPU synchronizations plus
`2*num_sequences` tiny slice-fill kernels **per call**. Each `.item()` stalls
the CPU on the GPU stream. Under packed-varlen inference serving this runs
once per layer per prefill batch: with 29 mamba3 layers and 64 packed prompts
that is ~3,700 pipeline stalls (~100–200 ms) per prefill wave, dominating
time-to-first-token. Varlen training forwards pay the same pattern once per
layer per micro-batch.

## Fix — fully vectorized on device, zero syncs

Sequence `i` owns the contiguous global chunk slots
`[cu[i]//C + i, cu[i]//C + i + len_i//C + 1)`. The starts are strictly
increasing (`floor(a+b) >= floor(a) + floor(b)`), so the owner of slot `g` is
`searchsorted(range_starts, g, right=True) - 1`, slots at/after the owner's
range end are inactive padding, and the local chunk index is
`g - range_starts[owner]`:

```python
range_starts = cu_seqlens[:-1] // C + arange(NS)
range_ends   = range_starts + (cu_seqlens[1:] - cu_seqlens[:-1]) // C + 1
owner  = searchsorted(range_starts, arange(nchunks), right=True) - 1
active = arange(nchunks) < range_ends[owner]
state_seq_mapping  = where(active, owner, 0)
state_chunk_in_seq = where(active, g - range_starts[owner], sentinel)
```

The inactive-slot sentinel (`ceil(len_0 / C)`, same as before) stays a
device-side scalar. ~7 small kernels replace the loop; no `.item()`/`.tolist()`
anywhere, so the call no longer serializes the CPU against the GPU stream —
which also matters under async scheduling, where any sync blocks pipelining
of the next step's host work.

The old per-sequence overflow assert is dropped: by the same floor
inequality the last range end is always `<= nchunks`, so it could never fire.

## Validation / measurements

- Mapping tensors bit-identical to the original loop for: NS=1 short/long,
  lengths exactly multiple of C, single-token sequences, mixed lengths, and
  32 packed sequences.
- End-to-end greedy outputs of our mamba3-MIMO hybrid unchanged.
- In serving (vLLM, GH200): together with hoisting two smaller sync sites in
  our integration layer, prefill syncs dropped ~520 → ~7 per 8-prompt batch
  and TTFT at 256 concurrent requests dropped 1.31 s → 0.85 s.