### PR TITLE
fix: pin apache-tvm-ffi below 0.1.10 for tilelang 0.1.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ classifiers = [
 dependencies = [
     "torch",
     "tilelang==0.1.8",
-    "apache-tvm-ffi<=0.1.12",
+    "apache-tvm-ffi<0.1.10",
     "quack-kernels>=0.3.4",
     "triton>=3.5.0",
     "ninja",

--- a/setup.py
+++ b/setup.py
@@ -400,7 +400,7 @@ setup(
         "triton>=3.5.0",
         "transformers",
         "tilelang==0.1.8",
-        "apache-tvm-ffi<=0.1.12",
+        "apache-tvm-ffi<0.1.10",
         "quack-kernels>=0.3.4",
         # "causal_conv1d>=1.4.0",
     ],


### PR DESCRIPTION
## Summary
- With `tilelang==0.1.8`, `apache-tvm-ffi` 0.1.10+ breaks import/compile.
- Cap at `<0.1.10` (0.1.9 works).

Fixes #986

## Test plan
- [ ] `pip install` resolves `apache-tvm-ffi<0.1.10`
- [ ] `import mamba_ssm` / tilelang MIMO smoke

Made with [Cursor](https://cursor.com)