### PR TITLE
fix: force TileLang-contiguous inputs for Mamba3 MIMO

### DIFF
--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
@@ -62,8 +62,22 @@ class _Mamba3Function(torch.autograd.Function):
         ctx.dtype = dtype
         ctx.fuse_pregate_headwise_rms_norm = fuse_pregate_headwise_rms_norm
         ctx.outproj_norm_eps = outproj_norm_eps
+
+        def _ensure_tilelang_contiguous(t: Optional[Tensor]) -> Optional[Tensor]:
+            """Make tensor truly contiguous with last-stride=1.
+
+            PyTorch's .contiguous() treats a size-1 trailing dimension as contiguous even when
+            stride(-1) != 1 (e.g. after transpose). TileLang kernels require physical stride 1.
+            """
+            if t is None:
+                return None
+            t = t.contiguous()
+            if t.stride(-1) != 1:
+                t = torch.empty(t.shape, device=t.device, dtype=t.dtype).copy_(t)
+            return t
+
         (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z) = tuple(
-            t.contiguous() if t is not None else None
+            _ensure_tilelang_contiguous(t)
             for t in (
                 Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z,
             )

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
@@ -21,11 +21,13 @@ from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_fwd_varlen import mamba_mimo_forw
 
 from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_bwd import mamba_mimo_bwd_combined
 from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo_bwd_varlen import mamba_mimo_bwd_combined_varlen
+from mamba_ssm.ops.tilelang.mamba3.tilelang_layout import ensure_tilelang_contiguous
 
 
 # =============================================================================
 # Autograd Function
 # =============================================================================
+
 
 class _Mamba3Function(torch.autograd.Function):
     """Custom autograd function for Mamba-3 with Triton/Tilelang kernels."""
@@ -63,21 +65,8 @@ class _Mamba3Function(torch.autograd.Function):
         ctx.fuse_pregate_headwise_rms_norm = fuse_pregate_headwise_rms_norm
         ctx.outproj_norm_eps = outproj_norm_eps
 
-        def _ensure_tilelang_contiguous(t: Optional[Tensor]) -> Optional[Tensor]:
-            """Make tensor truly contiguous with last-stride=1.
-
-            PyTorch's .contiguous() treats a size-1 trailing dimension as contiguous even when
-            stride(-1) != 1 (e.g. after transpose). TileLang kernels require physical stride 1.
-            """
-            if t is None:
-                return None
-            t = t.contiguous()
-            if t.stride(-1) != 1:
-                t = torch.empty(t.shape, device=t.device, dtype=t.dtype).copy_(t)
-            return t
-
         (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z) = tuple(
-            _ensure_tilelang_contiguous(t)
+            ensure_tilelang_contiguous(t)
             for t in (
                 Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z,
             )

--- a/mamba_ssm/ops/tilelang/mamba3/tilelang_layout.py
+++ b/mamba_ssm/ops/tilelang/mamba3/tilelang_layout.py
@@ -1,0 +1,23 @@
+"""Shared TileLang tensor layout helpers."""
+
+from __future__ import annotations
+
+from typing import Optional
+
+import torch
+from torch import Tensor
+
+
+def ensure_tilelang_contiguous(t: Optional[Tensor]) -> Optional[Tensor]:
+    """Make tensor truly contiguous with last-stride=1.
+
+    PyTorch's `.contiguous()` treats a size-1 trailing dimension as contiguous even
+    when `stride(-1) != 1` (e.g. after transpose). TileLang kernels require physical
+    stride 1 — without this, Mamba3 MIMO `forward` fails at `seqlen=1` (#985).
+    """
+    if t is None:
+        return None
+    t = t.contiguous()
+    if t.stride(-1) != 1:
+        t = torch.empty(t.shape, device=t.device, dtype=t.dtype).copy_(t)
+    return t

--- a/tests/modules/test_mamba3_varlen.py
+++ b/tests/modules/test_mamba3_varlen.py
@@ -116,3 +116,15 @@ def test_mamba3_varlen_backward(is_mimo):
         if param.requires_grad:
             assert param.grad is not None, f"No gradient for param {name}"
             assert torch.isfinite(param.grad).all(), f"Non-finite gradient for param {name}"
+
+
+@pytest.mark.parametrize("is_mimo", [True])
+def test_mamba3_mimo_forward_seqlen_one(is_mimo):
+    """MIMO forward must accept (B, 1, D) — regression for #985 / stride(-1)!=1."""
+    _require_cuda()
+    torch.manual_seed(0)
+    model = _make_model(is_mimo=is_mimo)
+    x = torch.randn(2, 1, model.d_model, device="cuda", dtype=torch.bfloat16)
+    with torch.no_grad():
+        y = model(x)
+    assert y.shape == x.shape

--- a/tests/ops/tilelang/test_tilelang_contiguous.py
+++ b/tests/ops/tilelang/test_tilelang_contiguous.py
@@ -2,7 +2,7 @@
 
 import torch
 
-from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo import ensure_tilelang_contiguous
+from mamba_ssm.ops.tilelang.mamba3.tilelang_layout import ensure_tilelang_contiguous
 
 
 def test_ensure_tilelang_contiguous_none():

--- a/tests/ops/tilelang/test_tilelang_contiguous.py
+++ b/tests/ops/tilelang/test_tilelang_contiguous.py
@@ -1,0 +1,38 @@
+"""CPU tests for TileLang contiguity helper used by Mamba3 MIMO (#985)."""
+
+import torch
+
+from mamba_ssm.ops.tilelang.mamba3.mamba3_mimo import ensure_tilelang_contiguous
+
+
+def test_ensure_tilelang_contiguous_none():
+    assert ensure_tilelang_contiguous(None) is None
+
+
+def test_ensure_tilelang_contiguous_already_ok():
+    t = torch.randn(2, 3, 4)
+    out = ensure_tilelang_contiguous(t)
+    assert out is not None
+    assert out.stride(-1) == 1
+    assert out.shape == t.shape
+
+
+def test_ensure_tilelang_contiguous_fixes_size1_trailing_stride():
+    # Transpose so the last dim has size 1 but stride(-1) != 1 after .contiguous()'s
+    # false-positive "already contiguous" for size-1 dims — construct explicitly.
+    base = torch.randn(2, 4, 1)
+    weird = base.transpose(1, 2)  # (2, 1, 4) — last stride is fine
+    # Build (B, D, 1) view whose last stride is not 1:
+    src = torch.randn(2, 8)
+    view = src[:, :1]  # shape (2, 1), often stride (8, 1) which is ok
+    # Force non-unit last stride: as_strided
+    t = torch.as_strided(src, size=(2, 3, 1), stride=(8, 1, 2))
+    assert t.shape[-1] == 1
+    # .contiguous() may still leave stride(-1) != 1 for size-1 trailing dims
+    c = t.contiguous()
+    # Regardless of contiguous() quirks, helper must guarantee stride(-1)==1
+    out = ensure_tilelang_contiguous(t)
+    assert out is not None
+    assert out.shape == t.shape
+    assert out.stride(-1) == 1
+    assert torch.allclose(out, t)

--- a/tests/ops/tilelang/test_tilelang_contiguous.py
+++ b/tests/ops/tilelang/test_tilelang_contiguous.py
@@ -1,8 +1,16 @@
 """CPU tests for TileLang contiguity helper used by Mamba3 MIMO (#985)."""
 
+import importlib.util
+from pathlib import Path
+
 import torch
 
-from mamba_ssm.ops.tilelang.mamba3.tilelang_layout import ensure_tilelang_contiguous
+_LAYOUT = Path(__file__).resolve().parents[3] / "mamba_ssm/ops/tilelang/mamba3/tilelang_layout.py"
+_spec = importlib.util.spec_from_file_location("tilelang_layout", _LAYOUT)
+_mod = importlib.util.module_from_spec(_spec)
+assert _spec.loader is not None
+_spec.loader.exec_module(_mod)
+ensure_tilelang_contiguous = _mod.ensure_tilelang_contiguous
 
 
 def test_ensure_tilelang_contiguous_none():
@@ -18,19 +26,9 @@ def test_ensure_tilelang_contiguous_already_ok():
 
 
 def test_ensure_tilelang_contiguous_fixes_size1_trailing_stride():
-    # Transpose so the last dim has size 1 but stride(-1) != 1 after .contiguous()'s
-    # false-positive "already contiguous" for size-1 dims — construct explicitly.
-    base = torch.randn(2, 4, 1)
-    weird = base.transpose(1, 2)  # (2, 1, 4) — last stride is fine
-    # Build (B, D, 1) view whose last stride is not 1:
     src = torch.randn(2, 8)
-    view = src[:, :1]  # shape (2, 1), often stride (8, 1) which is ok
-    # Force non-unit last stride: as_strided
     t = torch.as_strided(src, size=(2, 3, 1), stride=(8, 1, 2))
     assert t.shape[-1] == 1
-    # .contiguous() may still leave stride(-1) != 1 for size-1 trailing dims
-    c = t.contiguous()
-    # Regardless of contiguous() quirks, helper must guarantee stride(-1)==1
     out = ensure_tilelang_contiguous(t)
     assert out is not None
     assert out.shape == t.shape


### PR DESCRIPTION
## Summary
- Force physical last-stride=1 after `.contiguous()` before TileLang MIMO kernels.
- Fixes forward crash at `seqlen=1` where PyTorch still reports contiguous despite `stride(-1) != 1`.

Fixes #985

## Test plan
- [ ] `Mamba3(..., is_mimo=True)(x)` with `x.shape == (B, 1, D)` on CUDA