### PR TITLE
ci: publish wheels for torch 2.11, 2.12.1, and 2.13.0

### DIFF
--- a/.github/workflows/_build.yml
+++ b/.github/workflows/_build.yml
@@ -108,6 +108,9 @@ jobs:
               '2.8': [126, 128, 129], \
               '2.9': [126, 128, 130], \
               '2.10': [126, 128, 130], \
+              '2.11': [126, 128, 129, 130], \
+              '2.12': [126, 128, 129, 130], \
+              '2.13': [126, 128, 129, 130], \
             }[env['MATRIX_TORCH_VERSION']]; \
             sys_cuda = int(env['MATRIX_CUDA_VERSION']); \
             print(max(v for v in available if v <= sys_cuda))" \

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,7 +41,7 @@ jobs:
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
-        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0"]
+        torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0", "2.11.0", "2.12.1", "2.13.0"]
         cuda-version: ["11.8.0", "12.9.1", "13.0.1"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.
         # Pytorch wheels currently don't use it, but nvcr images have Pytorch compiled with C++11 ABI.
@@ -55,6 +55,12 @@ jobs:
           - torch-version: "2.9.1"
             cuda-version: "11.8.0"
           - torch-version: "2.10.0"
+            cuda-version: "11.8.0"
+          - torch-version: "2.11.0"
+            cuda-version: "11.8.0"
+          - torch-version: "2.12.1"
+            cuda-version: "11.8.0"
+          - torch-version: "2.13.0"
             cuda-version: "11.8.0"
           # CUDA 13.0 is only supported by PyTorch 2.9+
           - torch-version: "2.6.0"
@@ -77,6 +83,12 @@ jobs:
           - torch-version: "2.9.1"
             cxx11_abi: "FALSE"
           - torch-version: "2.10.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.11.0"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.12.1"
+            cxx11_abi: "FALSE"
+          - torch-version: "2.13.0"
             cxx11_abi: "FALSE"
     uses: ./.github/workflows/_build.yml
     with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -41,6 +41,8 @@ jobs:
         # manylinux docker image, but I haven't figured out how to install CUDA on manylinux.
         os: [ubuntu-22.04, ubuntu-22.04-arm]
         python-version: ["3.10", "3.11", "3.12", "3.13"]
+        # Keep in sync with setup.py get_wheel_url() torch major.minor tags.
+        # New torch minors require a tagged release to publish matching wheels (#999).
         torch-version: ["2.6.0", "2.7.1", "2.8.0", "2.9.1", "2.10.0", "2.11.0", "2.12.1", "2.13.0"]
         cuda-version: ["11.8.0", "12.9.1", "13.0.1"]
         # We need separate wheels that either uses C++11 ABI (-D_GLIBCXX_USE_CXX11_ABI) or not.

--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ Install PyTorch first. By default, `mamba-ssm` installs the core package without
 | CUDA selective scan opt-in | `MAMBA_KEEP_CUDA_BUILD=TRUE pip install mamba-ssm --no-build-isolation` | Installs `selective_scan_cuda`; pip first tries a matching prebuilt CUDA/HIP wheel, then compiles locally if no wheel is available. |
 | Force local CUDA selective scan build | `MAMBA_FORCE_BUILD=TRUE MAMBA_KEEP_CUDA_BUILD=TRUE pip install mamba-ssm --no-build-isolation` | Skips cached wheels and compiles `selective_scan_cuda` locally. |
 
+Prebuilt CUDA wheels (when using `MAMBA_KEEP_CUDA_BUILD=TRUE`) are published on
+[GitHub releases](https://github.com/state-spaces/mamba/releases) for select
+torch/CUDA/Python/platform combinations. The release CI matrix in
+`.github/workflows/publish.yaml` defines which torch versions are built; if your
+stack is newer than the latest release (e.g. torch 2.11+ on Colab), pip falls
+back to a local `selective_scan_cuda` compile with no warning beyond setup logs.
+
 `--no-build-isolation` is required for CUDA builds so that pip uses your existing CUDA-enabled
 PyTorch instead of installing torch-cpu in an isolated build environment.
 


### PR DESCRIPTION
## Summary
- Extend `.github/workflows/publish.yaml` to build release wheels for torch 2.11.0, 2.12.1, and 2.13.0 with CUDA 11.8 excludes and CXX11_ABI excludes (#999).
- Document in README how prebuilt wheel coverage tracks the release matrix.
- Add maintainer comment linking the matrix to `setup.py` wheel URL tags.

## Test plan
- [ ] Requires a tagged release to exercise the expanded matrix in CI
- [x] YAML/matrix diff reviewed against existing exclude rules


Made with [Cursor](https://cursor.com)