### PR TITLE
build: change upper bound of apache-tvm-ffi to 0.1.12

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
     "torch",
     "tilelang==0.1.8",
-    "apache-tvm-ffi<=0.1.9",
+    "apache-tvm-ffi<=0.1.12",
     "quack-kernels>=0.3.4",
     "triton>=3.5.0",
     "ninja",

--- a/setup.py
+++ b/setup.py
@@ -400,7 +400,7 @@ setup(
         "triton>=3.5.0",
         "transformers",
         "tilelang==0.1.8",
-        "apache-tvm-ffi<=0.1.9",
+        "apache-tvm-ffi<=0.1.12",
         "quack-kernels>=0.3.4",
         # "causal_conv1d>=1.4.0",
     ],


### PR DESCRIPTION
Changes the upper bound of apache-tvm-ffi to 0.1.12.

Useful because `flash-attn-4` 4.0.0b20 requires `apache-tvm-ffi` to 0.1.12 or later.