### PR TITLE
fix: cast x buffer offset to int64 to prevent int32 overflow

### DIFF
--- a/csrc/selective_scan/selective_scan_bwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_bwd_kernel.cuh
@@ -139,7 +139,7 @@ void selective_scan_bwd_kernel(SSMParamsBwd params) {
     float delta_bias = params.delta_bias_ptr == nullptr ? 0 : reinterpret_cast<float *>(params.delta_bias_ptr)[dim_id];
     scan_t *x = params.x_ptr == nullptr
         ? nullptr
-        : reinterpret_cast<scan_t *>(params.x_ptr) + (batch_id * params.dim + dim_id) * (params.n_chunks) * params.dstate;
+        : reinterpret_cast<scan_t *>(params.x_ptr) + (int64_t)(batch_id * params.dim + dim_id) * params.n_chunks * params.dstate;
     float dD_val = 0;
     float ddelta_bias_val = 0;
 

--- a/csrc/selective_scan/selective_scan_fwd_kernel.cuh
+++ b/csrc/selective_scan/selective_scan_fwd_kernel.cuh
@@ -111,7 +111,7 @@ void selective_scan_fwd_kernel(SSMParamsBase params) {
     input_t *Bvar = reinterpret_cast<input_t *>(params.B_ptr) + batch_id * params.B_batch_stride + group_id * params.B_group_stride;
     weight_t *C = reinterpret_cast<weight_t *>(params.C_ptr) + dim_id * kNRows * params.C_d_stride;
     input_t *Cvar = reinterpret_cast<input_t *>(params.C_ptr) + batch_id * params.C_batch_stride + group_id * params.C_group_stride;
-    scan_t *x = reinterpret_cast<scan_t *>(params.x_ptr) + (batch_id * params.dim + dim_id * kNRows) * params.n_chunks * params.dstate;
+    scan_t *x = reinterpret_cast<scan_t *>(params.x_ptr) + (int64_t)(batch_id * params.dim + dim_id * kNRows) * params.n_chunks * params.dstate;
 
     float D_val[kNRows] = {0};
     if (params.D_ptr != nullptr) {


### PR DESCRIPTION
## Summary
- Cast the `x` buffer pointer offset to `int64_t` in the forward and backward selective scan CUDA kernels before multiplying by `n_chunks * dstate`.
- Prevents signed int32 overflow when `batch * dim * n_chunks * dstate` exceeds `INT32_MAX`, which previously wrapped to a negative offset and silently corrupted memory or caused illegal CUDA accesses.

Fixes #884

## Test plan
- [ ] Build CUDA extensions with `MAMBA_FORCE_BUILD=TRUE pip install --no-cache-dir --force-reinstall . --no-build-isolation`
- [ ] Run selective scan forward/backward with large `batch`, `dim`, `n_chunks`, and `dstate` where the product exceeds 2^31-1
- [ ] Verify gradients match a smaller configuration that does not overflow
- [ ] Confirm no regression on default/smaller model configs


Made with [Cursor](https://cursor.com)