### PR TITLE
Fix int32 overflow in chunk_cumsum kernels' pointer arithmetic

### DIFF
--- a/mamba_ssm/ops/triton/ssd_chunk_state.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_state.py
@@ -55,7 +55,9 @@ def _chunk_cumsum_fwd_kernel(
     BLOCK_SIZE_H: tl.constexpr, BLOCK_SIZE_CHUNK: tl.constexpr,
 ):
     pid_b = tl.program_id(axis=0)
-    pid_c = tl.program_id(axis=1)
+    # if dt is long, may cause problems, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_c = tl.program_id(axis=1).to(tl.int64)
     pid_h = tl.program_id(axis=2)
     dt_ptr += pid_b * stride_dt_batch + pid_c * chunk_size * stride_dt_seqlen
     dt_out_ptr += pid_b * stride_dt_out_batch + pid_c * stride_dt_out_chunk
@@ -122,7 +124,9 @@ def _chunk_cumsum_bwd_kernel(
     DETERMINISTIC_REDUCTION: tl.constexpr,
 ):
     pid_b = tl.program_id(axis=0)
-    pid_c = tl.program_id(axis=1)
+    # if dt is long, may cause problems, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_c = tl.program_id(axis=1).to(tl.int64)
     pid_h = tl.program_id(axis=2)
     ddt_out_ptr += pid_b * stride_ddt_out_batch + pid_c * stride_ddt_out_chunk
     ddA_ptr += pid_b * stride_ddA_batch + pid_c * stride_ddA_chunk

--- a/mamba_ssm/ops/triton/ssd_chunk_state.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_state.py
@@ -54,9 +54,13 @@ def _chunk_cumsum_fwd_kernel(
     HAS_DT_BIAS: tl.constexpr,
     BLOCK_SIZE_H: tl.constexpr, BLOCK_SIZE_CHUNK: tl.constexpr,
 ):
-    pid_b = tl.program_id(axis=0)
-    # if dt is long, may cause problems, so use 64 bit
+    # pid_b * stride_dt_batch can exceed int32 range when dt is a
+    # non-contiguous slice of a wide fused projection, e.g. batch=4,
+    # seqlen=40_960, parent_width=35_072 gives stride_dt_batch=1_436_549_120,
+    # so pid_b=2 alone already gives 2_873_098_240 > 2**31 - 1. A similar
+    # problem exists for the pid_c term below.
     # https://github.com/triton-lang/triton/issues/1058
+    pid_b = tl.program_id(axis=0).to(tl.int64)
     pid_c = tl.program_id(axis=1).to(tl.int64)
     pid_h = tl.program_id(axis=2)
     dt_ptr += pid_b * stride_dt_batch + pid_c * chunk_size * stride_dt_seqlen
@@ -123,9 +127,13 @@ def _chunk_cumsum_bwd_kernel(
     BLOCK_SIZE_H: tl.constexpr, BLOCK_SIZE_CHUNK: tl.constexpr,
     DETERMINISTIC_REDUCTION: tl.constexpr,
 ):
-    pid_b = tl.program_id(axis=0)
-    # if dt is long, may cause problems, so use 64 bit
+    # pid_b * stride_dt_batch can exceed int32 range when dt is a
+    # non-contiguous slice of a wide fused projection, e.g. batch=4,
+    # seqlen=40_960, parent_width=35_072 gives stride_dt_batch=1_436_549_120,
+    # so pid_b=2 alone already gives 2_873_098_240 > 2**31 - 1. A similar
+    # problem exists for the pid_c term below.
     # https://github.com/triton-lang/triton/issues/1058
+    pid_b = tl.program_id(axis=0).to(tl.int64)
     pid_c = tl.program_id(axis=1).to(tl.int64)
     pid_h = tl.program_id(axis=2)
     ddt_out_ptr += pid_b * stride_ddt_out_batch + pid_c * stride_ddt_out_chunk

