### PR TITLE
mamba3: access ctx.saved_tensors exactly once in backward

### DIFF
--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
@@ -132,7 +132,12 @@ class _Mamba3Function(torch.autograd.Function):
     def backward(ctx, dout, *args) -> tuple:
         """Backward pass: compute gradients using Tilelang backward kernels."""
         
-        if len(ctx.saved_tensors) == 0:
+        # Access ctx.saved_tensors exactly once: each access re-runs the
+        # saved-tensor unpack hooks, and non-reentrant gradient checkpointing
+        # (torch.utils.checkpoint use_reentrant=False) only permits a single
+        # unpack per tensor — a second access raises CheckpointError.
+        saved = ctx.saved_tensors
+        if len(saved) == 0:
             raise RuntimeError(
                 "Backward called but forward ran without gradient tracking. "
                 "Ensure inputs require grad or run under torch.enable_grad()."
@@ -143,7 +148,7 @@ class _Mamba3Function(torch.autograd.Function):
             D, Z,
             MIMO_V, MIMO_Out, MIMO_Z, Out_Norm_Weight,
             cu_seqlens
-            ) = ctx.saved_tensors
+            ) = saved
 
         if cu_seqlens is not None:
             DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton_varlen(ADT, ctx.chunk_size, cu_seqlens=cu_seqlens)

--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
@@ -165,7 +165,12 @@ class _Mamba3Function(torch.autograd.Function):
         except Exception:
             pass
         
-        if len(ctx.saved_tensors) == 0:
+        # Access ctx.saved_tensors exactly once: each access re-runs the
+        # saved-tensor unpack hooks, and non-reentrant gradient checkpointing
+        # only permits a single unpack per tensor — a second access raises
+        # CheckpointError.
+        saved = ctx.saved_tensors
+        if len(saved) == 0:
             raise RuntimeError(
                 "Backward called but forward ran without gradient tracking. "
                 "Ensure inputs require grad or run under torch.enable_grad()."
@@ -176,7 +181,7 @@ class _Mamba3Function(torch.autograd.Function):
         (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, Angles_Cumsum,
         D_save, Z_save, Input_SSM_State_save, Input_K_State_save, Input_V_State_save,
         Out, Out_v, SSM_States, DA_CS, DA_CS_SUM, Q_rot, K_scaled, QK_dot, Scale, Gamma,
-        Final_SSM_State_save, cu_seqlens_save) = ctx.saved_tensors
+        Final_SSM_State_save, cu_seqlens_save) = saved
         
         D = D_save if ctx.has_D else None
         Z = Z_save if ctx.has_Z else None


### PR DESCRIPTION
## Summary

`_Mamba3Function.backward` in `mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py` (and the SISO
variant in `mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py`) accesses `ctx.saved_tensors`
**twice**: once inside a `len(ctx.saved_tensors) == 0` emptiness guard, and again for the real
tuple unpack a few lines later.

Each access to `ctx.saved_tensors` re-runs the registered saved-tensor unpack hooks. Under
non-reentrant gradient checkpointing (`torch.utils.checkpoint` with `use_reentrant=False` —
the default in HF Transformers and most modern training stacks, including verl), each saved
tensor may only be unpacked **once**; the second access raises on the very first backward
through a checkpointed region:

```
torch.utils.checkpoint.CheckpointError: torch.utils.checkpoint: Unpack is being triggered
for a tensor that was already unpacked once. If you are calling ctx.saved_tensors in
backward, make sure to do so only once.
```

This makes any model using the mamba3 MIMO/SISO kernels untrainable with activation
checkpointing enabled. Without checkpointing the double access is harmless, which is why it
went unnoticed.

## Fix

Read `ctx.saved_tensors` once into a local and use that for both the emptiness guard and the
unpack — exactly the pattern the PyTorch error message recommends:

```python
saved = ctx.saved_tensors
if len(saved) == 0:
    raise RuntimeError(...)
...
(Q, K, V, ...) = saved
```

Applied to both `mamba3_mimo.py` and `mamba3_siso_combined.py`. No functional change outside
the checkpointing scenario: same tensors, same order, same guard semantics.

I audited the rest of the repo for the pattern; all other files with multiple
`ctx.saved_tensors` mentions (`ssd_combined.py`, `layer_norm.py`, `selective_scan_interface.py`,
`tensor_parallel.py`) are separate autograd Functions with a single access each, so no other
call sites are affected.

## Testing

- Reproduced on a 7A1B (mamba3 MIMO) model trained with verl (FSDP,
  `enable_gradient_checkpointing=True`, torch 2.11): first `loss.backward()` through a
  checkpointed mamba3 layer raised the `CheckpointError` above with a traceback ending at the
  `ctx.saved_tensors` access in `_Mamba3Function.backward`.
- With this patch, the same run completes the backward cleanly (training proceeds through the
  full forward/backward, subsequently failing only on an unrelated single-GPU optimizer-memory
  limit).
- Backward without checkpointing is unaffected (double unpack was already legal there).