### PR TITLE
[BugFix] mamba3: access ctx.saved_tensors exactly once in backward (fixes gradient checkpointing)

### DIFF
--- a/mamba_ssm/modules/mamba3.py
+++ b/mamba_ssm/modules/mamba3.py
@@ -207,6 +207,11 @@ class Mamba3(nn.Module):
         
         # Apply Mamba-3 kernel
         if self.is_mimo:
+            input_states = (
+                (angle_dt_state, ssm_state, k_state, v_state)
+                if ssm_state is not None
+                else None
+            )
             y = mamba3_mimo_combined(
                 Q=C,
                 K=B,
@@ -226,6 +231,7 @@ class Mamba3(nn.Module):
                 rotary_dim_divisor=self.rotary_dim_divisor,
                 dtype=x.dtype,
                 return_state=ssm_state is not None,
+                Input_States=input_states,
                 cu_seqlens=cu_seqlens,
                 fuse_pregate_headwise_rms_norm=self.fuse_pregate_headwise_norm,
                 outproj_norm_weight=self.norm.weight if self.fuse_pregate_headwise_norm else None,
@@ -246,6 +252,11 @@ class Mamba3(nn.Module):
                 y = torch.einsum("blrhp,hrp->blhp", y, self.mimo_o)
             y = rearrange(y, "b l h p -> b l (h p)")
         else:
+            input_states = (
+                (angle_dt_state, ssm_state, k_state.squeeze(1), v_state)
+                if ssm_state is not None
+                else None
+            )
             y = mamba3_siso_combined(
                 Q=C.squeeze(2),
                 K=B.squeeze(2),
@@ -259,7 +270,7 @@ class Mamba3(nn.Module):
                 D=self.D,
                 Z=z if not self.is_outproj_norm else None,
                 chunk_size=self.chunk_size,
-                Input_States=None,
+                Input_States=input_states,
                 return_final_states=ssm_state is not None,
                 cu_seqlens=cu_seqlens,
             )

--- a/mamba_ssm/ops/cute/mamba3/mamba3_step_fn.py
+++ b/mamba_ssm/ops/cute/mamba3/mamba3_step_fn.py
@@ -46,7 +46,7 @@ def get_gmem_tiled_copy(dtype: Type[cutlass.Numeric], major_mode_size: int, num_
 
 
 class Mamba3Step():
-    def __init__(self, tile_D: int, dstate: int, mimo: int = 1, num_warps: int = 4, remove_gate: bool = False, remove_outproj: bool = False):
+    def __init__(self, tile_D: int, dstate: int, mimo: int = 1, num_warps: int = 4, remove_gate: bool = False, remove_outproj: bool = False, update_kv_state: bool = False):
         assert num_warps >= 2
         assert dstate % 8 == 0, "dstate must be multiple of 8" # for vectorized load /store
         self.tile_D = tile_D
@@ -55,6 +55,12 @@ class Mamba3Step():
         self.num_warps = num_warps
         self.remove_gate = remove_gate
         self.remove_outproj = remove_outproj
+        # When True (indexed mode only), the kernel stores the new key/value
+        # states (its B and x inputs) into mBstate/mXstate after consuming the
+        # old values — saves the caller's separate scatter kernels. Requires a
+        # single D-tile per (b, h) (tile_D >= D), otherwise the bidd=0 CTA's
+        # Bstate write would race other CTAs' reads.
+        self.update_kv_state = update_kv_state
 
     def _setup_smem_layouts(self):
         self.sState_layout = cute.make_ordered_layout((self.tile_D, self.dstate), order=(1, 0))
@@ -102,6 +108,10 @@ class Mamba3Step():
         mOut: cute.Tensor,  # (B, H, D) or (B, R, H, D) if remove_outproj
         mZ: Optional[cute.Tensor],  # (B, H, D), None if remove_gate
         mZproj: Optional[cute.Tensor],  # (R, H, D), None if remove_gate
+        mStateBatchIdx: Optional[cute.Tensor],  # (B,) int32 — row of the state pools
+        # for each batch element; when given, mState/mStateOut/mBstate/mXstate
+        # are pools of shape (P, ...) indexed indirectly (avoids the PyTorch
+        # gather/scatter round-trip on the SSM state).
         stream: cuda.CUstream,
     ):
         self.dtype = mState.element_type
@@ -206,6 +216,7 @@ class Mamba3Step():
             mOut,
             mZ,
             mZproj,
+            mStateBatchIdx,
             self.sState_layout,
             self.sBC_layout,
             self.sProj_layout,
@@ -217,8 +228,9 @@ class Mamba3Step():
             tiled_copy_B_s2r,
             vecsize_dstate,
         ).launch(
-            # grid: (d, h, b)
-            grid=[cute.ceil_div(mState.shape[2], self.tile_D), mState.shape[1], mState.shape[0]],
+            # grid: (d, h, b) — batch from mX (mState may be a larger pool
+            # when mStateBatchIdx is used)
+            grid=[cute.ceil_div(mState.shape[2], self.tile_D), mState.shape[1], mX.shape[0]],
             block=[num_threads, 1, 1],
             stream=stream,
         )
@@ -242,6 +254,7 @@ class Mamba3Step():
         mOut: cute.Tensor,  # (B, H, D) or (B, R, H, D) if remove_outproj
         mZ: Optional[cute.Tensor],  # (B, H, D), None if remove_gate
         mZproj: Optional[cute.Tensor],  # (R, H, D), None if remove_gate
+        mStateBatchIdx: Optional[cute.Tensor],  # (B,) int32 pool-row indices
         sState_layout: cute.Layout | cute.ComposedLayout,
         sBC_layout: cute.Layout | cute.ComposedLayout,
         sProj_layout: cute.Layout | cute.ComposedLayout,
@@ -260,24 +273,39 @@ class Mamba3Step():
 
         limit_d = mState.shape[2]
 
+        # Pool-row index for the state tensors (indirect when mStateBatchIdx given).
+        # Batch padding (e.g. vLLM CUDA-graph capture sizes) uses negative
+        # indices (PAD_SLOT_ID = -1): clamp the row for the loads and suppress
+        # the state write so padded lanes never touch a real pool row.
+        valid_st = Boolean(True)
+        if const_expr(mStateBatchIdx is not None):
+            idx_val = Int32(mStateBatchIdx[bidb])
+            valid_st = idx_val >= Int32(0)
+            bidb_st = idx_val
+            if not valid_st:
+                bidb_st = Int32(0)
+        else:
+            bidb_st = bidb
+
         # ///////////////////////////////////////////////////////////////////////////////
         #  Slice for CTA
         # ///////////////////////////////////////////////////////////////////////////////
         # (tile_D, N)
         gState, gStateOut = [
-            cute.local_tile(t[bidb, bidh, None, None], (self.tile_D, self.dstate), (bidd, 0))
+            cute.local_tile(t[bidb_st, bidh, None, None], (self.tile_D, self.dstate), (bidd, 0))
             for t in (mState, mStateOut)
         ]
         # (R, N)