--- a/tests/ops/triton/test_ssd.py
+++ b/tests/ops/triton/test_ssd.py
@@ -76,3 +76,38 @@ def test_chunk_state_varlen(chunk_size, ngroups, dtype):
     out_ref = torch.cat(out_ref, dim=0)
     print(f"Max diff = {(out - out_ref).abs().max().item()}")
     assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
+
+
+def test_chunk_cumsum_fwd_noncontiguous_wide_view_no_overflow():
+    # Regression test for a 32-bit pointer-arithmetic overflow in
+    # _chunk_cumsum_fwd_kernel (and the identical pattern in
+    # _chunk_cumsum_bwd_kernel): `pid_c * chunk_size * stride_dt_seqlen` was
+    # computed in 32-bit and silently wrapped once it exceeded 2**31 - 1,
+    # corrupting the pointer offset into `dt` and causing a CUDA illegal
+    # memory access. This only shows up when `dt` is a non-contiguous view
+    # into a much wider parent tensor (large stride(1)), not for an
+    # ordinarily contiguous `dt` -- see
+    # https://github.com/triton-lang/triton/issues/1058.
+    device = 'cuda'
+    torch.manual_seed(0)
+    seqlen = 115_866
+    nheads = 128
+    chunk_size = 128
+    parent_width = 18_560  # wide enough that (nchunks - 1) * chunk_size * stride(1) overflows int32
+
+    A = -torch.exp(torch.randn(nheads, dtype=torch.float32, device=device))
+    dt_bias = torch.randn(nheads, dtype=torch.float32, device=device)
+
+    parent = torch.zeros((1, seqlen, parent_width), dtype=torch.bfloat16, device=device)
+    dt = parent[:, :, -nheads:]
+    assert not dt.is_contiguous()
+
+    with torch.no_grad():
+        dA_cumsum, dt_out = _chunk_cumsum_fwd(dt, A, chunk_size, dt_bias=dt_bias, dt_softplus=True)
+    torch.cuda.synchronize(device)
+
+    nchunks = math.ceil(seqlen / chunk_size)
+    assert dA_cumsum.shape == (1, nheads, nchunks, chunk_size)
+    assert dt_out.shape == (1, nheads, nchunks, chunk_size)
+    assert torch.isfinite(dA_cumsum).all()
+    assert torch.isfinite(dt_out).all()

--- a/tests/ops/triton/test_ssd.py
+++ b/tests/ops/triton/test_ssd.py
@@ -8,7 +8,7 @@ import pytest
 from einops import rearrange, repeat
 
 from mamba_ssm.ops.triton.ssd_chunk_state import chunk_state, chunk_state_ref
-from mamba_ssm.ops.triton.ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd
+from mamba_ssm.ops.triton.ssd_chunk_state import _chunk_cumsum_fwd, _chunk_cumsum_bwd, _chunk_state_fwd
 from mamba_ssm.ops.triton.ssd_chunk_state import chunk_state_varlen
 from mamba_ssm.ops.triton.ssd_state_passing import state_passing, state_passing_ref
 from mamba_ssm.ops.triton.ssd_state_passing import _state_passing_fwd
@@ -78,16 +78,17 @@ def test_chunk_state_varlen(chunk_size, ngroups, dtype):
     assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
 
 
