### PR TITLE
Audit follow-up: fix the same int32 overflow pattern in other Triton kernels

### DIFF
--- a/mamba_ssm/ops/triton/k_activations.py
+++ b/mamba_ssm/ops/triton/k_activations.py
@@ -31,7 +31,9 @@ def _swiglu_fwd_kernel(
     BLOCK_N: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
-    row = tl.program_id(0)
+    # if row * stride_x_row is large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    row = tl.program_id(0).to(tl.int64)
     start_col = tl.program_id(1) * BLOCK_N
     X += row * stride_x_row
     Y += row * stride_y_row
@@ -93,7 +95,9 @@ def _swiglu_bwd_kernel(
     RECOMPUTE_OUTPUT: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
-    row = tl.program_id(0)
+    # if row * stride_x_row is large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    row = tl.program_id(0).to(tl.int64)
     start_col = tl.program_id(1) * BLOCK_N
     X += row * stride_x_row
     Y += row * stride_y_row

--- a/mamba_ssm/ops/triton/layer_norm.py
+++ b/mamba_ssm/ops/triton/layer_norm.py
@@ -217,7 +217,9 @@ def _layer_norm_fwd_1pass_kernel(
     HAS_B1: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
-    row = tl.program_id(0)
+    # if row * stride_x_row is large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    row = tl.program_id(0).to(tl.int64)
     X += row * stride_x_row
     Y += row * stride_y_row
     if HAS_RESIDUAL:
@@ -479,7 +481,9 @@ def _layer_norm_bwd_kernel(
     RECOMPUTE_OUTPUT: tl.constexpr,
 ):
     # Map the program id to the elements of X, DX, and DY it should compute.
-    row_block_id = tl.program_id(0)
+    # if row_start * stride_x_row is large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    row_block_id = tl.program_id(0).to(tl.int64)
     row_start = row_block_id * rows_per_program
     # Do not early exit if row_start >= M, because we need to write DW and DB
     cols = tl.arange(0, BLOCK_N)

--- a/mamba_ssm/ops/triton/layernorm_gated.py
+++ b/mamba_ssm/ops/triton/layernorm_gated.py
@@ -63,7 +63,9 @@ def _layer_norm_fwd_1pass_kernel(
     IS_RMS_NORM: tl.constexpr,
 ):
     # Map the program id to the row of X and Y it should compute.
-    row = tl.program_id(0)
+    # if row * stride_x_row is large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    row = tl.program_id(0).to(tl.int64)
     group = tl.program_id(1)
     X += row * stride_x_row + group * N
     Y += row * stride_y_row + group * N
@@ -185,7 +187,9 @@ def _layer_norm_bwd_kernel(
     BLOCK_N: tl.constexpr,
 ):
     # Map the program id to the elements of X, DX, and DY it should compute.
-    row_block_id = tl.program_id(0)
+    # if row_start * stride_x_row is large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    row_block_id = tl.program_id(0).to(tl.int64)
     group = tl.program_id(1)
     row_start = row_block_id * rows_per_program
     cols = tl.arange(0, BLOCK_N)

--- a/mamba_ssm/ops/triton/ssd_bmm.py
+++ b/mamba_ssm/ops/triton/ssd_bmm.py
@@ -50,7 +50,9 @@ def _bmm_chunk_fwd_kernel(
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
     pid_b = tl.program_id(axis=1)
-    pid_ch = tl.program_id(axis=2)
+    # if chunk_size/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_ch = tl.program_id(axis=2).to(tl.int64)
     pid_c = pid_ch // ngroups
     pid_h = pid_ch - pid_c * ngroups
     num_pid_n = tl.cdiv(chunk_size, BLOCK_SIZE_N)
@@ -123,7 +125,9 @@ def _bmm_chunk_bwd_kernel(
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_CS: tl.constexpr,
 ):
     pid_b = tl.program_id(axis=1)
-    pid_ch = tl.program_id(axis=2)
+    # if chunk_size/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_ch = tl.program_id(axis=2).to(tl.int64)
     pid_c = pid_ch // ngroups
     pid_h = pid_ch - pid_c * ngroups
     num_pid_n = tl.cdiv(K, BLOCK_SIZE_N)

--- a/mamba_ssm/ops/triton/ssd_chunk_scan.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_scan.py
@@ -73,7 +73,9 @@ def _chunk_scan_fwd_kernel(
     BLOCK_SIZE_DSTATE: tl.constexpr,
     IS_TRITON_22: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -218,7 +220,9 @@ def _chunk_scan_fwd_kernel_wip(
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -370,7 +374,9 @@ def _chunk_scan_bwd_dz_kernel(
     RECOMPUTE_OUTPUT: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -462,7 +468,9 @@ def _chunk_scan_bwd_dstates_kernel(
     HAS_SEQ_IDX: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -548,7 +556,9 @@ def _chunk_scan_bwd_dc_kernel(
     DETERMINISTIC_REDUCTION: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_sg = tl.program_id(axis=2)
@@ -661,7 +671,9 @@ def _chunk_scan_bwd_dx_kernel(
     DETERMINISTIC_REDUCTION: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -792,7 +804,9 @@ def _chunk_scan_bwd_dcb_kernel(
     HAS_SEQ_IDX: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_sg = tl.program_id(axis=2)
@@ -908,7 +922,9 @@ def _chunk_scan_bwd_ddAcs_unstable_kernel(
     SUBTRACT_DDTDT: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -993,7 +1009,9 @@ def _chunk_scan_bwd_ddAcs_stable_kernel_old(
     # Meta-parameters
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -1112,7 +1130,9 @@ def _chunk_scan_bwd_ddAcs_stable_kernel(
     # Meta-parameters
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -1213,7 +1233,9 @@ def _chunk_scan_bwd_ddAcs_prev_kernel(
     HAS_SEQ_IDX: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)

--- a/mamba_ssm/ops/triton/ssd_chunk_state.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_state.py
@@ -210,7 +210,9 @@ def _chunk_state_fwd_kernel(
     HAS_SEQ_IDX: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -308,7 +310,9 @@ def _chunk_state_bwd_dx_kernel(
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -421,7 +425,9 @@ def _chunk_state_bwd_db_kernel(
     DETERMINISTIC_REDUCTION: tl.constexpr,
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_sg = tl.program_id(axis=2)
@@ -550,7 +556,9 @@ def _chunk_state_bwd_ddAcs_stable_kernel(
     BLOCK_SIZE_M: tl.constexpr, BLOCK_SIZE_N: tl.constexpr, BLOCK_SIZE_K: tl.constexpr,
     BLOCK_SIZE_DSTATE: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)
@@ -663,7 +671,9 @@ def _chunk_state_varlen_kernel(
     pid_m = tl.program_id(axis=0) // num_pid_n
     pid_n = tl.program_id(axis=0) % num_pid_n
     end_idx = tl.load(cu_seqlens_ptr + pid_b + 1)
-    pid_c = (end_idx - 1) // chunk_size
+    # if chunk_size/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_c = ((end_idx - 1) // chunk_size).to(tl.int64)
     b_ptr += pid_c * chunk_size * stride_b_seqlen + (pid_h // nheads_ngroups_ratio) * stride_b_head
     x_ptr += pid_c * chunk_size * stride_x_seqlen + pid_h * stride_x_head
     dt_ptr += pid_c * stride_dt_chunk + pid_h * stride_dt_head

--- a/mamba_ssm/ops/triton/ssd_chunk_state.py
+++ b/mamba_ssm/ops/triton/ssd_chunk_state.py
@@ -55,7 +55,9 @@ def _chunk_cumsum_fwd_kernel(
     BLOCK_SIZE_H: tl.constexpr, BLOCK_SIZE_CHUNK: tl.constexpr,
 ):
     pid_b = tl.program_id(axis=0)
-    pid_c = tl.program_id(axis=1)
+    # if dt is long, may cause problems, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_c = tl.program_id(axis=1).to(tl.int64)
     pid_h = tl.program_id(axis=2)
     dt_ptr += pid_b * stride_dt_batch + pid_c * chunk_size * stride_dt_seqlen
     dt_out_ptr += pid_b * stride_dt_out_batch + pid_c * stride_dt_out_chunk
@@ -122,7 +124,9 @@ def _chunk_cumsum_bwd_kernel(
     DETERMINISTIC_REDUCTION: tl.constexpr,
 ):
     pid_b = tl.program_id(axis=0)
-    pid_c = tl.program_id(axis=1)
+    # if dt is long, may cause problems, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_c = tl.program_id(axis=1).to(tl.int64)
     pid_h = tl.program_id(axis=2)
     ddt_out_ptr += pid_b * stride_ddt_out_batch + pid_c * stride_ddt_out_chunk
     ddA_ptr += pid_b * stride_ddA_batch + pid_c * stride_ddA_chunk

--- a/mamba_ssm/ops/triton/ssd_combined.py
+++ b/mamba_ssm/ops/triton/ssd_combined.py
@@ -120,7 +120,9 @@ def _chunk_scan_chunk_state_bwd_dx_kernel(
     IS_TRITON_22: tl.constexpr,
     DETERMINISTIC_REDUCTION: tl.constexpr,
 ):
-    pid_bc = tl.program_id(axis=1)
+    # if chunk_size/batch/stride products are large, may overflow int32, so use 64 bit
+    # https://github.com/triton-lang/triton/issues/1058
+    pid_bc = tl.program_id(axis=1).to(tl.int64)
     pid_c = pid_bc // batch
     pid_b = pid_bc - pid_c * batch
     pid_h = tl.program_id(axis=2)

--- a/tests/ops/triton/test_layernorm_gated.py
+++ b/tests/ops/triton/test_layernorm_gated.py
@@ -101,3 +101,30 @@ def test_layer_norm_gated(d, dtype, wtype, has_bias, has_z, is_rms_norm, has_gro
     assert (weight.grad - weight_ref.grad).abs().max().item() <= 2 * (weight_pt.grad - weight_ref.grad).abs().max().item() + atol
     if has_bias:
         assert (bias.grad - bias_ref.grad).abs().max().item() <= 2 * (bias_pt.grad - bias_ref.grad).abs().max().item() + atol
+
+
+def test_layer_norm_gated_large_row_count_no_overflow():
+    # Regression test for a 32-bit pointer-arithmetic overflow in
+    # _layer_norm_fwd_1pass_kernel and _layer_norm_bwd_kernel:
+    # `row * stride_x_row` (fwd) / `row_start * stride_x_row` (bwd) was
+    # computed in 32-bit and silently wrapped once it exceeded 2**31 - 1,
+    # corrupting the pointer offset into `x` and causing a CUDA illegal
+    # memory access. Unlike the ssd_chunk_state.py overflow, this doesn't
+    # need a non-contiguous view -- an ordinarily contiguous (M, N) input is
+    # enough once M * N is large, since `row` ranges over all M flattened
+    # rows and stride_x_row == N. See
+    # https://github.com/triton-lang/triton/issues/1058.
+    device = 'cuda'
+    torch.manual_seed(0)
+    M = 115_866
+    N = 18_560  # (M - 1) * N > 2**31 - 1
+
+    x = torch.randn(M, N, dtype=torch.bfloat16, device=device)
+    weight = torch.randn(N, dtype=torch.float32, device=device)
+
+    with torch.no_grad():
+        out = layernorm_fn(x, weight, bias=None, is_rms_norm=True)
+    torch.cuda.synchronize(device)
+
+    assert out.shape == (M, N)
+    assert torch.isfinite(out).all()

--- a/tests/ops/triton/test_ssd.py
+++ b/tests/ops/triton/test_ssd.py
@@ -121,3 +121,48 @@ def test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_no_overflow():
     assert torch.isfinite(ddt).all()
     assert torch.isfinite(dA).all()
     assert torch.isfinite(ddt_bias).all()
+
+
+def test_mamba_chunk_scan_combined_noncontiguous_wide_view_no_overflow():
+    # Regression test for the same 32-bit pointer-arithmetic overflow class
+    # as test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_no_overflow above,
+    # but hit through the full mamba_chunk_scan_combined path instead of
+    # _chunk_cumsum_fwd/_chunk_cumsum_bwd directly. This exercises
+    # _chunk_state_fwd_kernel, _chunk_state_bwd_dx_kernel,
+    # _chunk_state_bwd_db_kernel, _chunk_state_bwd_ddAcs_stable_kernel, and
+    # _chunk_state_varlen_kernel in ssd_chunk_state.py; the eleven
+    # pid_bc-derived kernels in ssd_chunk_scan.py; the fused kernel in
+    # ssd_combined.py; and the two kernels in ssd_bmm.py -- all of which had
+    # the identical uncast `pid_* * chunk_size * stride_*_seqlen` pattern and
+    # received the identical int64-cast fix. `x` is sliced non-contiguously
+    # out of a much wider parent tensor here, exactly as e.g. transformers'
+    # NemotronHMamba2Mixer slices x/B/C/dt out of a wide fused in_proj
+    # output -- see https://github.com/triton-lang/triton/issues/1058.
+    device = 'cuda'
+    torch.manual_seed(0)
+    batch = 1
+    seqlen = 115_866
+    nheads = 128
+    headdim = 64
+    ngroups = 1
+    dstate = 32
+    chunk_size = 128
+    parent_width = 18_560  # same width that overflowed in the ssd_chunk_state.py bug
+    width = nheads * headdim
+    assert parent_width >= width
+
+    parent_x = torch.randn((batch, seqlen, parent_width), dtype=torch.bfloat16, device=device)
+    x = parent_x[:, :, -width:].view(batch, seqlen, nheads, headdim)
+    assert not x.is_contiguous()
+
+    dt = F.softplus(torch.randn(batch, seqlen, nheads, dtype=torch.float32, device=device) - 4)
+    A = -torch.exp(torch.randn(nheads, dtype=torch.float32, device=device))
+    B = torch.randn(batch, seqlen, ngroups, dstate, dtype=torch.bfloat16, device=device) / 5
+    C = torch.randn(batch, seqlen, ngroups, dstate, dtype=torch.bfloat16, device=device) / 5
+
+    with torch.no_grad():
+        out = mamba_chunk_scan_combined(x, dt, A, B, C, chunk_size)
+    torch.cuda.synchronize(device)
+
+    assert out.shape == (batch, seqlen, nheads, headdim)
+    assert torch.isfinite(out).all()

--- a/tests/ops/triton/test_ssd.py
+++ b/tests/ops/triton/test_ssd.py
@@ -76,3 +76,38 @@ def test_chunk_state_varlen(chunk_size, ngroups, dtype):
     out_ref = torch.cat(out_ref, dim=0)
     print(f"Max diff = {(out - out_ref).abs().max().item()}")
     assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
+
+
+def test_chunk_cumsum_fwd_noncontiguous_wide_view_no_overflow():
+    # Regression test for a 32-bit pointer-arithmetic overflow in
+    # _chunk_cumsum_fwd_kernel (and the identical pattern in
+    # _chunk_cumsum_bwd_kernel): `pid_c * chunk_size * stride_dt_seqlen` was
+    # computed in 32-bit and silently wrapped once it exceeded 2**31 - 1,
+    # corrupting the pointer offset into `dt` and causing a CUDA illegal
+    # memory access. This only shows up when `dt` is a non-contiguous view
+    # into a much wider parent tensor (large stride(1)), not for an
+    # ordinarily contiguous `dt` -- see
+    # https://github.com/triton-lang/triton/issues/1058.
+    device = 'cuda'
+    torch.manual_seed(0)
+    seqlen = 115_866
+    nheads = 128
+    chunk_size = 128
+    parent_width = 18_560  # wide enough that (nchunks - 1) * chunk_size * stride(1) overflows int32
+
+    A = -torch.exp(torch.randn(nheads, dtype=torch.float32, device=device))
+    dt_bias = torch.randn(nheads, dtype=torch.float32, device=device)
+
+    parent = torch.zeros((1, seqlen, parent_width), dtype=torch.bfloat16, device=device)
+    dt = parent[:, :, -nheads:]
+    assert not dt.is_contiguous()
+
+    with torch.no_grad():
+        dA_cumsum, dt_out = _chunk_cumsum_fwd(dt, A, chunk_size, dt_bias=dt_bias, dt_softplus=True)
+    torch.cuda.synchronize(device)
+
+    nchunks = math.ceil(seqlen / chunk_size)
+    assert dA_cumsum.shape == (1, nheads, nchunks, chunk_size)
+    assert dt_out.shape == (1, nheads, nchunks, chunk_size)
+    assert torch.isfinite(dA_cumsum).all()
+    assert torch.isfinite(dt_out).all()

--- a/tests/ops/triton/test_ssd.py
+++ b/tests/ops/triton/test_ssd.py
@@ -8,7 +8,7 @@ import pytest
 from einops import rearrange, repeat
 
 from mamba_ssm.ops.triton.ssd_chunk_state import chunk_state, chunk_state_ref
-from mamba_ssm.ops.triton.ssd_chunk_state import _chunk_cumsum_fwd, _chunk_state_fwd
+from mamba_ssm.ops.triton.ssd_chunk_state import _chunk_cumsum_fwd, _chunk_cumsum_bwd, _chunk_state_fwd
 from mamba_ssm.ops.triton.ssd_chunk_state import chunk_state_varlen
 from mamba_ssm.ops.triton.ssd_state_passing import state_passing, state_passing_ref
 from mamba_ssm.ops.triton.ssd_state_passing import _state_passing_fwd
@@ -78,16 +78,17 @@ def test_chunk_state_varlen(chunk_size, ngroups, dtype):
     assert torch.allclose(out, out_ref, rtol=rtol, atol=atol)
 
 
-def test_chunk_cumsum_fwd_noncontiguous_wide_view_no_overflow():
-    # Regression test for a 32-bit pointer-arithmetic overflow in
-    # _chunk_cumsum_fwd_kernel (and the identical pattern in
-    # _chunk_cumsum_bwd_kernel): `pid_c * chunk_size * stride_dt_seqlen` was
-    # computed in 32-bit and silently wrapped once it exceeded 2**31 - 1,
-    # corrupting the pointer offset into `dt` and causing a CUDA illegal
-    # memory access. This only shows up when `dt` is a non-contiguous view
-    # into a much wider parent tensor (large stride(1)), not for an
-    # ordinarily contiguous `dt` -- see
-    # https://github.com/triton-lang/triton/issues/1058.
+def test_chunk_cumsum_fwd_bwd_noncontiguous_wide_view_no_overflow():
+    # Regression test for a 32-bit pointer-arithmetic overflow shared by
+    # _chunk_cumsum_fwd_kernel and _chunk_cumsum_bwd_kernel:
+    # `pid_c * chunk_size * stride_dt_seqlen` was computed in 32-bit and
+    # silently wrapped once it exceeded 2**31 - 1, corrupting the pointer
+    # offset into `dt` and causing a CUDA illegal memory access. This only
+    # shows up when `dt` is a non-contiguous view into a much wider parent
+    # tensor (large stride(1)), not for an ordinarily contiguous `dt` -- see
+    # https://github.com/triton-lang/triton/issues/1058. Both kernels have
+    # the identical uncast pattern and received the identical fix, so both
+    # are exercised here.
     device = 'cuda'
     torch.manual_seed(0)
     seqlen = 115_866
@@ -104,6 +105,9 @@ def test_chunk_cumsum_fwd_noncontiguous_wide_view_no_overflow():
 
     with torch.no_grad():
         dA_cumsum, dt_out = _chunk_cumsum_fwd(dt, A, chunk_size, dt_bias=dt_bias, dt_softplus=True)
+        ddA = torch.randn_like(dA_cumsum)
+        ddt_out = torch.randn_like(dt_out)
+        ddt, dA, ddt_bias = _chunk_cumsum_bwd(ddA, ddt_out, dt, A, dt_bias=dt_bias, dt_softplus=True)
     torch.cuda.synchronize(device)
 
     nchunks = math.ceil(seqlen / chunk_size)
@@ -111,3 +115,9 @@ def test_chunk_cumsum_fwd_noncontiguous_wide_view_no_overflow():
     assert dt_out.shape == (1, nheads, nchunks, chunk_size)
     assert torch.isfinite(dA_cumsum).all()
     assert torch.isfinite(dt_out).all()
+
+    assert ddt.shape == dt.shape
+    assert dA.shape == (nheads,)
+    assert torch.isfinite(ddt).all()
+    assert torch.isfinite(dA).all()
+    assert torch.isfinite(ddt_bias).all()


### PR DESCRIPTION
**Stacked on #987** — this branch is based on that one's branch (`fix/int32-overflow-chunk-cumsum`), so the diff shown here currently includes those changes too until #987 merges. Once #987 lands this diff will shrink to just the commits below.

## Summary

Follow-up audit after #987 fixed the int32 pointer-arithmetic overflow in `_chunk_cumsum_fwd_kernel`/`_chunk_cumsum_bwd_kernel`. The same unguarded `pid_* * chunk_size * stride_*_seqlen`-style chained multiplication, with an uncast 32-bit leading operand, turned out to exist in essentially every other `pid_bc`/`pid_c`/`pid_ch`-indexed kernel in the Triton ops:

- `ssd_chunk_state.py` — the remaining kernels: `_chunk_state_fwd_kernel`, `_chunk_state_bwd_dx_kernel`, `_chunk_state_bwd_db_kernel`, `_chunk_state_bwd_ddAcs_stable_kernel`, `_chunk_state_varlen_kernel`
- `ssd_chunk_scan.py` — all eleven `pid_bc`-indexed kernels
- `ssd_combined.py` — the fused kernel
- `ssd_bmm.py` — both kernels

Same fix in each case: cast the leading program-id-derived index to `tl.int64` immediately after it's obtained, mirroring the fix in #987.

**A related but distinct instance of the same overflow class** turned up in `layer_norm.py`, `layernorm_gated.py`, and `k_activations.py`: these kernels compute `row * stride_x_row` where `row = tl.program_id(0)` ranges over all flattened rows (`batch*seqlen`), and `stride_x_row` is the row's width (hidden dim). Unlike the chunk-indexed kernels, this doesn't need a non-contiguous view to overflow — an ordinarily *contiguous* `(M, N)` input is enough once `M * N` exceeds `2**31 - 1`, since `row` alone ranges up to `M-1`. Same fix: cast `row`/`row_block_id` to `tl.int64` right after `tl.program_id()`.

Every finding here was confirmed as a **real, reproducible crash** (not just a theoretical read of the code) before being fixed:

- `mamba_chunk_scan_combined`, called with `x` sliced non-contiguously out of a wide parent tensor (same shape as the original #987 bug report), crashed with the identical `Triton Error [CUDA]: an illegal memory access was encountered` pre-fix — tracing into `_chunk_state_fwd_kernel`, a kernel #987 didn't touch. Passes post-fix.
- `layernorm_fn` (RMSNorm path) on a contiguous `(115_866, 18_560)` input crashed identically pre-fix, passes post-fix.

## Not fixed here, flagged for follow-up

- `ssd_state_passing.py` has `(nchunks - 1) * stride_*_chunk` with an uncast `nchunks`, structurally the same class of risk, but `nchunks` isn't program-id-derived and `stride_*_chunk` is a state-tensor stride (`nheads * headdim`-ish) rather than a wide/sliceable seqlen stride — I couldn't construct a concrete overflow scenario for it, so I'm flagging it rather than speculatively patching it.
- `selective_state_update.py` only multiplies `pid_b`/`pid_h` against batch/head strides for single-token inference state updates — lower risk, not touched.
- `mamba_ssm/ops/triton/mamba3/` (a separate, newer subsystem) uses `pid_chunk * stride_*_chunk` as a single multiplication against a chunk-dim stride, not a chained product through a wide seqlen stride — a different shape of risk that I haven't audited in depth.

## Test plan

- [x] Added `test_mamba_chunk_scan_combined_noncontiguous_wide_view_no_overflow` in `tests/ops/triton/test_ssd.py` — exercises the `ssd_chunk_state.py`, `ssd_chunk_scan.py`, `ssd_combined.py`, and `ssd_bmm.py` fixes together via the full `mamba_chunk_scan_combined` path. Verified it fails with the illegal-memory-access error on the unpatched kernels and passes with the fix.
- [x] Added `test_layer_norm_gated_large_row_count_no_overflow` in `tests/ops/triton/test_layernorm_gated.py`. Verified it fails identically pre-fix and passes post-fix.