### PR TITLE
Fix Mamba2.step() D skip when D_has_hdim=True

### DIFF
--- a/mamba_ssm/modules/mamba2.py
+++ b/mamba_ssm/modules/mamba2.py
@@ -316,7 +316,7 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
             dBx = torch.einsum("bh,bn,bhp->bhpn", dt, B, x)
             ssm_state.copy_(ssm_state * rearrange(dA, "b h -> b h 1 1") + dBx)
             y = torch.einsum("bhpn,bn->bhp", ssm_state.to(dtype), C)
-            y = y + rearrange(self.D.to(dtype), "h -> h 1") * x
+            y = y + (rearrange(self.D.to(dtype), "(h p) -> h p", p=self.headdim) if self.D_has_hdim else rearrange(self.D.to(dtype), "h -> h 1")) * x
             y = rearrange(y, "b h p -> b (h p)")
             if not self.rmsnorm:
                 y = y * self.act(z)  # (B D)
@@ -324,7 +324,7 @@ class Mamba2(nn.Module, PyTorchModelHubMixin):
             A = repeat(A, "h -> h p n", p=self.headdim, n=self.d_state).to(dtype=torch.float32)
             dt = repeat(dt, "b h -> b h p", p=self.headdim)
             dt_bias = repeat(self.dt_bias, "h -> h p", p=self.headdim)
-            D = repeat(self.D, "h -> h p", p=self.headdim)
+            D = rearrange(self.D, "(h p) -> h p", p=self.headdim) if self.D_has_hdim else repeat(self.D, "h -> h p", p=self.headdim)
             B = rearrange(B, "b (g n) -> b g n", g=self.ngroups)
             C = rearrange(C, "b (g n) -> b g n", g=self.ngroups)
             x_reshaped = rearrange(x, "b (h p) -> b h p", p=self.headdim)


### PR DESCRIPTION
Fixes #887, #888

When `D_has_hdim=True`, `self.D` has shape `(nheads * headdim,)`. `forward()` reshapes it to `(h, p)` before applying the skip connection, but `step()` always treated `D` as `(nheads,)` and broadcast with `"h -> h 1"`.

That makes autoregressive `step()` output wrong (or fail to broadcast) compared to batched `forward()` for the same weights.

Made with [Cursor](https://cursor.com)