-def test_chunk_cumsum_fwd_noncontiguous_wide_view_no_overflow():
-    # Regression test for a 32-bit pointer-arithmetic overflow in
-    # _chunk_cumsum_fwd_kernel (and the identical pattern in
-    # _chunk_cumsum_bwd_kernel): `pid_c * chunk_size * stride_dt_seqlen` was
-    # computed in 32-bit and silently wrapped once it exceeded 2**31 - 1,
-    # corrupting the pointer offset into `dt` and causing a CUDA illegal
-    # memory access. This only shows up when `dt` is a non-contiguous view
-    # into a much wider parent tensor (large stride(1)), not for an
-    # ordinarily contiguous `dt` -- see
-    # https://github.com/triton-lang/triton/issues/1058.
+def test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_no_overflow():
+    # Regression test for a 32-bit pointer-arithmetic overflow shared by
+    # _chunk_cumsum_fwd_kernel and _chunk_cumsum_bwd_kernel:
+    # `pid_c * chunk_size * stride_dt_seqlen` was computed in 32-bit and
+    # silently wrapped once it exceeded 2**31 - 1, corrupting the pointer
+    # offset into `dt` and causing a CUDA illegal memory access. This only
+    # shows up when `dt` is a non-contiguous view into a much wider parent
+    # tensor (large stride(1)), not for an ordinarily contiguous `dt` -- see
+    # https://github.com/triton-lang/triton/issues/1058. Both kernels have
+    # the identical uncast pattern and received the identical fix, so both
+    # are exercised here.
     device = 'cuda'
     torch.manual_seed(0)
     seqlen = 115_866
@@ -104,6 +105,9 @@ def test_chunk_cumsum_fwd_noncontiguous_wide_view_no_overflow():
 
     with torch.no_grad():
         dA_cumsum, dt_out = _chunk_cumsum_fwd(dt, A, chunk_size, dt_bias=dt_bias, dt_softplus=True)
+        ddA = torch.randn_like(dA_cumsum)
+        ddt_out = torch.randn_like(dt_out)
+        ddt, dA, ddt_bias = _chunk_cumsum_bwd(ddA, ddt_out, dt, A, dt_bias=dt_bias, dt_softplus=True)
     torch.cuda.synchronize(device)
 
     nchunks = math.ceil(seqlen / chunk_size)
@@ -111,3 +115,9 @@ def test_chunk_cumsum_fwd_noncontiguous_wide_view_no_overflow():
     assert dt_out.shape == (1, nheads, nchunks, chunk_size)
     assert torch.isfinite(dA_cumsum).all()
     assert torch.isfinite(dt_out).all()
+
+    assert ddt.shape == dt.shape
+    assert dA.shape == (nheads,)
+    assert torch.isfinite(ddt).all()
+    assert torch.isfinite(dA).all()
+    assert torch.isfinite(ddt_bias).all()

--- a/tests/ops/triton/test_ssd.py
+++ b/tests/ops/triton/test_ssd.py
@@ -121,3 +121,67 @@ def test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_no_overflow():
     assert torch.isfinite(ddt).all()
     assert torch.isfinite(dA).all()
     assert torch.isfinite(ddt_bias).all()