-        gBstate, gB, gC = [
+        gBstate = cute.local_tile(
+            mBstate[bidb_st, None, bidh, None], (self.mimo, self.dstate), (0, 0)
+        )
+        gB, gC = [
             cute.local_tile(t[bidb, None, bidh, None], (self.mimo, self.dstate), (0, 0))
-            for t in (mBstate, mB, mC)
+            for t in (mB, mC)
         ]
         # (tile_D,)
-        gXstate, gX = [
-            cute.local_tile(t[bidb, bidh, None], (self.tile_D,), (bidd,))
-            for t in (mXstate, mX)
-        ]
+        gXstate = cute.local_tile(mXstate[bidb_st, bidh, None], (self.tile_D,), (bidd,))
+        gX = cute.local_tile(mX[bidb, bidh, None], (self.tile_D,), (bidd,))
         if const_expr(mOutproj is not None):
             # Output is (B, H, D), outproj reduces MIMO rank
             gOut = cute.local_tile(mOut[bidb, bidh, None], (self.tile_D,), (bidd,))
@@ -482,7 +510,11 @@ class Mamba3Step():
         cute.arch.cp_async_commit_group()
 
         # Write state back to StateOut (may be same memory as State for in-place)
-        cute.copy(tiled_copy_state_s2r, tSrS, tSgSOut)
+        if const_expr(mStateBatchIdx is not None):
+            if valid_st:
+                cute.copy(tiled_copy_state_s2r, tSrS, tSgSOut)
+        else:
+            cute.copy(tiled_copy_state_s2r, tSrS, tSgSOut)
 
         # Do state @ C
         cute.arch.cp_async_wait_group(1)  # C is done loading
@@ -530,6 +562,22 @@ class Mamba3Step():
         cute.arch.cp_async_wait_group(0)  # Zproj and Outproj are done loading
         cute.arch.sync_threads()
 
+        # Store the new key/value states (this step's B and x) into the pools,
+        # now that every thread has consumed the old Bstate/Xstate. Single
+        # D-tile per (b, h) is guaranteed by the wrapper (tile_D >= D), so no
+        # other CTA still reads these rows. tSrB / tXrX hold the original
+        # (pre-fp32) values, so the store is bit-exact with the caller-side
+        # `k_pool[slots] = B; v_pool[slots] = x` it replaces.
+        if const_expr(self.update_kv_state and mStateBatchIdx is not None):
+            if valid_st:
+                tpd_b = self.dstate // vecsize_dstate
+                if tidx < tpd_b:
+                    tSgBstate_w = smem_thr_copy_B.partition_S(gBstate)[None, None, 0]
+                    cute.autovec_copy(tSrB, tSgBstate_w)
+                if warp_idx == 0:
+                    if not need_bound_check_X or lane_idx < num_loads_X:
+                        cute.autovec_copy(tXrX, tXgXstate)
+
         if const_expr(mOutproj is not None):
             # Gate: z_r * sigmoid(z_r)
             if const_expr(mZ is not None):
@@ -552,6 +600,11 @@ class Mamba3Step():
                 else:
                     out_val += out[r] * out_proj_val
 
+            # Skip padding tokens: zero the output (selective_state_update
+            # does the same for state_batch_indices < 0).
+            if const_expr(mStateBatchIdx is not None):
+                if not valid_st:
+                    out_val = Float32(0.0)
             # Write final output (B, H, D)
             if lane_idx < lanes_per_D:
                 gOut[warp_idx * lanes_per_D + lane_idx] = out_val.to(mOut.element_type)
@@ -559,8 +612,13 @@ class Mamba3Step():
             # No outproj: write per-rank output (B, R, H, D)
             for r in cutlass.range_constexpr(self.mimo):
                 gOut_r = cute.local_tile(mOut[bidb, r, bidh, None], (self.tile_D,), (bidd,))
+                out_r_val = out[r]
+                # Skip padding tokens (see above).
+                if const_expr(mStateBatchIdx is not None):
+                    if not valid_st:
+                        out_r_val = Float32(0.0)
                 if lane_idx < lanes_per_D:
-                    gOut_r[warp_idx * lanes_per_D + lane_idx] = out[r].to(mOut.element_type)
+                    gOut_r[warp_idx * lanes_per_D + lane_idx] = out_r_val.to(mOut.element_type)
 
 
 def mamba3_step_fn(
@@ -581,17 +639,42 @@ def mamba3_step_fn(
     out: Tensor = None,  # (B, H, D) or (B, R, H, D) if remove_outproj
     z: Optional[Tensor] = None,  # (B, H, D), None if remove_gate
     zproj: Optional[Tensor] = None,  # (R, H, D), None if remove_gate
+    state_batch_indices: Optional[Tensor] = None,  # (B,) int32 — when given,
+    # state/Bstate/Xstate are pools of shape (P, ...) and row
+    # state_batch_indices[b] holds batch element b's state. The state is updated
+    # in place in the pool (state_out must be None). Avoids gather/scatter.
+    update_kv_state: bool = False,  # kernel also stores this step's B and x
+    # into Bstate/Xstate after consuming the old values, replacing the
+    # caller's scatter kernels. Requires state_batch_indices and tile_D >= headdim
+    # (a single D-tile per (b, h): the Bstate write would race other CTAs'
+    # reads otherwise). NOTE: mutates Bstate/Xstate.
     tile_D: int = 64,
     num_warps: int = 2,
 ) -> None:
     has_z = z is not None
     has_outproj = outproj is not None
+    has_state_batch_idx = state_batch_indices is not None
     inplace = state_out is None
-    batch, nheads, hdim, dstate = state.shape
+    pool, nheads, hdim, dstate = state.shape
+    if update_kv_state:
+        assert has_state_batch_idx, "update_kv_state requires state_batch_indices"
+        assert tile_D >= hdim, (
+            f"update_kv_state requires a single D-tile per (b, h) "
+            f"(tile_D={tile_D} >= headdim={hdim}); with multiple D-tiles the "
+            f"bidd=0 CTA's Bstate write would race other CTAs' reads"
+        )
     mimo = Bstate.shape[1]
-    assert state.shape == (batch, nheads, hdim, dstate)
-    assert Bstate.shape == (batch, mimo, nheads, dstate)
-    assert Xstate.shape == (batch, nheads, hdim)
+    batch = x.shape[0]
+    if has_state_batch_idx:
+        assert inplace, "state_batch_indices requires in-place update (state_out=None)"
+        assert state_batch_indices.shape == (batch,)
+        assert state_batch_indices.dtype == torch.int32
+        assert state_batch_indices.is_cuda
+    else:
+        assert pool == batch
+    assert state.shape == (pool, nheads, hdim, dstate)
+    assert Bstate.shape == (pool, mimo, nheads, dstate)
+    assert Xstate.shape == (pool, nheads, hdim)
     assert A.shape == (batch, nheads)
     assert B.shape == (batch, mimo, nheads, dstate)
     assert C.shape == (batch, mimo, nheads, dstate)
@@ -615,7 +698,7 @@ def mamba3_step_fn(
     if inplace:
         state_out = state
     else:
-        assert state_out.shape == (batch, nheads, hdim, dstate)
+        assert state_out.shape == (pool, nheads, hdim, dstate)
 
     required_tensors = [state, Bstate, Xstate, A, B, C, D, x, dt, trap, xproj, state_out, out]
     if has_outproj:
@@ -650,13 +733,17 @@ def mamba3_step_fn(
         trap.dtype,
         has_z,
         has_outproj,
+        has_state_batch_idx,
+        update_kv_state,
     )
     if compile_key not in mamba3_step_fn.compile_cache:
-        mamba3_step_op = Mamba3Step(tile_D, dstate, mimo, num_warps, remove_gate=not has_z, remove_outproj=not has_outproj)
+        mamba3_step_op = Mamba3Step(tile_D, dstate, mimo, num_warps, remove_gate=not has_z, remove_outproj=not has_outproj, update_kv_state=update_kv_state)
 
         # Create symbolic dimensions for batch and nheads
         batch_sym = cute.sym_int()
         nheads_sym = cute.sym_int()
+        # Pool row count is independent of batch when state_batch_indices is used
+        pool_sym = cute.sym_int() if has_state_batch_idx else batch_sym
 
         # Divisibility for strides (128-bit alignment)
         div_state = 128 // state_cute_dtype.width
@@ -669,9 +756,9 @@ def mamba3_step_fn(
         div_trap = 128 // trap_cute_dtype.width
 
         # Create fake tensors with symbolic batch/nheads dimensions
-        state_fake = make_fake_tensor(state_cute_dtype, (batch_sym, nheads_sym, hdim, dstate), div_state)
-        Bstate_fake = make_fake_tensor(b_cute_dtype, (batch_sym, mimo, nheads_sym, dstate), div_b)
-        Xstate_fake = make_fake_tensor(x_cute_dtype, (batch_sym, nheads_sym, hdim), div_x)
+        state_fake = make_fake_tensor(state_cute_dtype, (pool_sym, nheads_sym, hdim, dstate), div_state)
+        Bstate_fake = make_fake_tensor(b_cute_dtype, (pool_sym, mimo, nheads_sym, dstate), div_b)
+        Xstate_fake = make_fake_tensor(x_cute_dtype, (pool_sym, nheads_sym, hdim), div_x)
         A_fake = make_fake_tensor(a_cute_dtype, (batch_sym, nheads_sym), div_a)
         B_fake = make_fake_tensor(b_cute_dtype, (batch_sym, mimo, nheads_sym, dstate), div_b)
         C_fake = make_fake_tensor(b_cute_dtype, (batch_sym, mimo, nheads_sym, dstate), div_b)
@@ -681,13 +768,16 @@ def mamba3_step_fn(
         trap_fake = make_fake_tensor(trap_cute_dtype, (batch_sym, nheads_sym), div_trap)
         xproj_fake = make_fake_tensor(proj_cute_dtype, (mimo, nheads_sym, hdim), div_proj)
         outproj_fake = make_fake_tensor(proj_cute_dtype, (mimo, nheads_sym, hdim), div_proj) if has_outproj else None
-        state_out_fake = make_fake_tensor(state_cute_dtype, (batch_sym, nheads_sym, hdim, dstate), div_state)
+        state_out_fake = make_fake_tensor(state_cute_dtype, (pool_sym, nheads_sym, hdim, dstate), div_state)
         if has_outproj:
             out_fake = make_fake_tensor(x_cute_dtype, (batch_sym, nheads_sym, hdim), div_x)
         else:
             out_fake = make_fake_tensor(x_cute_dtype, (batch_sym, mimo, nheads_sym, hdim), div_x)
         z_fake = make_fake_tensor(x_cute_dtype, (batch_sym, nheads_sym, hdim), div_x) if has_z else None
         zproj_fake = make_fake_tensor(proj_cute_dtype, (mimo, nheads_sym, hdim), div_proj) if has_z else None
+        state_batch_idx_fake = (
+            make_fake_tensor(Int32, (batch_sym,)) if has_state_batch_idx else None
+        )
 
         fake_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
@@ -709,6 +799,7 @@ def mamba3_step_fn(
             out_fake,
             z_fake,
             zproj_fake,
+            state_batch_idx_fake,
             fake_stream,
             options="--enable-tvm-ffi",
         )
@@ -732,6 +823,7 @@ def mamba3_step_fn(
         out,
         z,
         zproj,
+        state_batch_indices,
     )
 
 

--- a/mamba_ssm/ops/cute/mamba3/mamba3_step_fn.py
+++ b/mamba_ssm/ops/cute/mamba3/mamba3_step_fn.py
@@ -46,7 +46,7 @@ def get_gmem_tiled_copy(dtype: Type[cutlass.Numeric], major_mode_size: int, num_
 
 
 class Mamba3Step():
-    def __init__(self, tile_D: int, dstate: int, mimo: int = 1, num_warps: int = 4, remove_gate: bool = False, remove_outproj: bool = False, update_kv_state: bool = False):
+    def __init__(self, tile_D: int, dstate: int, mimo: int = 1, num_warps: int = 4, remove_gate: bool = False, remove_outproj: bool = False, update_kv_state: bool = False, rotary_dim: int = 0):
         assert num_warps >= 2
         assert dstate % 8 == 0, "dstate must be multiple of 8" # for vectorized load /store
         self.tile_D = tile_D
@@ -61,6 +61,12 @@ class Mamba3Step():
         # single D-tile per (b, h) (tile_D >= D), otherwise the bidd=0 CTA's
         # Bstate write would race other CTAs' reads.
         self.update_kv_state = update_kv_state
+        # When rotary_dim > 0, the kernel applies bias + rotary to its B/C
+        # inputs itself (and updates the per-(b,h) angle state row in the
+        # pool): callers pass PRE-rotation B/C (typically head-broadcast,
+        # stride 0 on H) and never materialize the per-head rotated tensors.
+        self.rotary_dim = rotary_dim
+        self.fuse_rotary = rotary_dim > 0
 
     def _setup_smem_layouts(self):
         self.sState_layout = cute.make_ordered_layout((self.tile_D, self.dstate), order=(1, 0))
@@ -112,6 +118,10 @@ class Mamba3Step():
         # for each batch element; when given, mState/mStateOut/mBstate/mXstate
         # are pools of shape (P, ...) indexed indirectly (avoids the PyTorch
         # gather/scatter round-trip on the SSM state).
+        mBiasQ: Optional[cute.Tensor],  # (R, H, N) — fused-rotary C bias
+        mBiasK: Optional[cute.Tensor],  # (R, H, N) — fused-rotary B bias
+        mAngleProj: Optional[cute.Tensor],  # (B, H, rotary_dim/2)
+        mAnglePool: Optional[cute.Tensor],  # (P, H, rotary_dim/2) fp32, in/out
         stream: cuda.CUstream,
     ):
         self.dtype = mState.element_type
@@ -162,6 +172,11 @@ class Mamba3Step():
 
         sZproj_size = cute.cosize(self.sProj_layout) if not self.remove_gate else 0
         sOutproj_size = cute.cosize(self.sProj_layout) if not self.remove_outproj else 0
+        # Fused-rotary: the new per-(b,h) angles are computed once into smem
+        # and consumed by both the B and C rotations; the pool row is only
+        # written at the very end of the kernel (an early in-place store races
+        # compiler-rematerialized reloads — learned the hard way).
+        sAngles_size = (self.rotary_dim // 2) if self.fuse_rotary else 0
 
         @cute.struct
         class SharedStorage:
@@ -196,6 +211,9 @@ class Mamba3Step():
                 cute.struct.MemRange[self.proj_dtype, sOutproj_size],
                 self.buffer_align_bytes,
             ]
+            sAngles: cute.struct.Align[
+                cute.struct.MemRange[Float32, sAngles_size], 128
+            ]
 
         self.shared_storage = SharedStorage
 
@@ -217,6 +235,10 @@ class Mamba3Step():
             mZ,
             mZproj,
             mStateBatchIdx,
+            mBiasQ,
+            mBiasK,
+            mAngleProj,
+            mAnglePool,
             self.sState_layout,
             self.sBC_layout,
             self.sProj_layout,
@@ -255,6 +277,10 @@ class Mamba3Step():
         mZ: Optional[cute.Tensor],  # (B, H, D), None if remove_gate
         mZproj: Optional[cute.Tensor],  # (R, H, D), None if remove_gate
         mStateBatchIdx: Optional[cute.Tensor],  # (B,) int32 pool-row indices
+        mBiasQ: Optional[cute.Tensor],  # (R, H, N)
+        mBiasK: Optional[cute.Tensor],  # (R, H, N)
+        mAngleProj: Optional[cute.Tensor],  # (B, H, A)
+        mAnglePool: Optional[cute.Tensor],  # (P, H, A) fp32 in/out
         sState_layout: cute.Layout | cute.ComposedLayout,
         sBC_layout: cute.Layout | cute.ComposedLayout,
         sProj_layout: cute.Layout | cute.ComposedLayout,
@@ -335,6 +361,10 @@ class Mamba3Step():
         sXstate = storage.sXstate.get_tensor(cute.make_layout(self.tile_D))
         sX = storage.sX.get_tensor(cute.make_layout(self.tile_D))
         sXgamma = storage.sXgamma.get_tensor(cute.make_layout(self.tile_D))
+        sAngles = (
+            storage.sAngles.get_tensor(cute.make_layout(self.rotary_dim // 2))
+            if const_expr(self.fuse_rotary) else None
+        )
 
         # ///////////////////////////////////////////////////////////////////////////////
         #  Partitioning using copy atoms
@@ -439,6 +469,68 @@ class Mamba3Step():
 
         cute.arch.cp_async_wait_group(2)  # B, Bstate, Xproj are done loading
         cute.arch.sync_threads()
+
+        if const_expr(self.fuse_rotary):
+            # ---- Fused bias + rotary on the B tile, in smem -----------------
+            # New per-(b, h) angles once into smem (consumed again for C; the
+            # pool row is only written at the END of the kernel).
+            A_half = self.rotary_dim // 2
+            gAnglePool = cute.local_tile(
+                mAnglePool[bidb_st, bidh, None], (A_half,), (0,)
+            )
+            gAngleProj = cute.local_tile(
+                mAngleProj[bidb, bidh, None], (A_half,), (0,)
+            )
+            if tidx < A_half:
+                a_proj = cute.math.tanh(
+                    Float32(gAngleProj[tidx]), fastmath=False
+                )
+                sAngles[tidx] = (
+                    Float32(gAnglePool[tidx])
+                    + a_proj * dt_val * 3.141592653589793
+                )
+            cute.arch.sync_threads()
+
+            gBiasK = cute.local_tile(
+                mBiasK[None, bidh, None], (self.mimo, self.dstate), (0, 0)
+            )
+            num_threads_k = self.num_warps * cute.arch.WARP_SIZE
+            # Rotation pairs element i with i + dstate/2 (half-half over the
+            # FULL dstate, original-RoPE style); only the first A_half pairs
+            # carry real angles, the rest are identity (angle 0 upstream).
+            pair_off = self.dstate // 2
+            total_pairs = self.mimo * A_half
+            for p0 in cutlass.range_constexpr(
+                (total_pairs + num_threads_k - 1) // num_threads_k
+            ):
+                p = p0 * num_threads_k + tidx
+                if p < total_pairs:
+                    r = p // A_half
+                    i = p % A_half
+                    lo = Float32(sB[r, i]) + Float32(gBiasK[r, i])
+                    hi = (Float32(sB[r, i + pair_off])
+                          + Float32(gBiasK[r, i + pair_off]))
+                    th = Float32(sAngles[i])
+                    c = cute.math.cos(th, fastmath=False)
+                    s = cute.math.sin(th, fastmath=False)
+                    sB[r, i] = (lo * c - hi * s).to(self.b_dtype)
+                    sB[r, i + pair_off] = (lo * s + hi * c).to(self.b_dtype)
+            # Identity dims (i in [A_half, pair_off) and partners): bias only.
+            seg = pair_off - A_half
+            total_plain = self.mimo * 2 * seg
+            for e0 in cutlass.range_constexpr(
+                (total_plain + num_threads_k - 1) // num_threads_k
+            ):
+                e = e0 * num_threads_k + tidx
+                if e < total_plain:
+                    r = e // (2 * seg)
+                    j = e % (2 * seg)
+                    n = A_half + j % seg + pair_off * (j // seg)
+                    sB[r, n] = (
+                        Float32(sB[r, n]) + Float32(gBiasK[r, n])
+                    ).to(self.b_dtype)
+            cute.arch.sync_threads()
+
         # Load B, Bstate, Xproj from smem
         smem_thr_copy_B = tiled_copy_B_s2r.get_slice(tidx % threads_per_dstate)
         # ((vecsize_dstate, 1), mimo, 1) -> ((vecsize_dstate, 1), mimo)
@@ -519,6 +611,46 @@ class Mamba3Step():
         # Do state @ C
         cute.arch.cp_async_wait_group(1)  # C is done loading
         cute.arch.sync_threads()
+
+        if const_expr(self.fuse_rotary):
+            # ---- Fused bias + rotary on the C tile (angles from smem) ------
+            A_half_c = self.rotary_dim // 2
+            gBiasQ = cute.local_tile(
+                mBiasQ[None, bidh, None], (self.mimo, self.dstate), (0, 0)
+            )
+            num_threads_c = self.num_warps * cute.arch.WARP_SIZE
+            pair_off_c = self.dstate // 2
+            total_pairs_c = self.mimo * A_half_c
+            for p0 in cutlass.range_constexpr(
+                (total_pairs_c + num_threads_c - 1) // num_threads_c
+            ):
+                p = p0 * num_threads_c + tidx
+                if p < total_pairs_c:
+                    r = p // A_half_c
+                    i = p % A_half_c
+                    lo = Float32(sC[r, i]) + Float32(gBiasQ[r, i])
+                    hi = (Float32(sC[r, i + pair_off_c])
+                          + Float32(gBiasQ[r, i + pair_off_c]))
+                    th = Float32(sAngles[i])
+                    c = cute.math.cos(th, fastmath=False)
+                    s = cute.math.sin(th, fastmath=False)
+                    sC[r, i] = (lo * c - hi * s).to(self.b_dtype)
+                    sC[r, i + pair_off_c] = (lo * s + hi * c).to(self.b_dtype)
+            seg_c = pair_off_c - A_half_c
+            total_plain_c = self.mimo * 2 * seg_c
+            for e0 in cutlass.range_constexpr(
+                (total_plain_c + num_threads_c - 1) // num_threads_c
+            ):
+                e = e0 * num_threads_c + tidx
+                if e < total_plain_c:
+                    r = e // (2 * seg_c)
+                    j = e % (2 * seg_c)
+                    n = A_half_c + j % seg_c + pair_off_c * (j // seg_c)
+                    sC[r, n] = (
+                        Float32(sC[r, n]) + Float32(gBiasQ[r, n])
+                    ).to(self.b_dtype)
+            cute.arch.sync_threads()
+
         # ((vecsize_dstate, 1), mimo, 1) -> ((vecsize_dstate, 1), 1, mimo)
         tSsC = select(smem_thr_copy_B.partition_S(sC), mode=[0, 2, 1])
         tSrC = cute.make_rmem_tensor_like(tSsC)
@@ -577,6 +709,18 @@ class Mamba3Step():
                 if warp_idx == 0:
                     if not need_bound_check_X or lane_idx < num_loads_X:
                         cute.autovec_copy(tXrX, tXgXstate)
+
+        # Fused rotary: write the new angle row LAST (every consumer read the
+        # smem copy; an earlier in-place pool store would race rematerialized
+        # loads). Padding lanes leave the pool untouched.
+        if const_expr(self.fuse_rotary):
+            if valid_st:
+                A_half_w = self.rotary_dim // 2
+                gAnglePool_w = cute.local_tile(
+                    mAnglePool[bidb_st, bidh, None], (A_half_w,), (0,)
+                )
+                if tidx < A_half_w:
+                    gAnglePool_w[tidx] = Float32(sAngles[tidx])
 
         if const_expr(mOutproj is not None):
             # Gate: z_r * sigmoid(z_r)
@@ -648,12 +792,22 @@ def mamba3_step_fn(
     # caller's scatter kernels. Requires state_batch_indices and tile_D >= headdim
     # (a single D-tile per (b, h): the Bstate write would race other CTAs'
     # reads otherwise). NOTE: mutates Bstate/Xstate.
+    rotary_dim: int = 0,  # > 0 fuses bias + rotary into the kernel: B/C are
+    # the PRE-rotation tensors (head dim may be a broadcast stride-0 view);
+    # the kernel adds rotary_bias_k/q, rotates the first rotary_dim entries
+    # of the dstate axis with angle = angle_state + tanh(angle_proj)*dt*pi,
+    # and updates rotary_angle_state row state_batch_indices[b] in place.
+    rotary_bias_q: Optional[Tensor] = None,   # (R, H, N)
+    rotary_bias_k: Optional[Tensor] = None,   # (R, H, N)
+    rotary_angle_proj: Optional[Tensor] = None,   # (B, H, rotary_dim/2)
+    rotary_angle_state: Optional[Tensor] = None,  # (P, H, rotary_dim/2) fp32
     tile_D: int = 64,
     num_warps: int = 2,
 ) -> None:
     has_z = z is not None
     has_outproj = outproj is not None
     has_state_batch_idx = state_batch_indices is not None
+    fuse_rotary = rotary_dim > 0
     inplace = state_out is None
     pool, nheads, hdim, dstate = state.shape
     if update_kv_state:
@@ -687,6 +841,19 @@ def mamba3_step_fn(
     assert dt.shape == (batch, nheads)
     assert trap.shape == (batch, nheads)
     assert xproj.shape == (mimo, nheads, hdim)
+    if fuse_rotary:
+        a_half = rotary_dim // 2
+        assert has_state_batch_idx, "fused rotary requires state_batch_indices"
+        assert rotary_dim % 2 == 0 and rotary_dim <= dstate
+        assert rotary_bias_q is not None and rotary_bias_k is not None
+        assert rotary_bias_q.shape == (mimo, nheads, dstate)
+        assert rotary_bias_k.shape == (mimo, nheads, dstate)
+        assert rotary_angle_proj is not None
+        assert rotary_angle_proj.shape == (batch, nheads, a_half)
+        assert rotary_angle_state is not None
+        assert rotary_angle_state.shape == (pool, nheads, a_half)
+        assert rotary_angle_state.dtype == torch.float32
+        assert rotary_bias_q.dtype == rotary_bias_k.dtype
     xproj = xproj.contiguous()
     if has_outproj:
         assert outproj.shape == (mimo, nheads, hdim)
@@ -735,9 +902,11 @@ def mamba3_step_fn(
         has_outproj,
         has_state_batch_idx,
         update_kv_state,
+        rotary_dim,
+        rotary_bias_q.dtype if fuse_rotary else None,
     )
     if compile_key not in mamba3_step_fn.compile_cache:
-        mamba3_step_op = Mamba3Step(tile_D, dstate, mimo, num_warps, remove_gate=not has_z, remove_outproj=not has_outproj, update_kv_state=update_kv_state)
+        mamba3_step_op = Mamba3Step(tile_D, dstate, mimo, num_warps, remove_gate=not has_z, remove_outproj=not has_outproj, update_kv_state=update_kv_state, rotary_dim=rotary_dim)
 
         # Create symbolic dimensions for batch and nheads
         batch_sym = cute.sym_int()
@@ -778,6 +947,24 @@ def mamba3_step_fn(
         state_batch_idx_fake = (
             make_fake_tensor(Int32, (batch_sym,)) if has_state_batch_idx else None
         )
+        if fuse_rotary:
+            a_half = rotary_dim // 2
+            bias_cute_dtype = torch2cute_dtype_map[rotary_bias_q.dtype]
+            div_bias = 128 // bias_cute_dtype.width
+            bias_q_fake = make_fake_tensor(
+                bias_cute_dtype, (mimo, nheads_sym, dstate), div_bias)
+            bias_k_fake = make_fake_tensor(
+                bias_cute_dtype, (mimo, nheads_sym, dstate), div_bias)
+            # angle_proj is typically a head-broadcast view (stride 0 on H):
+            # only assume a contiguous last dim.
+            angle_proj_fake = make_fake_tensor(
+                torch2cute_dtype_map[rotary_angle_proj.dtype],
+                (batch_sym, nheads_sym, a_half), 1)
+            angle_pool_fake = make_fake_tensor(
+                Float32, (pool_sym, nheads_sym, a_half), 1)
+        else:
+            bias_q_fake = bias_k_fake = None
+            angle_proj_fake = angle_pool_fake = None
 
         fake_stream = cute.runtime.make_fake_stream(use_tvm_ffi_env_stream=True)
 
@@ -800,6 +987,10 @@ def mamba3_step_fn(
             z_fake,
             zproj_fake,
             state_batch_idx_fake,
+            bias_q_fake,
+            bias_k_fake,
+            angle_proj_fake,
+            angle_pool_fake,
             fake_stream,
             options="--enable-tvm-ffi",
         )
@@ -824,6 +1015,10 @@ def mamba3_step_fn(
         z,
         zproj,
         state_batch_indices,
+        rotary_bias_q,
+        rotary_bias_k,
+        rotary_angle_proj,
+        rotary_angle_state,
     )
 
 

--- a/mamba_ssm/ops/cute/mamba3/mamba3_step_fn.py
+++ b/mamba_ssm/ops/cute/mamba3/mamba3_step_fn.py
@@ -306,7 +306,13 @@ class Mamba3Step():
         valid_st = Boolean(True)
         if const_expr(mStateBatchIdx is not None):
             idx_val = Int32(mStateBatchIdx[bidb])
-            valid_st = idx_val >= Int32(0)
+            # Negative (PAD_SLOT_ID) and out-of-range rows (CUDA-graph capture
+            # dummies) are both padding: clamp loads, suppress writes.
+            pool_rows = Int32(mState.shape[0])
+            valid_st = Boolean(False)
+            if idx_val >= Int32(0):
+                if idx_val < pool_rows:
+                    valid_st = Boolean(True)
             bidb_st = idx_val
             if not valid_st:
                 bidb_st = Int32(0)

--- a/mamba_ssm/ops/cute/mamba3/mamba3_step_fn.py
+++ b/mamba_ssm/ops/cute/mamba3/mamba3_step_fn.py
@@ -118,6 +118,8 @@ class Mamba3Step():
         # for each batch element; when given, mState/mStateOut/mBstate/mXstate
         # are pools of shape (P, ...) indexed indirectly (avoids the PyTorch
         # gather/scatter round-trip on the SSM state).
+        mStateBatchIdxOut: Optional[cute.Tensor],  # (B,) int32 — separate pool
+        # row for the state WRITES (spec-decode verify); None = write in place.
         mBiasQ: Optional[cute.Tensor],  # (R, H, N) — fused-rotary C bias
         mBiasK: Optional[cute.Tensor],  # (R, H, N) — fused-rotary B bias
         mAngleProj: Optional[cute.Tensor],  # (B, H, rotary_dim/2)
@@ -235,6 +237,7 @@ class Mamba3Step():
             mZ,
             mZproj,
             mStateBatchIdx,
+            mStateBatchIdxOut,
             mBiasQ,
             mBiasK,
             mAngleProj,
@@ -277,6 +280,7 @@ class Mamba3Step():
         mZ: Optional[cute.Tensor],  # (B, H, D), None if remove_gate
         mZproj: Optional[cute.Tensor],  # (R, H, D), None if remove_gate
         mStateBatchIdx: Optional[cute.Tensor],  # (B,) int32 pool-row indices
+        mStateBatchIdxOut: Optional[cute.Tensor],  # (B,) int32 write-row indices
         mBiasQ: Optional[cute.Tensor],  # (R, H, N)
         mBiasK: Optional[cute.Tensor],  # (R, H, N)
         mAngleProj: Optional[cute.Tensor],  # (B, H, A)
@@ -319,14 +323,35 @@ class Mamba3Step():
         else:
             bidb_st = bidb
 
+        # Separate write row (speculative-decode verify: position t reads the
+        # state after position t-1 and writes its own scratch slot, so k+1
+        # sequential launches leave per-position states behind). Defaults to
+        # the read row when mStateBatchIdxOut is absent (in-place update).
+        valid_out = valid_st
+        bidb_st_out = bidb_st
+        if const_expr(mStateBatchIdxOut is not None):
+            idx_out = Int32(mStateBatchIdxOut[bidb])
+            pool_rows_out = Int32(mState.shape[0])
+            valid_out = Boolean(False)
+            if idx_out >= Int32(0):
+                if idx_out < pool_rows_out:
+                    valid_out = Boolean(True)
+            bidb_st_out = idx_out
+            if not valid_out:
+                bidb_st_out = Int32(0)
+
         # ///////////////////////////////////////////////////////////////////////////////
         #  Slice for CTA
         # ///////////////////////////////////////////////////////////////////////////////
         # (tile_D, N)
-        gState, gStateOut = [
-            cute.local_tile(t[bidb_st, bidh, None, None], (self.tile_D, self.dstate), (bidd, 0))
-            for t in (mState, mStateOut)
-        ]
+        gState = cute.local_tile(
+            mState[bidb_st, bidh, None, None], (self.tile_D, self.dstate), (bidd, 0)
+        )
+        gStateOut = cute.local_tile(
+            mStateOut[bidb_st_out, bidh, None, None],
+            (self.tile_D, self.dstate),
+            (bidd, 0),
+        )
         # (R, N)
         gBstate = cute.local_tile(
             mBstate[bidb_st, None, bidh, None], (self.mimo, self.dstate), (0, 0)
@@ -607,9 +632,10 @@ class Mamba3Step():
                     cute.copy(gmem_tiled_copy_Proj, tPgOutproj[None, m, None], tPsOutproj[None, m, None])
         cute.arch.cp_async_commit_group()
 
-        # Write state back to StateOut (may be same memory as State for in-place)
+        # Write state back to StateOut (may be same memory as State for in-place;
+        # a different pool row when mStateBatchIdxOut is given).
         if const_expr(mStateBatchIdx is not None):
-            if valid_st:
+            if valid_out:
                 cute.copy(tiled_copy_state_s2r, tSrS, tSgSOut)
         else:
             cute.copy(tiled_copy_state_s2r, tSrS, tSgSOut)
@@ -707,23 +733,32 @@ class Mamba3Step():
         # (pre-fp32) values, so the store is bit-exact with the caller-side
         # `k_pool[slots] = B; v_pool[slots] = x` it replaces.
         if const_expr(self.update_kv_state and mStateBatchIdx is not None):
-            if valid_st:
+            if valid_out:
+                gBstateOut = cute.local_tile(
+                    mBstate[bidb_st_out, None, bidh, None],
+                    (self.mimo, self.dstate),
+                    (0, 0),
+                )
+                gXstateOut = cute.local_tile(
+                    mXstate[bidb_st_out, bidh, None], (self.tile_D,), (bidd,)
+                )
+                tXgXstateOut = gmem_thr_copy_X.partition_S(gXstateOut)
                 tpd_b = self.dstate // vecsize_dstate
                 if tidx < tpd_b:
-                    tSgBstate_w = smem_thr_copy_B.partition_S(gBstate)[None, None, 0]
+                    tSgBstate_w = smem_thr_copy_B.partition_S(gBstateOut)[None, None, 0]
                     cute.autovec_copy(tSrB, tSgBstate_w)
                 if warp_idx == 0:
                     if not need_bound_check_X or lane_idx < num_loads_X:
-                        cute.autovec_copy(tXrX, tXgXstate)
+                        cute.autovec_copy(tXrX, tXgXstateOut)
 
         # Fused rotary: write the new angle row LAST (every consumer read the
         # smem copy; an earlier in-place pool store would race rematerialized
         # loads). Padding lanes leave the pool untouched.
         if const_expr(self.fuse_rotary):
-            if valid_st:
+            if valid_out:
                 A_half_w = self.rotary_dim // 2
                 gAnglePool_w = cute.local_tile(
-                    mAnglePool[bidb_st, bidh, None], (A_half_w,), (0,)
+                    mAnglePool[bidb_st_out, bidh, None], (A_half_w,), (0,)
                 )
                 if tidx < A_half_w:
                     gAnglePool_w[tidx] = Float32(sAngles[tidx])
@@ -793,6 +828,11 @@ def mamba3_step_fn(
     # state/Bstate/Xstate are pools of shape (P, ...) and row
     # state_batch_indices[b] holds batch element b's state. The state is updated
     # in place in the pool (state_out must be None). Avoids gather/scatter.
+    state_batch_indices_out: Optional[Tensor] = None,  # (B,) int32 — separate
+    # pool row for all state WRITES (ssm/k/v/angle); reads still come from
+    # state_batch_indices. Enables speculative-decode verify: k+1 sequential
+    # launches with in=slot[t-1], out=slot[t] leave per-position states.
+    # Requires state_batch_indices; negative/out-of-range rows suppress writes.
     update_kv_state: bool = False,  # kernel also stores this step's B and x
     # into Bstate/Xstate after consuming the old values, replacing the
     # caller's scatter kernels. Requires state_batch_indices and tile_D >= headdim
@@ -832,6 +872,14 @@ def mamba3_step_fn(
         assert state_batch_indices.is_cuda
     else:
         assert pool == batch
+    has_state_batch_idx_out = state_batch_indices_out is not None
+    if has_state_batch_idx_out:
+        assert has_state_batch_idx, (
+            "state_batch_indices_out requires state_batch_indices"
+        )
+        assert state_batch_indices_out.shape == (batch,)
+        assert state_batch_indices_out.dtype == torch.int32
+        assert state_batch_indices_out.is_cuda
     assert state.shape == (pool, nheads, hdim, dstate)
     assert Bstate.shape == (pool, mimo, nheads, dstate)
     assert Xstate.shape == (pool, nheads, hdim)
@@ -907,6 +955,7 @@ def mamba3_step_fn(
         has_z,
         has_outproj,
         has_state_batch_idx,
+        has_state_batch_idx_out,
         update_kv_state,
         rotary_dim,
         rotary_bias_q.dtype if fuse_rotary else None,
@@ -953,6 +1002,9 @@ def mamba3_step_fn(
         state_batch_idx_fake = (
             make_fake_tensor(Int32, (batch_sym,)) if has_state_batch_idx else None
         )
+        state_batch_idx_out_fake = (
+            make_fake_tensor(Int32, (batch_sym,)) if has_state_batch_idx_out else None
+        )
         if fuse_rotary:
             a_half = rotary_dim // 2
             bias_cute_dtype = torch2cute_dtype_map[rotary_bias_q.dtype]
@@ -993,6 +1045,7 @@ def mamba3_step_fn(
             z_fake,
             zproj_fake,
             state_batch_idx_fake,
+            state_batch_idx_out_fake,
             bias_q_fake,
             bias_k_fake,
             angle_proj_fake,
@@ -1021,6 +1074,7 @@ def mamba3_step_fn(
         z,
         zproj,
         state_batch_indices,
+        state_batch_indices_out,
         rotary_bias_q,
         rotary_bias_k,
         rotary_angle_proj,

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
@@ -48,6 +48,10 @@ class _Mamba3Function(torch.autograd.Function):
         Angles: Tensor,
         D: Tensor,
         Z: Tensor,
+        Input_Angle_State: Optional[Tensor],
+        Input_SSM_State: Optional[Tensor],
+        Input_K_State: Optional[Tensor],
+        Input_V_State: Optional[Tensor],
         chunk_size: int,
         rotary_dim_divisor: int,
         dtype: torch.dtype,
@@ -62,10 +66,26 @@ class _Mamba3Function(torch.autograd.Function):
         ctx.dtype = dtype
         ctx.fuse_pregate_headwise_rms_norm = fuse_pregate_headwise_rms_norm
         ctx.outproj_norm_eps = outproj_norm_eps
-        (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z) = tuple(
+        ctx.has_input_state = Input_SSM_State is not None
+        all_states_present = (
+            Input_Angle_State is not None
+            and Input_SSM_State is not None
+            and Input_K_State is not None
+            and Input_V_State is not None
+        )
+        all_states_absent = (
+            Input_Angle_State is None
+            and Input_SSM_State is None
+            and Input_K_State is None
+            and Input_V_State is None
+        )
+        assert all_states_present or all_states_absent, "Input states must be provided together or all be None."
+        (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z,
+            Input_Angle_State, Input_SSM_State, Input_K_State, Input_V_State) = tuple(
             t.contiguous() if t is not None else None
             for t in (
                 Q, K, V, ADT, DT, Trap, Q_bias, K_bias, MIMO_V, MIMO_Z, MIMO_Out, Out_Norm_Weight, Angles, D, Z,
+                Input_Angle_State, Input_SSM_State, Input_K_State, Input_V_State,
             )
         )
         # Kernels require cu_seqlens as int32; torch.cumsum promotes int32→int64 on CUDA
@@ -75,6 +95,7 @@ class _Mamba3Function(torch.autograd.Function):
         # Compute cumulative angles (varlen-aware)
         Angles_Cumsum, angle_output_state = angle_dt_fwd(
             Angles, DT,
+            init_state=Input_Angle_State,
             chunk_size=chunk_size,
             return_output_state=True,
             cu_seqlens=cu_seqlens,
@@ -89,6 +110,7 @@ class _Mamba3Function(torch.autograd.Function):
                 Z, D, MIMO_Z, Angles_Cumsum,
                 DA_CS, DA_CS_REV, DT, Trap, Segsum,
                 cu_seqlens=cu_seqlens,
+                initial_states=(Input_SSM_State, Input_K_State, Input_V_State) if all_states_present else None,
                 return_state=return_state,
                 chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor,
                 dtype=dtype,
@@ -103,6 +125,7 @@ class _Mamba3Function(torch.autograd.Function):
                 Q, K, V, Q_bias, K_bias, MIMO_V, MIMO_Out,
                 Z, D, MIMO_Z, Angles_Cumsum,
                 DA_CS, DA_CS_REV, DT, Trap, Segsum,
+                initial_states=(Input_SSM_State, Input_K_State, Input_V_State) if all_states_present else None,
                 return_state=return_state,
                 chunk_size=chunk_size, rotary_dim_divisor=rotary_dim_divisor,
                 dtype=dtype,
@@ -124,7 +147,14 @@ class _Mamba3Function(torch.autograd.Function):
         else:
             Final_SSM_State = Final_SSM_State.permute(0, 1, 3, 2).contiguous().detach()
             Final_K = Final_K.contiguous().detach()
-            Final_V = V[:, -1, :, :].contiguous().detach()
+            if cu_seqlens is None:
+                Final_V = torch.empty((V.shape[0], V.shape[2], V.shape[3]), device=V.device, dtype=V.dtype)
+                Final_V.copy_(V[:, -1, :, :])
+            else:
+                final_v_indices = cu_seqlens[1:].to(torch.long) - 1
+                Final_V = torch.empty((final_v_indices.shape[0], V.shape[2], V.shape[3]), device=V.device, dtype=V.dtype)
+                Final_V.copy_(V[0, final_v_indices, :, :])
+            Final_V = Final_V.detach()
             ctx.mark_non_differentiable(Final_Angle, Final_SSM_State, Final_K, Final_V)
             return Out, Final_Angle, Final_SSM_State, Final_K, Final_V
     
@@ -136,6 +166,11 @@ class _Mamba3Function(torch.autograd.Function):
             raise RuntimeError(
                 "Backward called but forward ran without gradient tracking. "
                 "Ensure inputs require grad or run under torch.enable_grad()."
+            )
+        if ctx.has_input_state:
+            raise NotImplementedError(
+                "Mamba-3 MIMO backward with Input_States is not implemented; "
+                "use input states only for inference/prefill."
             )
         dout = dout.contiguous()
 
@@ -236,6 +271,7 @@ class _Mamba3Function(torch.autograd.Function):
             dAngles,
             dD,
             dZ,
+            None, None, None, None,
             None, None, None, None, None, None, None,
         )
 
@@ -264,6 +300,7 @@ def mamba3_mimo(
     dtype: torch.dtype,
     return_state: bool = False,
     cu_seqlens: Optional[Tensor] = None,
+    Input_States: Optional[Tuple[Tensor, Tensor, Tensor, Tensor]] = None,
     fuse_pregate_headwise_rms_norm: bool = False,
     outproj_norm_weight: Optional[Tensor] = None,
     outproj_norm_eps: float = 1e-5,
@@ -289,6 +326,10 @@ def mamba3_mimo(
         rotary_dim_divisor: Divisor for rotary embedding dimensions (default: 4, meaning angles have 1/4 of headdim_qk)
         dtype: Data type for lower-precision computation (e.g., torch.bfloat16)
         return_state: Whether to return final state for autoregressive decoding (default: False)
+        Input_States: Optional tuple of initial states (angle, ssm, k, v). Dense shapes are
+         (batch, nheads, angle_dim), (batch, nheads, headdim_v, headdim_qk),
+         (batch, mimo_rank, nheads, headdim_qk), and (batch, nheads, headdim_v).
+         Varlen mode uses num_sequences as the leading dimension.
         cu_seqlens: Optional tensor of cumulative sequence lengths for variable-length sequences. 
          If provided, should be a tensor of shape (num_seq + 1,) where cu_seqlens[i] is 
          the cumulative sequence length up to sequence i. This is used for efficient processing of 
@@ -324,6 +365,25 @@ def mamba3_mimo(
     assert nheads % nheads_qk == 0, f"nheads ({nheads}) must be divisible by nheads_qk ({nheads_qk})"
     assert headdim_qk % 2 == 0, f"headdim_qk ({headdim_qk}) must be even for rotary embeddings"
     assert rotary_dim_divisor in [2, 4], f"currently only supports rotary embedding on entire or half of headdim_qk"
+    num_sequences = cu_seqlens.shape[0] - 1 if cu_seqlens is not None else batch
+    if Input_States is None:
+        Input_Angle_State, Input_SSM_State, Input_K_State, Input_V_State = None, None, None, None
+    else:
+        assert len(Input_States) == 4, "Input_States must be a tuple of (angle_state, ssm_state, k_state, v_state)"
+        Input_Angle_State, Input_SSM_State, Input_K_State, Input_V_State = Input_States
+        angle_dim = Angles.shape[-1]
+        assert Input_Angle_State.shape == (num_sequences, nheads, angle_dim), (
+            f"Input angle state shape mismatch: expected {(num_sequences, nheads, angle_dim)}, got {Input_Angle_State.shape}"
+        )
+        assert Input_SSM_State.shape == (num_sequences, nheads, headdim_v, headdim_qk), (
+            f"Input SSM state shape mismatch: expected {(num_sequences, nheads, headdim_v, headdim_qk)}, got {Input_SSM_State.shape}"
+        )
+        assert Input_K_State.shape == (num_sequences, mimo_rank, nheads, headdim_qk), (
+            f"Input K state shape mismatch: expected {(num_sequences, mimo_rank, nheads, headdim_qk)}, got {Input_K_State.shape}"
+        )
+        assert Input_V_State.shape == (num_sequences, nheads, headdim_v), (
+            f"Input V state shape mismatch: expected {(num_sequences, nheads, headdim_v)}, got {Input_V_State.shape}"
+        )
     # NOTE: the following (headdim_qk, headdim_v) values currently can result in compilation errors: (16, 32), (256, 128) 
     if headdim_qk not in [16, 32, 64, 128, 256]:
         print(f"WARNING: The value headdim_qk={headdim_qk} has not been tested. " +\
@@ -354,6 +414,10 @@ def mamba3_mimo(
         Angles,
         D,
         Z,
+        Input_Angle_State,
+        Input_SSM_State,
+        Input_K_State,
+        Input_V_State,
         chunk_size,
         rotary_dim_divisor,
         dtype,

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
@@ -162,7 +162,12 @@ class _Mamba3Function(torch.autograd.Function):
     def backward(ctx, dout, *args) -> tuple:
         """Backward pass: compute gradients using Tilelang backward kernels."""
         
-        if len(ctx.saved_tensors) == 0:
+        # Access ctx.saved_tensors exactly once: each access re-runs the
+        # saved-tensor unpack hooks, and non-reentrant gradient checkpointing
+        # (torch.utils.checkpoint use_reentrant=False) only permits a single
+        # unpack per tensor — a second access raises CheckpointError.
+        saved = ctx.saved_tensors
+        if len(saved) == 0:
             raise RuntimeError(
                 "Backward called but forward ran without gradient tracking. "
                 "Ensure inputs require grad or run under torch.enable_grad()."
@@ -178,7 +183,7 @@ class _Mamba3Function(torch.autograd.Function):
             D, Z,
             MIMO_V, MIMO_Out, MIMO_Z, Out_Norm_Weight,
             cu_seqlens
-            ) = ctx.saved_tensors
+            ) = saved
 
         if cu_seqlens is not None:
             DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton_varlen(ADT, ctx.chunk_size, cu_seqlens=cu_seqlens)

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd.py
@@ -48,6 +48,7 @@ def mamba_mimo_fwd(
     reduceO,
     fuse_pregate_headwise_rms_norm=False,
     return_final_state=False,
+    has_initial_state=False,
     chunk_size: int = 16,
     rotary_dim_divisor = 4,
     dtype: str = 'bfloat16',
@@ -61,6 +62,9 @@ def mamba_mimo_fwd(
     nchunks = tilelang.cdiv(S, chunk_size)
     tail_len = S % chunk_size
     fused_chunk_size = chunk_size * R
+    Init_SSM_State_shape = (B, H, P, N)
+    Init_K_State_shape = (B, R, H, N)
+    Init_V_State_shape = (B, H, P)
 
     if reduceO:
         O_shape = (B, S, H, P)
@@ -88,6 +92,9 @@ def mamba_mimo_fwd(
             DT: T.Tensor([B, H, S], T.float32), # type: ignore
             TRAP: T.Tensor([B, H, S], dtype), # type: ignore
             SEGSUM: T.Tensor([B, H, nchunks, chunk_size, chunk_size], T.float32), # type: ignore
+            INIT_SSM_STATE: T.Tensor(Init_SSM_State_shape, T.float32),  # type: ignore
+            INIT_K_STATE: T.Tensor(Init_K_State_shape, dtype),  # type: ignore
+            INIT_V_STATE: T.Tensor(Init_V_State_shape, dtype),  # type: ignore
 
             FINAL_STATE: T.Tensor([B, H, N, P], T.float32),  # type: ignore
             FINAL_K: T.Tensor([B, R, H, N], dtype)  # type: ignore
@@ -188,6 +195,22 @@ def mamba_mimo_fwd(
 
             T.copy(Q_BIAS[i_h, :, :], q_bias_frag)
             T.copy(K_BIAS[i_h, :, :], k_bias_frag)
+
+            if has_initial_state:
+                boundary_scale = T.alloc_var(T.float32)
+                boundary_trap = T.alloc_var(dtype)
+                T.copy(DT[i_b, i_h, 0], boundary_scale)
+                T.copy(TRAP[i_b, i_h, 0], boundary_trap)
+                boundary_scale *= T.sigmoid(-boundary_trap)
+                for n, p in T.Parallel(N, P):
+                    states_frag[n, p] = INIT_SSM_STATE[i_b, i_h, p, n]
+                    for r in T.serial(R):
+                        states_frag[n, p] += (
+                            INIT_K_STATE[i_b, r, i_h, n]
+                            * INIT_V_STATE[i_b, i_h, p]
+                            * MIMO_V[i_h, r, p]
+                            * boundary_scale
+                        )
 
             # --- Chunk Loop ---
             for i in T.Pipelined(0, nchunks, num_stages=num_stages):
@@ -477,6 +500,7 @@ def mamba_mimo_forward(q, k, v,
                        segsum,
                        chunk_size, rotary_dim_divisor, dtype, 
                        return_state=False,
+                       initial_states=None,
                        fuse_pregate_headwise_rms_norm=False,
                        outproj_norm_weight=None,
                        outproj_norm_eps=1e-5,
@@ -504,6 +528,7 @@ def mamba_mimo_forward(q, k, v,
                             reduceO,
                             fuse_pregate_headwise_rms_norm,
                             return_final_state=return_state,
+                            has_initial_state=initial_states is not None,
                             chunk_size=chunk_size, 
                             rotary_dim_divisor=rotary_dim_divisor, 
                             dtype=tl_dtype, 
@@ -540,6 +565,28 @@ def mamba_mimo_forward(q, k, v,
     z_arg = z
     D_arg = D
     mimo_z_arg = mimo_z
+    if initial_states is None:
+        init_ssm_state_arg, init_k_state_arg, init_v_state_arg = None, None, None
+    else:
+        init_ssm_state_arg, init_k_state_arg, init_v_state_arg = initial_states
+        if init_ssm_state_arg.shape != (B, H, P, N):
+            raise ValueError(
+                f"Expected initial SSM state shape {(B, H, P, N)}, "
+                f"got {tuple(init_ssm_state_arg.shape)}"
+            )
+        if init_k_state_arg.shape != (B, R, H, N):
+            raise ValueError(
+                f"Expected initial K state shape {(B, R, H, N)}, "
+                f"got {tuple(init_k_state_arg.shape)}"
+            )
+        if init_v_state_arg.shape != (B, H, P):
+            raise ValueError(
+                f"Expected initial V state shape {(B, H, P)}, "
+                f"got {tuple(init_v_state_arg.shape)}"
+            )
+        init_ssm_state_arg = init_ssm_state_arg.contiguous()
+        init_k_state_arg = init_k_state_arg.contiguous()
+        init_v_state_arg = init_v_state_arg.contiguous()
 
     h = torch.empty((B, H, N, P), device='cuda', dtype=torch.float32) if return_state else None
     k_final = torch.empty((B, R, H, N), device='cuda', dtype=dtype) if return_state else None
@@ -557,6 +604,9 @@ def mamba_mimo_forward(q, k, v,
             dt,
             trap,
             segsum,
+            init_ssm_state_arg,
+            init_k_state_arg,
+            init_v_state_arg,
             h,
             k_final
             )

--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo_fwd_varlen.py
@@ -69,6 +69,7 @@ def mamba_mimo_fwd(
     fuse_pregate_headwise_rms_norm=False,
     isVarlen: bool = True,
     return_final_state=False,
+    has_initial_state=False,
     chunk_size: int = 16,
     rotary_dim_divisor = 4,
     dtype: str = 'bfloat16',
@@ -116,10 +117,16 @@ def mamba_mimo_fwd(
         max_nchunks = (S//chunk_size) + NS
         Final_State_shape = (NS, H, N, P)
         Final_K_shape = (NS, R, H, N)
+        Init_SSM_State_shape = (NS, H, P, N)
+        Init_K_State_shape = (NS, R, H, N)
+        Init_V_State_shape = (NS, H, P)
     else:
         max_nchunks = tilelang.cdiv(S, chunk_size)
         Final_State_shape = (B, H, N, P)
         Final_K_shape = (B, R, H, N)
+        Init_SSM_State_shape = (B, H, P, N)
+        Init_K_State_shape = (B, R, H, N)
+        Init_V_State_shape = (B, H, P)
     fused_chunk_size = chunk_size * R
 
     if reduceO:
@@ -149,6 +156,9 @@ def mamba_mimo_fwd(
             TRAP: T.Tensor([B, H, S], dtype), # type: ignore
             SEGSUM: T.Tensor([B, H, max_nchunks, chunk_size, chunk_size], T.float32), # type: ignore
             CU_SEQLENS: T.Tensor([NS+1], dtype=T.int32), # type: ignore
+            INIT_SSM_STATE: T.Tensor(Init_SSM_State_shape, T.float32),  # type: ignore
+            INIT_K_STATE: T.Tensor(Init_K_State_shape, dtype),  # type: ignore
+            INIT_V_STATE: T.Tensor(Init_V_State_shape, dtype),  # type: ignore
 
             FINAL_STATE: T.Tensor(Final_State_shape, T.float32),  # type: ignore
             FINAL_K: T.Tensor(Final_K_shape, dtype)  # type: ignore
@@ -284,6 +294,33 @@ def mamba_mimo_fwd(
                 tail_len = S % chunk_size
             if tail_len > 0:
                 full_nchunks += 1
+
+            if has_initial_state:
+                boundary_scale = T.alloc_var(T.float32)
+                boundary_trap = T.alloc_var(dtype)
+                T.copy(DT[i_b, i_h, start_seq_ind], boundary_scale)
+                T.copy(TRAP[i_b, i_h, start_seq_ind], boundary_trap)
+                boundary_scale *= T.sigmoid(-boundary_trap)
+                if isVarlen:
+                    for n, p in T.Parallel(N, P):
+                        states_frag[n, p] = INIT_SSM_STATE[i_ns, i_h, p, n]
+                        for r in T.serial(R):
+                            states_frag[n, p] += (
+                                INIT_K_STATE[i_ns, r, i_h, n]
+                                * INIT_V_STATE[i_ns, i_h, p]
+                                * MIMO_V[i_h, r, p]
+                                * boundary_scale
+                            )
+                else:
+                    for n, p in T.Parallel(N, P):
+                        states_frag[n, p] = INIT_SSM_STATE[i_b, i_h, p, n]
+                        for r in T.serial(R):
+                            states_frag[n, p] += (
+                                INIT_K_STATE[i_b, r, i_h, n]
+                                * INIT_V_STATE[i_b, i_h, p]
+                                * MIMO_V[i_h, r, p]
+                                * boundary_scale
+                            )
 
             # --- Chunk Loop ---
             for i in T.Pipelined(0, full_nchunks, num_stages=num_stages):
@@ -596,6 +633,7 @@ def mamba_mimo_forward_varlen(q, k, v,
                        chunk_size, rotary_dim_divisor, dtype,
                        cu_seqlens=None,
                        return_state=False,
+                       initial_states=None,
                        fuse_pregate_headwise_rms_norm=False,
                        outproj_norm_weight=None,
                        outproj_norm_eps=1e-5,
@@ -682,6 +720,7 @@ def mamba_mimo_forward_varlen(q, k, v,
                                        fuse_pregate_headwise_rms_norm,
                                        isVarlen=cu_seqlens is not None,
                                        return_final_state=return_state,
+                                       has_initial_state=initial_states is not None,
                                        chunk_size=chunk_size,
                                        rotary_dim_divisor=rotary_dim_divisor,
                                        dtype=tl_dtype,
@@ -718,6 +757,29 @@ def mamba_mimo_forward_varlen(q, k, v,
     z_arg = z
     D_arg = D
     mimo_z_arg = mimo_z
+    if initial_states is None:
+        init_ssm_state_arg, init_k_state_arg, init_v_state_arg = None, None, None
+    else:
+        init_ssm_state_arg, init_k_state_arg, init_v_state_arg = initial_states
+        expected_sequences = NS if cu_seqlens is not None else B
+        if init_ssm_state_arg.shape != (expected_sequences, H, P, N):
+            raise ValueError(
+                f"Expected initial SSM state shape {(expected_sequences, H, P, N)}, "
+                f"got {tuple(init_ssm_state_arg.shape)}"
+            )
+        if init_k_state_arg.shape != (expected_sequences, R, H, N):
+            raise ValueError(
+                f"Expected initial K state shape {(expected_sequences, R, H, N)}, "
+                f"got {tuple(init_k_state_arg.shape)}"
+            )
+        if init_v_state_arg.shape != (expected_sequences, H, P):
+            raise ValueError(
+                f"Expected initial V state shape {(expected_sequences, H, P)}, "
+                f"got {tuple(init_v_state_arg.shape)}"
+            )
+        init_ssm_state_arg = init_ssm_state_arg.contiguous()
+        init_k_state_arg = init_k_state_arg.contiguous()
+        init_v_state_arg = init_v_state_arg.contiguous()
 
     if cu_seqlens is not None:
         h = torch.empty((NS, H, N, P), device='cuda', dtype=torch.float32) if return_state else None
@@ -740,6 +802,9 @@ def mamba_mimo_forward_varlen(q, k, v,
             trap,
             segsum,
             cu_seqlens,
+            init_ssm_state_arg,
+            init_k_state_arg,
+            init_v_state_arg,
             h,
             k_final
             )

--- a/mamba_ssm/ops/triton/mamba3/mamba3_mimo_rotary_step.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_mimo_rotary_step.py
@@ -187,6 +187,9 @@ def apply_rotary_qk_inference_fwd(
     conjugate=False,
     rotate_pairwise=True,
     state_batch_indices: Optional[torch.Tensor] = None,
+    # 2 warps ≈ 2.1x faster than 8 for the plain rotary (programs own only
+    # MIMO_DIM x BLOCK_D elements; 8 warps was for a qk_sum variant).
+    num_warps: int = 2,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Apply rotary embedding to both q and k tensors using the same angle.
@@ -276,7 +279,7 @@ def apply_rotary_qk_inference_fwd(
             state_batch_indices is not None,
             MIMO_DIM=mimo_dim,
             BLOCK_D=triton.next_power_of_2(headdim),
-            num_warps=8,  # important, 4 warps is slower if we compute qk_sum
+            num_warps=num_warps,  # 8 was important when computing qk_sum
             ROTATE_PAIRWISE=rotate_pairwise,
         )
     return output_q, output_k, output_angle_state

--- a/mamba_ssm/ops/triton/mamba3/mamba3_mimo_rotary_step.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_mimo_rotary_step.py
@@ -24,6 +24,7 @@ def rotary_qk_inference_kernel(
     DT,
     BIAS_Q,
     BIAS_K,
+    STATE_BATCH_INDICES,  # (batch,) int32 pool rows, or None
     nheads,
     headdim,
     stride_out_q,           # (batch, mimo_dim, nheads, headdim)
@@ -41,6 +42,7 @@ def rotary_qk_inference_kernel(
     CONJUGATE: tl.constexpr,
     HAS_BIAS_Q: tl.constexpr,
     HAS_BIAS_K: tl.constexpr,
+    HAS_STATE_BATCH_INDICES: tl.constexpr,
     MIMO_DIM: tl.constexpr,
     BLOCK_D: tl.constexpr, # headdim, no chunking
     ROTATE_PAIRWISE: tl.constexpr, # If true, rotate every pair of dimensions together. Otherwise, rotate the first half and second half separately (like in the original RoPE paper)
@@ -50,13 +52,26 @@ def rotary_qk_inference_kernel(
 
     Q = Q + pid_batch * stride_q[0] + pid_nheads * stride_q[2]
     K = K + pid_batch * stride_k[0] + pid_nheads * stride_k[2]
-    ANGLE_STATE = ANGLE_STATE + pid_batch * stride_angle_state[0] + pid_nheads * stride_angle_state[1]  # FIX: [1]
     ANGLE_PROJ = ANGLE_PROJ + pid_batch * stride_angle_proj[0] + pid_nheads * stride_angle_proj[1]      # FIX: [1]
     DT = DT + pid_batch * stride_dt[0] + pid_nheads * stride_dt[1]
 
     OUT_Q = OUT_Q + pid_batch * stride_out_q[0] + pid_nheads * stride_out_q[2]
     OUT_K = OUT_K + pid_batch * stride_out_k[0] + pid_nheads * stride_out_k[2]
-    OUT_ANGLE_STATE = OUT_ANGLE_STATE + pid_batch * stride_out_angle_state[0] + pid_nheads * stride_out_angle_state[1]  # FIX: [1]
+
+    # Angle state may live in a slot-indexed pool (paged inference): read and
+    # write row state_batch_indices[b] in place instead of row b. Negative
+    # rows (padding tokens) skip the token — q/k outputs zeroed, angle state
+    # untouched (selective_state_update semantics). Implemented return-free:
+    # loads are clamped to row 0 and every store is masked by ``valid``.
+    if HAS_STATE_BATCH_INDICES:
+        state_batch_idx = tl.load(STATE_BATCH_INDICES + pid_batch)
+        valid = state_batch_idx >= 0
+        angle_batch = tl.maximum(state_batch_idx, 0)
+    else:
+        valid = True
+        angle_batch = pid_batch
+    ANGLE_STATE = ANGLE_STATE + angle_batch * stride_angle_state[0] + pid_nheads * stride_angle_state[1]  # FIX: [1]
+    OUT_ANGLE_STATE = OUT_ANGLE_STATE + angle_batch * stride_out_angle_state[0] + pid_nheads * stride_out_angle_state[1]  # FIX: [1]
 
     rm = tl.arange(0, MIMO_DIM)
     rd = tl.arange(0, BLOCK_D)
@@ -77,13 +92,22 @@ def rotary_qk_inference_kernel(
     angle = angle_state + angle_proj * dt * 3.141592653589793  # (rotary_dim // 2)
 
     OUT_ANGLE_STATE = OUT_ANGLE_STATE + rd_half * stride_out_angle_state[2]
-    tl.store(OUT_ANGLE_STATE, angle, mask=mask_angle)
+    # NOTE: the angle store is deferred to the END of the kernel. When the
+    # update is in place (state_batch_indices), the compiler may rematerialize
+    # the angle_state load inside the multi-warp q/k section instead of
+    # keeping it in registers; storing here would race those reloads with
+    # this program's own write (flaky double-stepped rotations).
+    angle_out = angle
 
     angle = angle[None, :]  # (1, rotary_dim // 2) for mimo_dim broadcasting
     cos = tl.cos(angle)
     sin = tl.sin(angle)
     if CONJUGATE:
         sin = -sin
+    if HAS_STATE_BATCH_INDICES:
+        # Padding tokens: zeroed cos/sin make every q/k output zero.
+        cos = tl.where(valid, cos, 0.0)
+        sin = tl.where(valid, sin, 0.0)
 
     # Process Q tensor
     Q = Q + (rm[:, None] * stride_q[1] + rd[None, :] * stride_q[3])
@@ -148,6 +172,9 @@ def rotary_qk_inference_kernel(
         ko = tl.reshape(k_final, [MIMO_DIM, BLOCK_D])
         tl.store(OUT_K, ko, mask=mask)
 
+    # Angle store last (see NOTE above): safe for in-place pool updates.
+    tl.store(OUT_ANGLE_STATE, angle_out, mask=mask_angle & valid)
+
 def apply_rotary_qk_inference_fwd(
     q: torch.Tensor,
     k: torch.Tensor,
@@ -159,6 +186,7 @@ def apply_rotary_qk_inference_fwd(
     inplace=False,
     conjugate=False,
     rotate_pairwise=True,
+    state_batch_indices: Optional[torch.Tensor] = None,
 ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """
     Apply rotary embedding to both q and k tensors using the same angle.
@@ -167,22 +195,34 @@ def apply_rotary_qk_inference_fwd(
     Arguments:
         q: (batch, mimo_dim, nheads, headdim)
         k: (batch, mimo_dim, nheads, headdim)
-        angle_state: (batch, nheads, rotary_dim / 2)
+        angle_state: (batch, nheads, rotary_dim / 2), or a pool of
+            (P, nheads, rotary_dim / 2) when state_batch_indices is given
         angle_proj: (batch, nheads, rotary_dim / 2)
         dt: (batch, nheads)
         bias_q: Optional (mimo_dim, nheads, headdim) - bias to add to q before rotary
         bias_k: Optional (mimo_dim, nheads, headdim) - bias to add to k before rotary
+        state_batch_indices: Optional (batch,) int32 — row of the angle-state
+            pool for each batch element. The angle state is read from and
+            written back to row state_batch_indices[b] IN PLACE (mirrors
+            selective_state_update). Negative rows skip the token: q/k
+            outputs zeroed, state untouched.
     Returns:
         (q_out, k_out, angle_state_out): q_out and k_out are (batch, mimo_dim, nheads, headdim),
                                angle_state_out is (batch, nheads, rotary_dim / 2)
+                               (= angle_state itself when state_batch_indices is given)
     """
     batch, mimo_dim, nheads, headdim = q.shape
     assert headdim % 2 == 0
     assert k.shape == q.shape, f"k shape {k.shape} != q shape {q.shape}"
 
     rotary_dim = angle_state.shape[-1] * 2
-    assert angle_state.shape == (batch, nheads, rotary_dim // 2)
-    assert angle_state.shape == angle_proj.shape
+    if state_batch_indices is not None:
+        assert state_batch_indices.shape == (batch,)
+        assert angle_state.shape[1:] == (nheads, rotary_dim // 2)
+        assert angle_proj.shape == (batch, nheads, rotary_dim // 2)
+    else:
+        assert angle_state.shape == (batch, nheads, rotary_dim // 2)
+        assert angle_state.shape == angle_proj.shape
     assert dt.shape == (batch, nheads)
     assert rotary_dim <= headdim, "rotary_dim must be <= headdim"
     assert headdim <= 256, "Only support headdim <= 256"
@@ -197,7 +237,11 @@ def apply_rotary_qk_inference_fwd(
 
     output_q = torch.empty_like(q) if not inplace else q
     output_k = torch.empty_like(k) if not inplace else k
-    output_angle_state = torch.empty_like(angle_state) if not inplace else angle_state
+    # With state_batch_indices the angle pool is always updated in place.
+    output_angle_state = (
+        angle_state if (inplace or state_batch_indices is not None)
+        else torch.empty_like(angle_state)
+    )
 
     grid = lambda META: (nheads, batch)  # noqa
     with torch.cuda.device(q.device.index):
@@ -212,6 +256,7 @@ def apply_rotary_qk_inference_fwd(
             dt,
             bias_q,
             bias_k,
+            state_batch_indices,
             nheads,
             headdim,
             output_q.stride(),  # output strides tuples
@@ -228,6 +273,7 @@ def apply_rotary_qk_inference_fwd(
             conjugate,
             bias_q is not None,
             bias_k is not None,
+            state_batch_indices is not None,
             MIMO_DIM=mimo_dim,
             BLOCK_D=triton.next_power_of_2(headdim),
             num_warps=8,  # important, 4 warps is slower if we compute qk_sum

--- a/mamba_ssm/ops/triton/mamba3/mamba3_mimo_rotary_step.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_mimo_rotary_step.py
@@ -25,6 +25,7 @@ def rotary_qk_inference_kernel(
     BIAS_Q,
     BIAS_K,
     STATE_BATCH_INDICES,  # (batch,) int32 pool rows, or None
+    angle_pool_rows,      # rows of the angle-state pool (bound check)
     nheads,
     headdim,
     stride_out_q,           # (batch, mimo_dim, nheads, headdim)
@@ -65,11 +66,15 @@ def rotary_qk_inference_kernel(
     # loads are clamped to row 0 and every store is masked by ``valid``.
     if HAS_STATE_BATCH_INDICES:
         state_batch_idx = tl.load(STATE_BATCH_INDICES + pid_batch)
-        valid = state_batch_idx >= 0
-        angle_batch = tl.maximum(state_batch_idx, 0)
+        # Out-of-range rows (CUDA-graph capture dummies) = padding too.
+        valid = (state_batch_idx >= 0) & (state_batch_idx < angle_pool_rows)
+        # int64: the pool may be a page-strided view, so int32
+        # row * stride overflows once slot ids grow with server uptime.
+        angle_batch = tl.minimum(tl.maximum(state_batch_idx, 0),
+                                 angle_pool_rows - 1).to(tl.int64)
     else:
         valid = True
-        angle_batch = pid_batch
+        angle_batch = pid_batch.to(tl.int64)
     ANGLE_STATE = ANGLE_STATE + angle_batch * stride_angle_state[0] + pid_nheads * stride_angle_state[1]  # FIX: [1]
     OUT_ANGLE_STATE = OUT_ANGLE_STATE + angle_batch * stride_out_angle_state[0] + pid_nheads * stride_out_angle_state[1]  # FIX: [1]
 
@@ -260,6 +265,7 @@ def apply_rotary_qk_inference_fwd(
             bias_q,
             bias_k,
             state_batch_indices,
+            angle_state.shape[0],
             nheads,
             headdim,
             output_q.stride(),  # output strides tuples

--- a/mamba_ssm/ops/triton/mamba3/mamba3_mimo_utils.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_mimo_utils.py
@@ -648,28 +648,41 @@ def compute_dacs_segsum_triton_varlen(
     da_cs_rev = torch.empty_like(da)
     segsum = torch.zeros(B, H, nchunks, chunk_size, chunk_size, device=da.device, dtype=da.dtype)
 
-    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
-    chunks_per_seq = (seq_lens // chunk_size) + 1
-
     # Build mapping tensors: both have length nchunks_global.
     # Inactive (padding) slots are given a sentinel local-chunk index that
     # places chunk_start >= seq_end, making the kernel mask all-False.
-    state_seq_mapping  = torch.zeros(nchunks, dtype=torch.int32, device=da.device)
-    state_chunk_in_seq = torch.zeros(nchunks, dtype=torch.int32, device=da.device)
-    default_seq_len = int(seq_lens[0].item()) if num_sequences > 0 else 0
-    default_inactive_local_chunk = (default_seq_len + chunk_size - 1) // chunk_size
-    state_chunk_in_seq.fill_(default_inactive_local_chunk)
-
-    for i in range(num_sequences):
-        start = int(cu_seqlens[i].item())
-        n = int(chunks_per_seq[i].item())
-        chunk_start = (start // chunk_size) + i
-        chunk_end = chunk_start + n
-        assert chunk_end <= nchunks, (
-            f"Chunk mapping overflow for seq {i}: [{chunk_start}, {chunk_end}) vs nchunks={nchunks}"
-        )
-        state_seq_mapping[chunk_start:chunk_end] = i
-        state_chunk_in_seq[chunk_start:chunk_end] = torch.arange(n, dtype=torch.int32, device=da.device)
+    #
+    # Fully vectorized on device — NO GPU<->CPU sync. (The previous
+    # per-sequence cu_seqlens[i].item() loop issued 2*num_sequences+1 syncs
+    # and 2*num_sequences slice-fill kernels per call; per layer per packed
+    # prefill this dominated TTFT under serving.)
+    #
+    # Sequence i owns the global chunk slots
+    #     [cu[i]//C + i,  cu[i]//C + i + len_i//C + 1)
+    # These starts are strictly increasing (floor(a+b) >= floor(a)+floor(b)),
+    # so the owner of slot g is searchsorted(starts, g, right) - 1, and
+    # slots at/after that owner's end are inactive padding. The end of the
+    # last range is always <= nchunks by the same floor inequality, so the
+    # old per-sequence overflow assert could never fire and is dropped.
+    seq_lens = cu_seqlens[1:] - cu_seqlens[:-1]
+    seq_idx = torch.arange(
+        num_sequences, dtype=cu_seqlens.dtype, device=da.device
+    )
+    range_starts = cu_seqlens[:-1] // chunk_size + seq_idx
+    range_ends = range_starts + seq_lens // chunk_size + 1
+    g = torch.arange(nchunks, dtype=cu_seqlens.dtype, device=da.device)
+    owner = torch.searchsorted(range_starts, g, right=True) - 1
+    active = g < range_ends[owner]
+    # Sentinel for inactive slots: ceil(len_0 / C), matching the original.
+    default_inactive_local_chunk = (
+        (seq_lens[0] + chunk_size - 1) // chunk_size
+    )
+    state_seq_mapping = torch.where(
+        active, owner, torch.zeros_like(owner)
+    ).to(torch.int32)
+    state_chunk_in_seq = torch.where(
+        active, g - range_starts[owner], default_inactive_local_chunk
+    ).to(torch.int32)
 
     grid = (B, H, nchunks)
     dacs_segsum_kernel_varlen[grid](

--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
@@ -165,7 +165,12 @@ class _Mamba3Function(torch.autograd.Function):
         except Exception:
             pass
         
-        if len(ctx.saved_tensors) == 0:
+        # Access ctx.saved_tensors exactly once: each access re-runs the
+        # saved-tensor unpack hooks, and non-reentrant gradient checkpointing
+        # only permits a single unpack per tensor — a second access raises
+        # CheckpointError.
+        saved = ctx.saved_tensors
+        if len(saved) == 0:
             raise RuntimeError(
                 "Backward called but forward ran without gradient tracking. "
                 "Ensure inputs require grad or run under torch.enable_grad()."
@@ -176,7 +181,7 @@ class _Mamba3Function(torch.autograd.Function):
         (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, Angles_Cumsum,
         D_save, Z_save, Input_SSM_State_save, Input_K_State_save, Input_V_State_save,
         Out, Out_v, SSM_States, DA_CS, DA_CS_SUM, Q_rot, K_scaled, QK_dot, Scale, Gamma,
-        Final_SSM_State_save, cu_seqlens_save) = ctx.saved_tensors
+        Final_SSM_State_save, cu_seqlens_save) = saved
         
         D = D_save if ctx.has_D else None
         Z = Z_save if ctx.has_Z else None

--- a/tests/modules/test_mamba3_inference.py
+++ b/tests/modules/test_mamba3_inference.py
@@ -1,0 +1,58 @@
+"""
+Mamba-3 module-level inference tests.
+
+Copyright (c) 2026, Dao AI Lab, Goombalab.
+"""
+
+import pytest
+import torch
+
+from mamba_ssm.modules.mamba3 import Mamba3
+from mamba_ssm.utils.generation import InferenceParams
+
+
+def _require_cuda():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+
+
+def _make_model(is_mimo: bool, **kwargs) -> Mamba3:
+    defaults = dict(
+        d_model=128,
+        d_state=64,
+        expand=2,
+        headdim=64,
+        ngroups=1,
+        is_mimo=is_mimo,
+        mimo_rank=2,
+        chunk_size=16,
+        layer_idx=0,
+        device="cuda",
+        dtype=torch.bfloat16,
+    )
+    defaults.update(kwargs)
+    return Mamba3(**defaults).eval()
+
+
+@pytest.mark.parametrize("is_mimo", [False, True])
+def test_mamba3_inference_params_prefill_uses_cached_states(is_mimo):
+    """Prefill should consume cached states when seqlen_offset stays at 0."""
+    _require_cuda()
+    torch.manual_seed(2)
+
+    model = _make_model(is_mimo=is_mimo)
+    d_model = model.d_model
+    split = 32
+    seqlen = 48
+    u = torch.randn(1, seqlen, d_model, device="cuda", dtype=torch.bfloat16)
+    inference_params = InferenceParams(max_seqlen=seqlen, max_batch_size=1)
+
+    with torch.no_grad():
+        full = model(u)
+        first = model(u[:, :split], inference_params=inference_params)
+        second = model(u[:, split:], inference_params=inference_params)
+
+    combined = torch.cat([first, second], dim=1)
+    assert torch.allclose(combined, full, atol=8e-2, rtol=8e-2), (
+        f"max diff = {(combined - full).abs().max():.4f}"
+    )

--- a/tests/ops/test_mamba3_step_fused_rotary.py
+++ b/tests/ops/test_mamba3_step_fused_rotary.py
@@ -1,0 +1,97 @@
+# Copyright (c) 2025, Tri Dao.
+"""Parity: mamba3_step_fn fused bias+rotary vs the two-kernel reference
+(apply_rotary_qk_inference_fwd -> mamba3_step_fn).
+
+Tolerances are bf16-level: the two paths use different cos/sin backends
+(Triton libdevice vs CuteDSL), so bit-identity is not expected; everything
+else (single bf16 rounding of the rotated values, fp32 state math) matches.
+"""
+import pytest
+import torch
+
+from mamba_ssm.ops.cute.mamba3.mamba3_step_fn import mamba3_step_fn
+from mamba_ssm.ops.triton.mamba3.mamba3_mimo_rotary_step import (
+    apply_rotary_qk_inference_fwd,
+)
+
+H, D, N, R = 48, 64, 128, 4
+ROT, A_HALF = 64, 32
+P = 37
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+@requires_cuda
+@pytest.mark.parametrize("B,npad", [(1, 0), (5, 0), (24, 0), (8, 3), (24, 8)])
+def test_fused_rotary_matches_two_kernel_reference(B: int, npad: int):
+    torch.manual_seed(0)
+    dev = "cuda"
+    real = B - npad
+    slots = torch.randperm(P, device=dev)[:B].to(torch.int32)
+    slots[real:] = -1
+
+    ssm_pool = torch.randn(P, H, D, N, device=dev, dtype=torch.float32)
+    k_pool = torch.randn(P, R, H, N, device=dev, dtype=torch.bfloat16)
+    v_pool = torch.randn(P, H, D, device=dev, dtype=torch.bfloat16)
+    angle_pool = torch.randn(P, H, A_HALF, device=dev, dtype=torch.float32)
+
+    # Pre-rotation B/C: shared across heads (Dragon: ngroups == 1).
+    B_pre = torch.randn(B, R, 1, N, device=dev, dtype=torch.bfloat16)
+    C_pre = torch.randn(B, R, 1, N, device=dev, dtype=torch.bfloat16)
+    bias_q = torch.randn(R, H, N, device=dev, dtype=torch.float32)
+    bias_k = torch.randn(R, H, N, device=dev, dtype=torch.float32)
+    angle_proj = torch.randn(B, 1, A_HALF, device=dev, dtype=torch.float32)
+
+    A = -torch.rand(B, H, device=dev, dtype=torch.float32)
+    Dp = torch.randn(H, device=dev, dtype=torch.float32)
+    x = torch.randn(B, H, D, device=dev, dtype=torch.bfloat16)
+    dt = torch.rand(B, H, device=dev, dtype=torch.float32)
+    trap = torch.rand(B, H, device=dev, dtype=torch.float32)
+    xpj = torch.randn(R, H, D, device=dev, dtype=torch.bfloat16)
+    opj = torch.randn(R, H, D, device=dev, dtype=torch.bfloat16)
+    zz = torch.randn(B, H, D, device=dev, dtype=torch.bfloat16)
+    zpj = torch.randn(R, H, D, device=dev, dtype=torch.bfloat16)
+
+    B_exp = B_pre.expand(-1, -1, H, -1)
+    C_exp = C_pre.expand(-1, -1, H, -1)
+    ap_exp = angle_proj.expand(-1, H, -1)
+
+    # --- reference: rotary kernel then step kernel --------------------------
+    pool_r, k_r, v_r = ssm_pool.clone(), k_pool.clone(), v_pool.clone()
+    ang_r = angle_pool.clone()
+    C_rot, B_rot, _ = apply_rotary_qk_inference_fwd(
+        q=C_exp, k=B_exp, angle_state=ang_r, angle_proj=ap_exp, dt=dt,
+        bias_q=bias_q, bias_k=bias_k, conjugate=False, inplace=False,
+        rotate_pairwise=False, state_batch_indices=slots)
+    y_r = torch.empty_like(x)
+    mamba3_step_fn(pool_r, k_r, v_r, A, B_rot.to(torch.bfloat16),
+                   C_rot.to(torch.bfloat16), Dp, x, dt, trap, xpj, opj,
+                   None, y_r, z=zz, zproj=zpj, state_batch_indices=slots,
+                   update_kv_state=True, tile_D=64, num_warps=4)
+
+    # --- fused: single step kernel ------------------------------------------
+    pool_f, k_f, v_f = ssm_pool.clone(), k_pool.clone(), v_pool.clone()
+    ang_f = angle_pool.clone()
+    y_f = torch.empty_like(x)
+    mamba3_step_fn(pool_f, k_f, v_f, A, B_exp, C_exp, Dp, x, dt, trap,
+                   xpj, opj, None, y_f, z=zz, zproj=zpj,
+                   state_batch_indices=slots, update_kv_state=True,
+                   rotary_dim=ROT, rotary_bias_q=bias_q,
+                   rotary_bias_k=bias_k, rotary_angle_proj=ap_exp,
+                   rotary_angle_state=ang_f, tile_D=64, num_warps=4)
+    torch.cuda.synchronize()
+
+    assert torch.allclose(ang_f, ang_r, atol=1e-5, rtol=1e-5)
+    assert torch.allclose(k_f.float(), k_r.float(), atol=2e-2, rtol=2e-2)
+    assert torch.equal(v_f, v_r)
+    assert torch.allclose(pool_f, pool_r, atol=2e-2, rtol=2e-2)
+    assert torch.allclose(y_f.float(), y_r.float(), atol=4e-2, rtol=4e-2)
+    if npad:
+        assert torch.equal(y_f[real:], torch.zeros_like(y_f[real:]))
+    # untouched pool rows untouched
+    mask = torch.ones(P, dtype=torch.bool, device=dev)
+    mask[slots[:real].long()] = False
+    assert torch.equal(pool_f[mask], ssm_pool[mask])
+    assert torch.equal(ang_f[mask], angle_pool[mask])

--- a/tests/ops/test_mamba3_step_indexed.py
+++ b/tests/ops/test_mamba3_step_indexed.py
@@ -1,0 +1,107 @@
+# Copyright (c) 2025, Tri Dao.
+"""Parity tests for mamba3_step_fn's indexed state-pool mode.
+
+The indexed path (``state_indices``) must be byte-identical to the
+gather -> dense kernel -> scatter reference, including:
+- negative (PAD_SLOT_ID) indices from CUDA-graph batch padding,
+- untouched pool rows staying untouched,
+- ``update_kv_state=True`` storing the new B/x states exactly as the
+  caller-side scatter would.
+"""
+import pytest
+import torch
+
+from mamba_ssm.ops.cute.mamba3.mamba3_step_fn import mamba3_step_fn
+
+H, D, N, R = 48, 64, 128, 4
+P = 37  # pool rows
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+def _rand_inputs(B, state_dtype=torch.float32):
+    dev = "cuda"
+    ssm_pool = torch.randn(P, H, D, N, device=dev, dtype=state_dtype)
+    k_pool = torch.randn(P, R, H, N, device=dev, dtype=torch.bfloat16)
+    v_pool = torch.randn(P, H, D, device=dev, dtype=torch.bfloat16)
+    return dict(
+        ssm_pool=ssm_pool, k_pool=k_pool, v_pool=v_pool,
+        A=-torch.rand(B, H, device=dev, dtype=torch.float32),
+        B=torch.randn(B, R, H, N, device=dev, dtype=torch.bfloat16),
+        C=torch.randn(B, R, H, N, device=dev, dtype=torch.bfloat16),
+        Dp=torch.randn(H, device=dev, dtype=torch.float32),
+        x=torch.randn(B, H, D, device=dev, dtype=torch.bfloat16),
+        dt=torch.rand(B, H, device=dev, dtype=torch.float32),
+        trap=torch.rand(B, H, device=dev, dtype=torch.float32),
+        xpj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        opj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        z=torch.randn(B, H, D, device=dev, dtype=torch.bfloat16),
+        zpj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+    )
+
+
+@requires_cuda
+@pytest.mark.parametrize("B,npad", [(1, 0), (5, 0), (32, 0), (8, 3), (24, 8)])
+@pytest.mark.parametrize("update_kv", [False, True])
+def test_indexed_matches_gather_scatter(B: int, npad: int, update_kv: bool):
+    torch.manual_seed(0)
+    t = _rand_inputs(B)
+    real = B - npad
+    slots = torch.randperm(P, device="cuda")[:B].to(torch.int32)
+    slots[real:] = -1  # PAD_SLOT_ID lanes
+    rs = slots[:real].long()
+
+    # Reference: gather -> dense kernel -> scatter (real lanes only).
+    pool_ref = t["ssm_pool"].clone()
+    k_ref, v_ref = t["k_pool"].clone(), t["v_pool"].clone()
+    st = pool_ref[rs]
+    st_out = torch.empty_like(st)
+    y_ref = torch.empty_like(t["x"][:real])
+    mamba3_step_fn(st, k_ref[rs], v_ref[rs], t["A"][:real], t["B"][:real],
+                   t["C"][:real], t["Dp"], t["x"][:real], t["dt"][:real],
+                   t["trap"][:real], t["xpj"], t["opj"], st_out, y_ref,
+                   z=t["z"][:real], zproj=t["zpj"], tile_D=64, num_warps=4)
+    pool_ref[rs] = st_out
+    k_ref[rs] = t["B"][:real]  # caller-side kv update (old semantics)
+    v_ref[rs] = t["x"][:real]
+
+    # Indexed: in-place pool update via slot indices.
+    pool_new = t["ssm_pool"].clone()
+    k_new, v_new = t["k_pool"].clone(), t["v_pool"].clone()
+    y_new = torch.empty_like(t["x"])
+    mamba3_step_fn(pool_new, k_new, v_new, t["A"], t["B"], t["C"], t["Dp"],
+                   t["x"], t["dt"], t["trap"], t["xpj"], t["opj"], None,
+                   y_new, z=t["z"], zproj=t["zpj"], state_batch_indices=slots,
+                   update_kv_state=update_kv, tile_D=64, num_warps=4)
+    if not update_kv:
+        k_new[torch.where(slots >= 0, slots, 0).long()[:real]] = t["B"][:real]
+        v_new[torch.where(slots >= 0, slots, 0).long()[:real]] = t["x"][:real]
+    torch.cuda.synchronize()
+
+    assert torch.equal(y_new[:real], y_ref)
+    # Padding lanes produce zeroed outputs (selective_state_update semantics).
+    if npad:
+        assert torch.equal(y_new[real:], torch.zeros_like(y_new[real:]))
+    assert torch.equal(pool_new, pool_ref)
+    assert torch.equal(k_new, k_ref)
+    assert torch.equal(v_new, v_ref)
+    # untouched pool rows must be untouched
+    mask = torch.ones(P, dtype=torch.bool, device="cuda")
+    mask[rs] = False
+    assert torch.equal(pool_new[mask], t["ssm_pool"][mask])
+
+
+@requires_cuda
+def test_update_kv_state_requires_single_d_tile():
+    torch.manual_seed(0)
+    t = _rand_inputs(4)
+    slots = torch.arange(4, device="cuda", dtype=torch.int32)
+    y = torch.empty_like(t["x"])
+    with pytest.raises(AssertionError, match="single D-tile"):
+        mamba3_step_fn(t["ssm_pool"], t["k_pool"], t["v_pool"], t["A"],
+                       t["B"], t["C"], t["Dp"], t["x"], t["dt"], t["trap"],
+                       t["xpj"], t["opj"], None, y, z=t["z"], zproj=t["zpj"],
+                       state_batch_indices=slots, update_kv_state=True,
+                       tile_D=32, num_warps=4)

--- a/tests/ops/test_mamba3_step_specslots.py
+++ b/tests/ops/test_mamba3_step_specslots.py
@@ -1,0 +1,183 @@
+# Copyright (c) 2026.
+"""Parity: dual-slot step (state_batch_indices_out) vs the in-place step.
+
+The spec-decode verify primitive: launch t reads the state at slot[t-1] and
+writes slot[t]. Reference = the plain in-place step advanced sequentially on
+one slot, checkpointing the pool after every token. Every per-position state
+(ssm/k/v/angle) and every per-token output must be BIT-IDENTICAL: the dual
+slot changes addressing only, not math.
+"""
+import pytest
+import torch
+
+from mamba_ssm.ops.cute.mamba3.mamba3_step_fn import mamba3_step_fn
+
+H, D, N, R = 48, 64, 128, 4
+ROT, A_HALF = 64, 32
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+def _mk_inputs(B, dev):
+    return dict(
+        A=-torch.rand(B, H, device=dev, dtype=torch.float32),
+        x=torch.randn(B, H, D, device=dev, dtype=torch.bfloat16),
+        dt=torch.rand(B, H, device=dev, dtype=torch.float32),
+        trap=torch.rand(B, H, device=dev, dtype=torch.float32),
+        B_pre=torch.randn(B, R, 1, N, device=dev, dtype=torch.bfloat16),
+        C_pre=torch.randn(B, R, 1, N, device=dev, dtype=torch.bfloat16),
+        angle_proj=torch.randn(B, 1, A_HALF, device=dev, dtype=torch.float32),
+        z=torch.randn(B, H, D, device=dev, dtype=torch.bfloat16),
+    )
+
+
+def _step(pools, slots_in, slots_out, inp, weights, y):
+    ssm, k, v, ang = pools
+    mamba3_step_fn(
+        ssm, k, v, inp["A"],
+        inp["B_pre"].expand(-1, -1, H, -1),
+        inp["C_pre"].expand(-1, -1, H, -1),
+        weights["Dp"], inp["x"], inp["dt"], inp["trap"],
+        weights["xpj"], weights["opj"], None, y,
+        z=inp["z"], zproj=weights["zpj"],
+        state_batch_indices=slots_in,
+        state_batch_indices_out=slots_out,
+        update_kv_state=True,
+        rotary_dim=ROT,
+        rotary_bias_q=weights["bias_q"], rotary_bias_k=weights["bias_k"],
+        rotary_angle_proj=inp["angle_proj"].expand(-1, H, -1),
+        rotary_angle_state=ang,
+        tile_D=64, num_warps=4,
+    )
+
+
+@requires_cuda
+@pytest.mark.parametrize("n_req,T", [(1, 4), (3, 5), (8, 2)])
+def test_dual_slot_chain_matches_inplace(n_req: int, T: int):
+    """T dual-slot launches == T in-place launches, per-position states."""
+    torch.manual_seed(0)
+    dev = "cuda"
+    # Slot layout: request r owns main slot r and scratch slots
+    # n_req + r*T + t for position t.
+    P = n_req * (T + 1) + 3
+    weights = dict(
+        Dp=torch.randn(H, device=dev, dtype=torch.float32),
+        xpj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        opj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        zpj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        bias_q=torch.randn(R, H, N, device=dev, dtype=torch.float32),
+        bias_k=torch.randn(R, H, N, device=dev, dtype=torch.float32),
+    )
+    ssm0 = torch.randn(P, H, D, N, device=dev, dtype=torch.float32)
+    k0 = torch.randn(P, R, H, N, device=dev, dtype=torch.bfloat16)
+    v0 = torch.randn(P, H, D, device=dev, dtype=torch.bfloat16)
+    ang0 = torch.randn(P, H, A_HALF, device=dev, dtype=torch.float32)
+    steps = [_mk_inputs(n_req, dev) for _ in range(T)]
+
+    # --- reference: in-place chain on the main slots, checkpoint each t ----
+    pools_r = (ssm0.clone(), k0.clone(), v0.clone(), ang0.clone())
+    main = torch.arange(n_req, device=dev, dtype=torch.int32)
+    y_ref, ckpt = [], []
+    for t in range(T):
+        y = torch.empty(n_req, H, D, device=dev, dtype=torch.bfloat16)
+        _step(pools_r, main, None, steps[t], weights, y)
+        y_ref.append(y.clone())
+        ckpt.append(tuple(p[main.long()].clone() for p in pools_r))
+
+    # --- dual-slot chain: read slot[t-1], write scratch slot[t] ------------
+    pools_s = (ssm0.clone(), k0.clone(), v0.clone(), ang0.clone())
+    scratch = (
+        n_req
+        + torch.arange(n_req, device=dev, dtype=torch.int32)[:, None] * T
+        + torch.arange(T, device=dev, dtype=torch.int32)[None, :]
+    )  # (n_req, T)
+    y_spec = []
+    for t in range(T):
+        slots_in = main if t == 0 else scratch[:, t - 1].contiguous()
+        slots_out = scratch[:, t].contiguous()
+        y = torch.empty(n_req, H, D, device=dev, dtype=torch.bfloat16)
+        _step(pools_s, slots_in, slots_out, steps[t], weights, y)
+        y_spec.append(y.clone())
+
+    for t in range(T):
+        assert torch.equal(y_spec[t], y_ref[t]), f"output mismatch at t={t}"
+        rows = scratch[:, t].long()
+        for name, pool, ref in zip(
+            ("ssm", "k", "v", "angle"),
+            pools_s,
+            ckpt[t],
+        ):
+            assert torch.equal(pool[rows], ref), f"{name} state mismatch t={t}"
+
+    # Main slots (and every untouched row) must be unmodified by the
+    # dual-slot chain except main's first read.
+    assert torch.equal(pools_s[0][main.long()], ssm0[main.long()])
+    assert torch.equal(pools_s[3][main.long()], ang0[main.long()])
+
+
+@requires_cuda
+def test_out_equals_in_matches_inplace():
+    """slots_out == slots_in must be bit-identical to plain in-place."""
+    torch.manual_seed(1)
+    dev = "cuda"
+    B, P = 6, 11
+    weights = dict(
+        Dp=torch.randn(H, device=dev, dtype=torch.float32),
+        xpj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        opj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        zpj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        bias_q=torch.randn(R, H, N, device=dev, dtype=torch.float32),
+        bias_k=torch.randn(R, H, N, device=dev, dtype=torch.float32),
+    )
+    slots = torch.randperm(P, device=dev)[:B].to(torch.int32)
+    ssm0 = torch.randn(P, H, D, N, device=dev, dtype=torch.float32)
+    k0 = torch.randn(P, R, H, N, device=dev, dtype=torch.bfloat16)
+    v0 = torch.randn(P, H, D, device=dev, dtype=torch.bfloat16)
+    ang0 = torch.randn(P, H, A_HALF, device=dev, dtype=torch.float32)
+    inp = _mk_inputs(B, dev)
+
+    pools_a = (ssm0.clone(), k0.clone(), v0.clone(), ang0.clone())
+    y_a = torch.empty(B, H, D, device=dev, dtype=torch.bfloat16)
+    _step(pools_a, slots, None, inp, weights, y_a)
+
+    pools_b = (ssm0.clone(), k0.clone(), v0.clone(), ang0.clone())
+    y_b = torch.empty(B, H, D, device=dev, dtype=torch.bfloat16)
+    _step(pools_b, slots, slots.clone(), inp, weights, y_b)
+
+    assert torch.equal(y_a, y_b)
+    for pa, pb in zip(pools_a, pools_b):
+        assert torch.equal(pa, pb)
+
+
+@requires_cuda
+def test_pad_lane_out_slot_suppressed():
+    """A padded out slot (-1) must leave every pool row untouched."""
+    torch.manual_seed(2)
+    dev = "cuda"
+    B, P = 4, 9
+    weights = dict(
+        Dp=torch.randn(H, device=dev, dtype=torch.float32),
+        xpj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        opj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        zpj=torch.randn(R, H, D, device=dev, dtype=torch.bfloat16),
+        bias_q=torch.randn(R, H, N, device=dev, dtype=torch.float32),
+        bias_k=torch.randn(R, H, N, device=dev, dtype=torch.float32),
+    )
+    slots_in = torch.tensor([0, 1, 2, -1], device=dev, dtype=torch.int32)
+    slots_out = torch.tensor([4, 5, -1, -1], device=dev, dtype=torch.int32)
+    ssm0 = torch.randn(P, H, D, N, device=dev, dtype=torch.float32)
+    k0 = torch.randn(P, R, H, N, device=dev, dtype=torch.bfloat16)
+    v0 = torch.randn(P, H, D, device=dev, dtype=torch.bfloat16)
+    ang0 = torch.randn(P, H, A_HALF, device=dev, dtype=torch.float32)
+    pools = (ssm0.clone(), k0.clone(), v0.clone(), ang0.clone())
+    y = torch.empty(B, H, D, device=dev, dtype=torch.bfloat16)
+    _step(pools, slots_in, slots_out, _mk_inputs(B, dev), weights, y)
+
+    written = {4, 5}
+    untouched = [i for i in range(P) if i not in written]
+    for pool, ref in zip(pools, (ssm0, k0, v0, ang0)):
+        assert torch.equal(pool[untouched], ref[untouched])
+    # Lane 2 (valid in, pad out): output still computed, nothing written.
+    assert torch.isfinite(y[:3].float()).all()

--- a/tests/ops/test_rotary_step_indexed.py
+++ b/tests/ops/test_rotary_step_indexed.py
@@ -1,0 +1,67 @@
+# Copyright (c) 2025, Tri Dao.
+"""Parity for apply_rotary_qk_inference_fwd's state_batch_indices mode:
+indexed in-place pool update must match gather -> kernel -> scatter, with
+negative (padding) indices skipping the token (q/k zeroed, pool untouched)."""
+import pytest
+import torch
+
+from mamba_ssm.ops.triton.mamba3.mamba3_mimo_rotary_step import (
+    apply_rotary_qk_inference_fwd,
+)
+
+H, D, R = 48, 128, 4
+ROT_HALF = 32  # rotary_dim // 2
+P = 37
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+@requires_cuda
+@pytest.mark.parametrize("B,npad", [(1, 0), (5, 0), (24, 0), (8, 3), (24, 8)])
+def test_indexed_rotary_matches_gather_scatter(B: int, npad: int):
+    torch.manual_seed(0)
+    dev = "cuda"
+    real = B - npad
+    slots = torch.randperm(P, device=dev)[:B].to(torch.int32)
+    slots[real:] = -1
+
+    angle_pool = torch.randn(P, H, ROT_HALF, device=dev, dtype=torch.float32)
+    q = torch.randn(B, R, H, D, device=dev, dtype=torch.bfloat16)
+    k = torch.randn(B, R, H, D, device=dev, dtype=torch.bfloat16)
+    angle_proj = torch.randn(B, H, ROT_HALF, device=dev, dtype=torch.float32)
+    dt = torch.rand(B, H, device=dev, dtype=torch.float32)
+    bias_q = torch.randn(R, H, D, device=dev, dtype=torch.float32)
+    bias_k = torch.randn(R, H, D, device=dev, dtype=torch.float32)
+
+    # Reference: gather -> kernel -> scatter (real lanes only).
+    rs = slots[:real].long()
+    pool_ref = angle_pool.clone()
+    q_ref, k_ref, nxt = apply_rotary_qk_inference_fwd(
+        q=q[:real], k=k[:real], angle_state=pool_ref[rs],
+        angle_proj=angle_proj[:real], dt=dt[:real],
+        bias_q=bias_q, bias_k=bias_k,
+        conjugate=False, inplace=False, rotate_pairwise=False)
+    pool_ref[rs] = nxt
+
+    # Indexed: pool + slot indices, in-place.
+    pool_new = angle_pool.clone()
+    q_new, k_new, ret = apply_rotary_qk_inference_fwd(
+        q=q, k=k, angle_state=pool_new,
+        angle_proj=angle_proj, dt=dt,
+        bias_q=bias_q, bias_k=bias_k,
+        conjugate=False, inplace=False, rotate_pairwise=False,
+        state_batch_indices=slots)
+    torch.cuda.synchronize()
+
+    assert ret is pool_new  # in-place pool return
+    assert torch.equal(q_new[:real], q_ref)
+    assert torch.equal(k_new[:real], k_ref)
+    if npad:
+        assert torch.equal(q_new[real:], torch.zeros_like(q_new[real:]))
+        assert torch.equal(k_new[real:], torch.zeros_like(k_new[real:]))
+    assert torch.equal(pool_new, pool_ref)
+    mask = torch.ones(P, dtype=torch.bool, device=dev)
+    mask[rs] = False
+    assert torch.equal(pool_new[mask], angle_pool[mask])

--- a/tests/ops/test_segsum_varlen_mapping.py
+++ b/tests/ops/test_segsum_varlen_mapping.py
@@ -1,0 +1,72 @@
+# Copyright (c) 2025, Tri Dao.
+"""The vectorized chunk-mapping in compute_dacs_segsum_triton_varlen must be
+bit-identical to the original per-sequence loop semantics."""
+import pytest
+import torch
+
+from mamba_ssm.ops.triton.mamba3.mamba3_mimo_utils import (
+    compute_dacs_segsum_triton_varlen,
+)
+
+C = 64
+
+requires_cuda = pytest.mark.skipif(
+    not torch.cuda.is_available(), reason="requires CUDA"
+)
+
+
+def _ref_mappings(cu_list, chunk_size, nchunks):
+    """The original loop implementation (reference semantics)."""
+    seq_map = torch.zeros(nchunks, dtype=torch.int32)
+    default_seq_len = cu_list[1] - cu_list[0]
+    chunk_in_seq = torch.full(
+        (nchunks,), (default_seq_len + chunk_size - 1) // chunk_size,
+        dtype=torch.int32)
+    for i in range(len(cu_list) - 1):
+        start = cu_list[i]
+        n = (cu_list[i + 1] - start) // chunk_size + 1
+        cs = start // chunk_size + i
+        seq_map[cs:cs + n] = i
+        chunk_in_seq[cs:cs + n] = torch.arange(n, dtype=torch.int32)
+    return seq_map, chunk_in_seq
+
+
+@requires_cuda
+@pytest.mark.parametrize("cu_list", [
+    [0, 7],                          # single short seq
+    [0, 64],                         # exactly one chunk
+    [0, 64, 128, 192],               # all multiples of C
+    [0, 1, 2, 3, 4],                 # single-token seqs
+    [0, 100, 101, 357, 999, 1000],   # mixed
+    [0, 513],                        # NS=1 long
+    list(range(0, 33 * 17, 17)),     # 32 seqs of 17
+])
+def test_mapping_matches_reference(cu_list):
+    torch.manual_seed(0)
+    NS, S = len(cu_list) - 1, cu_list[-1]
+    nchunks = S // C + NS
+    cu = torch.tensor(cu_list, dtype=torch.int32, device="cuda")
+
+    # Recompute the vectorized mapping exactly as the function does.
+    seq_lens = cu[1:] - cu[:-1]
+    starts = cu[:-1] // C + torch.arange(NS, dtype=cu.dtype, device="cuda")
+    ends = starts + seq_lens // C + 1
+    g = torch.arange(nchunks, dtype=cu.dtype, device="cuda")
+    owner = torch.searchsorted(starts, g, right=True) - 1
+    active = g < ends[owner]
+    sm = torch.where(active, owner, torch.zeros_like(owner)).to(torch.int32)
+    cis = torch.where(active, g - starts[owner],
+                      (seq_lens[0] + C - 1) // C).to(torch.int32)
+
+    rsm, rcis = _ref_mappings(cu_list, C, nchunks)
+    assert torch.equal(sm.cpu(), rsm)
+    assert torch.equal(cis.cpu(), rcis)
+
+    # End-to-end: the full function runs and produces finite outputs of the
+    # right shapes through the vectorized path.
+    da = torch.randn(1, 2, S, device="cuda", dtype=torch.float32) * -0.1
+    da_cs, da_cs_rev, segsum = compute_dacs_segsum_triton_varlen(
+        da, C, cu_seqlens=cu)
+    assert da_cs.shape == da.shape
+    assert segsum.shape[2] == nchunks
+    assert torch.isfinite(da_cs).all()

--- a/tests/ops/tilelang/test_mamba3_mimo.py
+++ b/tests/ops/tilelang/test_mamba3_mimo.py
@@ -1637,6 +1637,157 @@ def test_mamba_mimo_smoke_forward_backward(mods: SimpleNamespace) -> None:
         assert torch.isfinite(grad).all(), f"Non-finite gradient detected for {name}"
 
 
+def test_mamba3_mimo_initial_states_split_prefill_matches_full(mods: SimpleNamespace) -> None:
+    chunk_size = 16
+    split = 32
+    inputs = make_smoke_inputs(
+        batch=1,
+        seqlen=64,
+        mimo_rank=4,
+        nheads_qk=1,
+        nheads=8,
+        headdim_qk=128,
+        headdim_v=64,
+        chunk_size=chunk_size,
+        rotary_dim_divisor=FIXED_ROTARY_DIM_DIVISOR,
+        device="cuda",
+        dtype=FIXED_DTYPE,
+        seed=123,
+    )
+
+    def copied(t: Tensor) -> Tensor:
+        out = torch.empty(t.shape, device=t.device, dtype=t.dtype)
+        out.copy_(t)
+        return out
+
+    def sliced(start: int, end: int) -> dict:
+        out = dict(inputs)
+        for name in ("Q", "K", "V", "Angles", "Z"):
+            out[name] = copied(inputs[name][:, start:end])
+        for name in ("ADT", "DT", "Trap"):
+            out[name] = copied(inputs[name][:, :, start:end])
+        return out
+
+    with torch.no_grad():
+        full_out, full_angle, full_ssm, full_k, full_v = mods.top.mamba3_mimo(
+            **inputs, return_state=True
+        )
+        first_out, first_angle, first_ssm, first_k, first_v = mods.top.mamba3_mimo(
+            **sliced(0, split), return_state=True
+        )
+        second_out, final_angle, final_ssm, final_k, final_v = mods.top.mamba3_mimo(
+            **sliced(split, 64),
+            return_state=True,
+            Input_States=(first_angle, first_ssm, first_k, first_v),
+        )
+
+    split_out = torch.cat([first_out, second_out], dim=1)
+    cfg = f"B=1, S=64, split={split}, H=8, P=64, N=128, R=4, C={chunk_size}"
+    assert_stable_rel(split_out, full_out, label="initial_state_split_out", cfg=cfg)
+    assert_stable_rel(final_angle, full_angle, label="initial_state_split_angle", cfg=cfg)
+    assert_stable_rel(final_ssm, full_ssm, label="initial_state_split_ssm", cfg=cfg)
+    assert_stable_rel(final_k, full_k, label="initial_state_split_k", cfg=cfg)
+    assert_stable_rel(final_v, full_v, label="initial_state_split_v", cfg=cfg)
+
+
+def test_mamba3_mimo_varlen_initial_states_split_prefill_matches_full(mods: SimpleNamespace) -> None:
+    chunk_size = 16
+    seqlens = [31, 42, 47]
+    splits = [16, 18, 21]
+    suffix_lens = [seqlen - split for seqlen, split in zip(seqlens, splits)]
+    full_starts = [0]
+    for seqlen in seqlens[:-1]:
+        full_starts.append(full_starts[-1] + seqlen)
+    s_total = sum(seqlens)
+    inputs = make_smoke_inputs(
+        batch=1,
+        seqlen=s_total,
+        mimo_rank=4,
+        nheads_qk=1,
+        nheads=8,
+        headdim_qk=128,
+        headdim_v=64,
+        chunk_size=chunk_size,
+        rotary_dim_divisor=FIXED_ROTARY_DIM_DIVISOR,
+        device="cuda",
+        dtype=FIXED_DTYPE,
+        seed=321,
+    )
+
+    def cu_seqlens(lengths: list[int]) -> Tensor:
+        return torch.tensor(
+            [0] + list(torch.cumsum(torch.tensor(lengths, dtype=torch.int32), dim=0).tolist()),
+            device="cuda",
+            dtype=torch.int32,
+        )
+
+    def packed_spans(starts: list[int], ends: list[int]) -> dict:
+        out = dict(inputs)
+        for name in ("Q", "K", "V", "Angles", "Z"):
+            out[name] = torch.cat(
+                [inputs[name][:, start:end] for start, end in zip(starts, ends)],
+                dim=1,
+            )
+        for name in ("ADT", "DT", "Trap"):
+            out[name] = torch.cat(
+                [inputs[name][:, :, start:end] for start, end in zip(starts, ends)],
+                dim=2,
+            )
+        return out
+
+    full_cu = cu_seqlens(seqlens)
+    prefix_cu = cu_seqlens(splits)
+    suffix_cu = cu_seqlens(suffix_lens)
+    prefix_starts = full_starts
+    prefix_ends = [start + split for start, split in zip(full_starts, splits)]
+    suffix_starts = prefix_ends
+    suffix_ends = [start + seqlen for start, seqlen in zip(full_starts, seqlens)]
+    prefix_inputs = packed_spans(prefix_starts, prefix_ends)
+    suffix_inputs = packed_spans(suffix_starts, suffix_ends)
+
+    with torch.no_grad():
+        full_out, full_angle, full_ssm, full_k, full_v = mods.top.mamba3_mimo(
+            **inputs,
+            return_state=True,
+            cu_seqlens=full_cu,
+        )
+        prefix_out, prefix_angle, prefix_ssm, prefix_k, prefix_v = mods.top.mamba3_mimo(
+            **prefix_inputs,
+            return_state=True,
+            cu_seqlens=prefix_cu,
+        )
+        suffix_out, final_angle, final_ssm, final_k, final_v = mods.top.mamba3_mimo(
+            **suffix_inputs,
+            return_state=True,
+            cu_seqlens=suffix_cu,
+            Input_States=(prefix_angle, prefix_ssm, prefix_k, prefix_v),
+        )
+
+    combined_parts = []
+    prefix_offset = 0
+    suffix_offset = 0
+    for split, suffix_len in zip(splits, suffix_lens):
+        combined_parts.append(
+            torch.cat(
+                [
+                    prefix_out[:, prefix_offset:prefix_offset + split],
+                    suffix_out[:, suffix_offset:suffix_offset + suffix_len],
+                ],
+                dim=1,
+            )
+        )
+        prefix_offset += split
+        suffix_offset += suffix_len
+    split_out = torch.cat(combined_parts, dim=1)
+
+    cfg = f"seqlens={seqlens}, splits={splits}, H=8, P=64, N=128, R=4, C={chunk_size}"
+    assert_stable_rel(split_out, full_out, label="varlen_initial_state_split_out", cfg=cfg)
+    assert_stable_rel(final_angle, full_angle, label="varlen_initial_state_split_angle", cfg=cfg)
+    assert_stable_rel(final_ssm, full_ssm, label="varlen_initial_state_split_ssm", cfg=cfg)
+    assert_stable_rel(final_k, full_k, label="varlen_initial_state_split_k", cfg=cfg)
+    assert_stable_rel(final_v, full_v, label="varlen_initial_state_split_v", cfg=cfg)
+
+
 def test_mamba_mimo_smoke_forward_backward_varlen(mods: SimpleNamespace) -> None:
     """Smoke test for the varlen forward+backward path through ``mamba3_mimo``.
 


### PR DESCRIPTION
## Summary

`_Mamba3Function.backward` in `mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py` (and the SISO
variant in `mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py`) accesses `ctx.saved_tensors`
**twice**: once inside a `len(ctx.saved_tensors) == 0` emptiness guard, and again for the real
tuple unpack a few lines later.

Each access to `ctx.saved_tensors` re-runs the registered saved-tensor unpack hooks. Under
non-reentrant gradient checkpointing (`torch.utils.checkpoint` with `use_reentrant=False` —
the default in HF Transformers and most modern training stacks, including verl), each saved
tensor may only be unpacked **once**; the second access raises on the very first backward
through a checkpointed region:

```
torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Unpack is being triggered
for a tensor that was already unpacked once. If you are calling ctx.saved_tensors in
backward, make sure to do so only once.
```

This makes any model using the mamba3 MIMO/SISO kernels untrainable with activation
checkpointing enabled. Without checkpointing the double access is harmless, which is why it
went unnoticed.

## Fix

Read `ctx.saved_tensors` once into a local and use that for both the emptiness guard and the
unpack — exactly the pattern the PyTorch error message recommends:

```python
saved = ctx.saved_tensors
if len(saved) == 0:
    raise RuntimeError(...)
...
(Q, K, V, ...) = saved
```

Applied to both `mamba3_mimo.py` and `mamba3_siso_combined.py`. No functional change outside
the checkpointing scenario: same tensors, same order, same guard semantics.

I audited the rest of the repo for the pattern; all other files with multiple
`ctx.saved_tensors` mentions (`ssd_combined.py`, `layer_norm.py`, `selective_scan_interface.py`,
`tensor_parallel.py`) are separate autograd Functions with a single access each, so no other
call sites are affected.

## Testing

- Reproduced on a 7A1B (mamba3 MIMO) model trained with verl (FSDP,
  `enable_gradient_checkpointing=True`, torch 2.11): first `loss.backward()` through a
  checkpointed mamba3 layer raised the `CheckpointError` above with a traceback ending at the
  `ctx.saved_tensors` access in `_Mamba3Function.backward`.
- With this patch, the same run completes the backward cleanly (training proceeds through the
  full forward/backward, subsequently failing only on an unrelated single-GPU optimizer-memory
  limit).
- Backward without checkpointing is unaffected (double unpack was already legal there).