+
+
+def test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_batch_axis_no_overflow():
+    # Regression test for a distinct 32-bit pointer-arithmetic overflow in
+    # the same two kernels as test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_no_overflow
+    # above: `pid_b * stride_dt_batch` is a separate pointer-offset
+    # multiplication from `pid_c * chunk_size * stride_dt_seqlen`, so casting
+    # pid_c alone does not protect it. The test above always uses batch=1,
+    # so pid_b is always 0 and this term is never exercised regardless of
+    # how large stride_dt_batch is -- this test uses batch=4 to cover it.
+    # stride_dt_batch is large exactly when dt is a non-contiguous slice of a
+    # wide fused projection (e.g. transformers' NemotronHMamba2Mixer
+    # splitting a fused in_proj output across batch elements), matching a
+    # real reported crash: batch=4, seqlen=40_960, parent_width=35_072.
+    #
+    # isfinite alone cannot reliably catch this (see the comparable
+    # discussion for test_mamba_chunk_scan_combined_noncontiguous_wide_view_no_overflow):
+    # a wrapped offset can land on another in-bounds address and produce
+    # finite but silently wrong values. Compare against the same kernels run
+    # on a contiguous copy of the identical values instead.
+    device = 'cuda'
+    torch.manual_seed(0)
+    batch = 4
+    seqlen = 40_960
+    nheads = 128
+    chunk_size = 128
+    parent_width = 35_072  # matches the real-world crash this guards against
+    assert parent_width >= nheads
+
+    parent = torch.randn((batch, seqlen, parent_width), dtype=torch.bfloat16, device=device)
+    dt = parent[:, :, -nheads:]
+    assert not dt.is_contiguous()
+    assert dt.stride(0) * (batch - 1) > 2**31 - 1, "test parameters too small to overflow the batch-axis term"
+    dt_c = dt.contiguous()
+
+    A = -torch.exp(torch.randn(nheads, dtype=torch.float32, device=device))
+    dt_bias = torch.randn(nheads, dtype=torch.float32, device=device)
+
+    with torch.no_grad():
+        dA_cumsum, dt_out = _chunk_cumsum_fwd(dt, A, chunk_size, dt_bias=dt_bias, dt_softplus=True)
+        dA_cumsum_c, dt_out_c = _chunk_cumsum_fwd(dt_c, A, chunk_size, dt_bias=dt_bias, dt_softplus=True)
+    torch.cuda.synchronize(device)
+
+    nchunks = math.ceil(seqlen / chunk_size)
+    assert dA_cumsum.shape == (batch, nheads, nchunks, chunk_size)
+    assert torch.isfinite(dA_cumsum).all()
+    torch.testing.assert_close(dA_cumsum, dA_cumsum_c, rtol=1e-4, atol=1e-4)
+    torch.testing.assert_close(dt_out, dt_out_c, rtol=1e-4, atol=1e-4)
+
+    with torch.no_grad():
+        ddA = torch.randn_like(dA_cumsum)
+        ddt_out = torch.randn_like(dt_out)
+        ddt, dA, ddt_bias = _chunk_cumsum_bwd(ddA, ddt_out, dt, A, dt_bias=dt_bias, dt_softplus=True)
+        ddt_c, dA_c, ddt_bias_c = _chunk_cumsum_bwd(ddA, ddt_out, dt_c, A, dt_bias=dt_bias, dt_softplus=True)
+    torch.cuda.synchronize(device)
+
+    assert ddt.shape == dt.shape
+    assert torch.isfinite(ddt).all()
+    torch.testing.assert_close(ddt, ddt_c, rtol=1e-4, atol=1e-4)
+    # Slightly looser: dA is summed over all chunks, and summing in a
+    # different order (contiguous vs. wide-sliced memory layout) causes tiny
+    # float roundoff differences at the ~1e-3 level even for a correct kernel.
+    torch.testing.assert_close(dA, dA_c, rtol=1e-3, atol=1e-3)
+    torch.testing.assert_close(ddt_bias, ddt_bias_c, rtol=1e-3, atol=1e-3)


### PR DESCRIPTION
*ABANDONED IN FAVOUR OF https://github.com/state-spaces/mamba/pull/1016*


## Summary

`_chunk_cumsum_fwd_kernel` and `_chunk_cumsum_bwd_kernel` in `ssd_chunk_state.py` compute pointer offsets as:

```python
dt_ptr += pid_b * stride_dt_batch + pid_c * chunk_size * stride_dt_seqlen
```

Triton's JIT specializes `pid_b`, `pid_c`, `chunk_size`, and the strides as 32-bit ints based on each operand's own value at specialization time, not the value their product will reach. Both `pid_b * stride_dt_batch` and `pid_c * chunk_size * stride_dt_seqlen` are separate multiplications that are each carried out in 32-bit, since their leading operand (`pid_b`/`pid_c`) is 32-bit. Once either product exceeds `2**31 - 1`, it silently wraps to a garbage value, corrupting the pointer offset added to `dt_ptr` -- and the kernel then reads/writes through a wildly out-of-bounds address, surfacing as a CUDA "illegal memory access" error that's far removed from the actual root cause.

For an ordinarily contiguous `dt` (shape `(batch, seqlen, nheads)`), both `stride(0)` and `stride(1)` stay small, so neither product gets close to overflowing at any realistic seqlen/batch. It only becomes a real problem when the caller passes a `dt` that is a **non-contiguous view into a much wider parent tensor** -- e.g. `transformers`' `NemotronHMamba2Mixer` slices `dt`/`B`/`C` directly out of a much wider `in_proj`/post-conv1d output. In that case both strides are the parent's width rather than `nheads`, and either product can overflow int32 well within realistic sequence lengths -- the `pid_c` term at large seqlen with `batch=1` (real width ~18,560 for the model that first surfaced this), and the `pid_b` term independently at `batch >= 2` with much shorter sequences (reported: `batch=4, seqlen=40_960, parent_width=35_072`, from Nemotron-H Ultra).

We verified this arithmetic against every empirical pass/fail boundary we found, including an exact sign-flip at a single-token transition (`N=115,712` passes, `N=115,713` fails, for one specific `stride_dt_seqlen` value) -- this is confirmed mechanism, not a guess. We also verified with a small standalone Triton kernel that casting the *leading* operand of a chained multiplication to `int64` is sufficient to make the whole chain safe (Triton's promotion rules propagate the width forward through subsequent multiplications), while casting only a *trailing* operand does not help, since the overflow already happens in an earlier sub-product before that operand is multiplied in. This also means `pid_b` and `pid_c` each need their own cast, since they lead two *separate* multiplications rather than one chain -- widening one does not protect the other (this was originally missed; see [comment thread](https://github.com/state-spaces/mamba/pull/988#issuecomment-5052840632) on the follow-up audit PR #988 for the report and repro).

## Fix

Cast `pid_b` and `pid_c` to `tl.int64` immediately after their respective `tl.program_id()` calls in both kernels, so each chained multiplication is carried out entirely in 64-bit from the first multiplication onward. This mirrors vLLM's own vendored copy of this kernel (`vllm/model_executor/layers/mamba/ops/`), which has had this exact cast (for `pid_c`) since the file was first added in [PR #10909](https://github.com/vllm-project/vllm/pull/10909) ("Add Bamba Model", commit `aff404571b0d5aba342c46fdf5d7f8a251da9383`) -- inherited while porting the kernels from `state-spaces/mamba`, not added in response to a specific bug report.

See also the related, still-open upstream Triton issue: https://github.com/triton-lang/triton/issues/1058

The casts are unconditional and cheap, so they should not regress the common small-sequence/contiguous-tensor case -- benchmark results confirming this are in a follow-up comment below.

`_chunk_cumsum_bwd_kernel` has the identical pattern and receives the identical fix here, though it was not the kernel that produced the original crash.

**Broader audit:** the same class of vulnerability across the rest of `mamba_ssm/ops/triton/` (`ssd_combined.py`, `ssd_state_passing.py`, `ssd_chunk_scan.py`, `ssd_bmm.py`, `layer_norm.py`, `layernorm_gated.py`, `k_activations.py`) is tracked separately in #988.

## Test plan

- [x] Added `test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_no_overflow` in `tests/ops/triton/test_ssd.py`, reproducing the exact failing shape (`seqlen=115_866, nheads=128, chunk_size=128, parent_width=18_560`, `batch=1`) and exercising both the forward and backward kernel.
- [x] Added `test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_batch_axis_no_overflow` covering the separate `pid_b` overflow (`batch=4, seqlen=40_960, parent_width=35_072`), comparing output/gradients against the same kernels run on a contiguous copy of identical values (an `isfinite`-only check can't reliably catch a wrapped-but-still-in-bounds pointer offset, since it can produce finite but silently wrong values rather than a crash or a NaN).
- [x] Verified both tests fail with `RuntimeError`/`AcceleratorError: ... an illegal memory access was encountered` on the unpatched kernels, and pass with the fix applied.
- [x] Benchmarked `_chunk_cumsum_fwd` across a range of typical contiguous shapes before/after the fix -- no regression (results in a follow-up comment).
