### PR TITLE
fix(mamba3): support GH200 256x256 SISO backward

### DIFF
--- a/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
+++ b/mamba_ssm/ops/tilelang/mamba3/mamba3_mimo.py
@@ -132,7 +132,12 @@ class _Mamba3Function(torch.autograd.Function):
     def backward(ctx, dout, *args) -> tuple:
         """Backward pass: compute gradients using Tilelang backward kernels."""
         
-        if len(ctx.saved_tensors) == 0:
+        # Access ctx.saved_tensors exactly once: each access re-runs the
+        # saved-tensor unpack hooks, and non-reentrant gradient checkpointing
+        # (torch.utils.checkpoint use_reentrant=False) only permits a single
+        # unpack per tensor -- a second access raises CheckpointError.
+        saved = ctx.saved_tensors
+        if len(saved) == 0:
             raise RuntimeError(
                 "Backward called but forward ran without gradient tracking. "
                 "Ensure inputs require grad or run under torch.enable_grad()."
@@ -143,7 +148,7 @@ class _Mamba3Function(torch.autograd.Function):
             D, Z,
             MIMO_V, MIMO_Out, MIMO_Z, Out_Norm_Weight,
             cu_seqlens
-            ) = ctx.saved_tensors
+            ) = saved
 
         if cu_seqlens is not None:
             DA_CS, DA_CS_REV, Segsum = compute_dacs_segsum_triton_varlen(ADT, ctx.chunk_size, cu_seqlens=cu_seqlens)

--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_bwd.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_bwd.py
@@ -366,18 +366,6 @@ def mamba3_siso_bwd_kernel_dqkv(
         strides=[stride_do_seqlen, stride_do_vdim],
         block_shape=[CHUNK_SIZE, HEADDIM_V],
     )
-    dq_desc = tl.make_tensor_descriptor(
-        dQ + dq_offset,
-        shape=[seqlen, headdim_qk],
-        strides=[stride_dq_seqlen, stride_dq_qkdim],
-        block_shape=[CHUNK_SIZE, HEADDIM_QK],
-    )
-    dk_desc = tl.make_tensor_descriptor(
-        dK + dk_offset,
-        shape=[seqlen, headdim_qk],
-        strides=[stride_dk_seqlen, stride_dk_qkdim],
-        block_shape=[CHUNK_SIZE, HEADDIM_QK],
-    )
     dv_desc = tl.make_tensor_descriptor(
         dV + dv_offset,
         shape=[seqlen, headdim_v],
@@ -467,7 +455,13 @@ def mamba3_siso_bwd_kernel_dqkv(
         # Inter-chunk: gradient flowing through accumulated states
         acc_dk += tl.dot(v_block, d_ssm_states_acc.to(v_block.dtype)) * exp_da_cs_rev[:, None]
 
-        dk_desc.store([chunk_start, 0], acc_dk)
+        offs_qk = tl.arange(0, HEADDIM_QK)
+        tl.store(
+            dK + dk_offset + offs_cs[:, None] * stride_dk_seqlen
+            + offs_qk[None, :] * stride_dk_qkdim,
+            acc_dk,
+            mask=seq_mask[:, None] & (offs_qk[None, :] < headdim_qk),
+        )
 
         # ============================================================
         # Compute dQ: Query Gradient
@@ -490,7 +484,12 @@ def mamba3_siso_bwd_kernel_dqkv(
         # Inter-chunk: gradient through states from previous chunks
         acc_dq += tl.dot(do_block, ssm_states_block) * exp_da_cs[:, None]
 
-        dq_desc.store([chunk_start, 0], acc_dq)
+        tl.store(
+            dQ + dq_offset + offs_cs[:, None] * stride_dq_seqlen
+            + offs_qk[None, :] * stride_dq_qkdim,
+            acc_dq,
+            mask=seq_mask[:, None] & (offs_qk[None, :] < headdim_qk),
+        )
 
         # ============================================================
         # Compute dV: Value Gradient
@@ -628,6 +627,9 @@ def compute_dqkv(
     chunk_size: int = 64,
     has_input_state: bool = False,
     Cu_Seqlens: Optional[torch.Tensor] = None,
+    *,
+    _allow_v_tiling: bool = True,
+    _partial_fp32: bool = False,
 ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor]]:
     """
     Compute gradients dQ_mid, dK_mid, dV, dADT, dQK_dot, dD, d_issm_state for Mamba-3 backward pass.
@@ -680,6 +682,68 @@ def compute_dqkv(
     if D is not None:
         assert D.shape == (nheads,)
 
+    # The fused kernel keeps the complete [HEADDIM_V, HEADDIM_QK] state-gradient
+    # recurrence resident in fp32.  At 256x256 that tensor alone is 262,144 B,
+    # above Hopper's 232,448 B per-block limit.  V rows are independent in the
+    # recurrence, while dQ, dK, dAdt, dQK and dD are sums over those rows.  Run
+    # the unchanged kernel serially on <=128-row V/state slices, accumulate the
+    # shared outputs in fp32 in a fixed order, and concatenate the disjoint dV
+    # and input-state gradients.  There are no atomics and every tile retains
+    # the original reverse chunk order.
+    if _allow_v_tiling and headdim_v > 128:
+        dq_acc = dk_acc = dadt_acc = dqk_acc = dd_acc = None
+        dv_tiles = []
+        dissm_tiles = []
+        for v_start in range(0, headdim_v, 128):
+            v_stop = min(v_start + 128, headdim_v)
+            tile = compute_dqkv(
+                q,
+                k,
+                v[..., v_start:v_stop],
+                da_cs,
+                da_cs_sum,
+                qk_dot,
+                SSM_States[:, :, v_start:v_stop, :],
+                do[..., v_start:v_stop],
+                None if d_ossm_state is None else d_ossm_state[:, :, v_start:v_stop, :],
+                None if d_ov_state is None else d_ov_state[:, :, v_start:v_stop],
+                D,
+                chunk_size,
+                has_input_state,
+                Cu_Seqlens,
+                _allow_v_tiling=False,
+                _partial_fp32=True,
+            )
+            tile_dq, tile_dk, tile_dv, tile_dadt, tile_dqk, tile_dd, tile_dissm = tile
+            if dq_acc is None:
+                dq_acc, dk_acc = tile_dq, tile_dk
+                dadt_acc, dqk_acc = tile_dadt, tile_dqk
+                dd_acc = tile_dd
+            else:
+                dq_acc.add_(tile_dq)
+                dk_acc.add_(tile_dk)
+                dadt_acc.add_(tile_dadt)
+                dqk_acc.add_(tile_dqk)
+                if dd_acc is not None:
+                    dd_acc.add_(tile_dd)
+            dv_tiles.append(tile_dv)
+            if tile_dissm is not None:
+                dissm_tiles.append(tile_dissm)
+
+        assert dq_acc is not None and dk_acc is not None
+        assert dadt_acc is not None and dqk_acc is not None
+        dv = torch.cat(dv_tiles, dim=-1)
+        d_issm_state = torch.cat(dissm_tiles, dim=2) if dissm_tiles else None
+        return (
+            dq_acc.to(q.dtype),
+            dk_acc.to(k.dtype),
+            dv,
+            dadt_acc.to(da_cs.dtype),
+            dqk_acc.to(da_cs.dtype),
+            dd_acc,
+            d_issm_state,
+        )
+
     # Ensure all tensors satisfy TMA alignment constraints.
     #
     # TMA 2D requires the global stride (seqlen dimension, in bytes) to be a
@@ -714,11 +778,12 @@ def compute_dqkv(
         d_ov_state = d_ov_state.contiguous()
 
     # Allocate output tensors
-    dq = torch.empty((batch, seqlen, nheads, headdim_qk), dtype=q.dtype, device=q.device)
-    dk = torch.empty((batch, seqlen, nheads, headdim_qk), dtype=k.dtype, device=k.device)
+    shared_gradient_dtype = torch.float32 if _partial_fp32 else q.dtype
+    dq = torch.empty((batch, seqlen, nheads, headdim_qk), dtype=shared_gradient_dtype, device=q.device)
+    dk = torch.empty((batch, seqlen, nheads, headdim_qk), dtype=shared_gradient_dtype, device=k.device)
     dv = torch.empty((batch, seqlen, nheads, headdim_v), dtype=v.dtype, device=v.device)
-    dAdt = torch.empty_like(da_cs)
-    dQK = torch.empty_like(da_cs)
+    dAdt = torch.empty_like(da_cs, dtype=torch.float32 if _partial_fp32 else da_cs.dtype)
+    dQK = torch.empty_like(da_cs, dtype=torch.float32 if _partial_fp32 else da_cs.dtype)
     dD = torch.empty((num_sequences, nheads), dtype=torch.float32, device=q.device) if D is not None else None
     d_issm_state = torch.empty((num_sequences, nheads, headdim_v, headdim_qk), dtype=torch.float32, device=q.device) if has_input_state else None
 
@@ -1629,6 +1694,10 @@ def compute_ddt_dtrap_dinput_states(
     input_k_state: Optional[torch.Tensor] = None,
     input_v_state: Optional[torch.Tensor] = None,
     Cu_Seqlens: Optional[torch.Tensor] = None,
+    *,
+    _allow_v_tiling: bool = True,
+    initial_state_scalar: Optional[torch.Tensor] = None,
+    initial_scale_gradient: Optional[torch.Tensor] = None,
 ) -> Tuple[torch.Tensor, torch.Tensor, Optional[torch.Tensor], Optional[torch.Tensor], Optional[torch.Tensor]]:
     """
     Compute dDT, dTrap from dScale/dGamma, and optionally input state gradients.
@@ -1677,6 +1746,139 @@ def compute_ddt_dtrap_dinput_states(
             f"input_v_state shape mismatch: {input_v_state.shape}"
     else:
         headdim_v, headdim_qk = 64, 128  # Dummy values for block size calculation
+
+    # This kernel also keeps the complete [HEADDIM_V, HEADDIM_QK]
+    # d_ISSM_State matrix resident in fp32.  Split only the independent V rows
+    # when that matrix is wider than Hopper can compile safely.  A state-free
+    # call computes the sequence-wide dDT/dTrap terms once.  Each <=128-row
+    # state call then computes only row-disjoint input-state gradients because
+    # zero dscale/dgamma tensors make Part 1 exactly zero.  For the exact tiled
+    # state path, evaluate the small scalar transform in PyTorch fp32 so it uses
+    # the same accurate sigmoid as the upstream reference; Triton's sigmoid
+    # approximation leaves aggregate varlen dDT just outside rtol=0.1.  Compute
+    # the shared start-token scalar once across the complete state in fp32.
+    # Row-disjoint outputs are concatenated and dInput_K is accumulated serially.
+    if _allow_v_tiling and has_input_state and headdim_v > 128:
+        dscale_fp32 = dscale.float()
+        dgamma_fp32 = dgamma.float()
+        dt_fp32 = dt.float()
+        trap_sigmoid = torch.sigmoid(trap.float())
+        dscale_prev = torch.zeros_like(dscale_fp32)
+        if is_varlen:
+            for seq_idx in range(num_sequences):
+                start = int(Cu_Seqlens[seq_idx].item())
+                stop = int(Cu_Seqlens[seq_idx + 1].item())
+                if stop - start > 1:
+                    dscale_prev[..., start + 1 : stop] = dscale_fp32[..., start : stop - 1]
+        else:
+            dscale_prev[..., 1:] = dscale_fp32[..., :-1]
+        ddt_acc = (
+            (dgamma_fp32 + dscale_fp32) * trap_sigmoid
+            + dscale_prev * (1.0 - trap_sigmoid)
+        )
+        dtrap_acc = (
+            (dgamma_fp32 + dscale_fp32 - dscale_prev)
+            * dt_fp32
+            * trap_sigmoid
+            * (1.0 - trap_sigmoid)
+        )
+        zero_dscale = torch.zeros_like(dscale)
+        zero_dgamma = torch.zeros_like(dgamma)
+        dinput_ssm_tiles = []
+        dinput_v_tiles = []
+        dinput_k_acc = None
+
+        d_scalar = initial_state_scalar
+        if d_scalar is None:
+            d_scalar = torch.sum(
+                d_issm_state.float()
+                * input_v_state.float().unsqueeze(-1)
+                * input_k_state.float().unsqueeze(-2),
+                dim=(-2, -1),
+            )
+        elif d_scalar.shape != (num_sequences, nheads):
+            raise ValueError("initial_state_scalar shape mismatch")
+        if initial_scale_gradient is not None and initial_scale_gradient.shape != (
+            num_sequences,
+            nheads,
+        ):
+            raise ValueError("initial_scale_gradient shape mismatch")
+        if is_varlen:
+            starts = Cu_Seqlens[:-1].to(dtype=torch.long)
+            dt_0 = dt[0, :, starts].transpose(0, 1).float()
+            trap_0 = trap_sigmoid[0, :, starts].transpose(0, 1)
+            ddt_acc[0].index_add_(1, starts, (d_scalar * (1.0 - trap_0)).transpose(0, 1))
+            dtrap_acc[0].index_add_(
+                1,
+                starts,
+                (-d_scalar * dt_0 * trap_0 * (1.0 - trap_0)).transpose(0, 1),
+            )
+            if initial_scale_gradient is not None:
+                ddt_acc[0].index_copy_(
+                    1,
+                    starts,
+                    (
+                        initial_scale_gradient * trap_0
+                        + d_scalar * (1.0 - trap_0)
+                    ).transpose(0, 1),
+                )
+                dtrap_acc[0].index_copy_(
+                    1,
+                    starts,
+                    (
+                        (initial_scale_gradient - d_scalar)
+                        * dt_0
+                        * trap_0
+                        * (1.0 - trap_0)
+                    ).transpose(0, 1),
+                )
+        else:
+            dt_0 = dt[:, :, 0].float()
+            trap_0 = trap_sigmoid[:, :, 0]
+            ddt_acc[:, :, 0].add_(d_scalar * (1.0 - trap_0))
+            dtrap_acc[:, :, 0].add_(-d_scalar * dt_0 * trap_0 * (1.0 - trap_0))
+            if initial_scale_gradient is not None:
+                ddt_acc[:, :, 0].copy_(
+                    initial_scale_gradient * trap_0 + d_scalar * (1.0 - trap_0)
+                )
+                dtrap_acc[:, :, 0].copy_(
+                    (initial_scale_gradient - d_scalar)
+                    * dt_0
+                    * trap_0
+                    * (1.0 - trap_0)
+                )
+
+        for v_start in range(0, headdim_v, 128):
+            v_stop = min(v_start + 128, headdim_v)
+            tile = compute_ddt_dtrap_dinput_states(
+                zero_dscale,
+                zero_dgamma,
+                dt,
+                trap,
+                d_issm_state[:, :, v_start:v_stop, :],
+                input_k_state,
+                input_v_state[:, :, v_start:v_stop],
+                Cu_Seqlens,
+                _allow_v_tiling=False,
+                initial_state_scalar=None,
+                initial_scale_gradient=None,
+            )
+            _, _, tile_dinput_ssm, tile_dinput_k, tile_dinput_v = tile
+            if dinput_k_acc is None:
+                dinput_k_acc = tile_dinput_k
+            else:
+                dinput_k_acc.add_(tile_dinput_k)
+            dinput_ssm_tiles.append(tile_dinput_ssm)
+            dinput_v_tiles.append(tile_dinput_v)
+
+        assert dinput_k_acc is not None
+        return (
+            ddt_acc,
+            dtrap_acc,
+            torch.cat(dinput_ssm_tiles, dim=2),
+            dinput_k_acc,
+            torch.cat(dinput_v_tiles, dim=2),
+        )
 
     # Ensure contiguity
     dscale = dscale.contiguous() if not dscale.is_contiguous() else dscale

--- a/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
+++ b/mamba_ssm/ops/triton/mamba3/mamba3_siso_combined.py
@@ -5,6 +5,7 @@ Copyright (c) 2025, Dao AI Lab, Goombalab
 
 from __future__ import annotations
 
+import math
 from dataclasses import dataclass
 from typing import Optional, Tuple
 
@@ -46,6 +47,146 @@ class Mamba3Output:
     final_ssm_state: Optional[Tensor] = None
     final_k_state: Optional[Tensor] = None
     final_v_state: Optional[Tensor] = None
+
+
+def _initial_state_start_terms_fp32(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    adt: Tensor,
+    dt: Tensor,
+    angles: Tensor,
+    q_bias: Tensor,
+    k_bias: Tensor,
+    grad_out: Tensor,
+    input_angle_state: Tensor,
+    input_k_state: Tensor,
+    input_v_state: Tensor,
+    z: Optional[Tensor],
+    grad_final_ssm_state: Optional[Tensor],
+    cu_seqlens: Optional[Tensor],
+) -> Tuple[Tensor, Tensor]:
+    """Recompute the small sequence-start adjoints in accurate fp32.
+
+    The tiled 256x256 path cannot retain the full state-gradient matrix in one
+    Hopper program. Contracting that already approximate matrix with the two
+    input-state vectors is especially cancellation-sensitive for variable-length
+    sequence starts. Equivalent factored contractions for the initial-state
+    scalar and first scaled key avoid materialising the matrix and follow the
+    public fp32 SISO reference operations exactly. They are used only by the
+    exact tiled path with explicit input states.
+    """
+    is_varlen = cu_seqlens is not None
+    batch, seqlen, nheads_qk, headdim_qk = q.shape
+    num_sequences = int(cu_seqlens.numel() - 1) if is_varlen else batch
+    nheads = input_k_state.shape[1]
+    repeats = nheads // nheads_qk
+    if nheads_qk * repeats != nheads:
+        raise ValueError("input-state heads must be an integer multiple of Q heads")
+
+    state_scalars = []
+    scale_gradients = []
+    for seq_idx in range(num_sequences):
+        if is_varlen:
+            start = int(cu_seqlens[seq_idx].item())
+            stop = int(cu_seqlens[seq_idx + 1].item())
+            batch_idx = 0
+        else:
+            start, stop, batch_idx = 0, seqlen, seq_idx
+
+        q_seq = q[batch_idx, start:stop].float().repeat_interleave(repeats, dim=1)
+        k_zero = k[batch_idx, start].float().repeat_interleave(repeats, dim=0)
+        q_seq = q_seq + q_bias.float().unsqueeze(0)
+        k_zero = k_zero + k_bias.float()
+        increments = (
+            torch.tanh(angles[batch_idx, start:stop].float())
+            * math.pi
+            * dt[batch_idx, :, start:stop].transpose(0, 1).unsqueeze(-1).float()
+        )
+        angle_cumsum = torch.cumsum(increments, dim=0)
+        angle_cumsum = angle_cumsum + input_angle_state[seq_idx].float().unsqueeze(0)
+        angle_cumsum = torch.remainder(angle_cumsum, 2 * math.pi)
+        pair_count = headdim_qk // 2
+        if angle_cumsum.shape[-1] < pair_count:
+            padding = pair_count - angle_cumsum.shape[-1]
+            cosine = torch.cat(
+                (
+                    torch.cos(angle_cumsum),
+                    angle_cumsum.new_ones(*angle_cumsum.shape[:-1], padding),
+                ),
+                dim=-1,
+            )
+            sine = torch.cat(
+                (
+                    torch.sin(angle_cumsum),
+                    angle_cumsum.new_zeros(*angle_cumsum.shape[:-1], padding),
+                ),
+                dim=-1,
+            )
+        else:
+            cosine, sine = torch.cos(angle_cumsum), torch.sin(angle_cumsum)
+        q_pairs = q_seq.reshape(*q_seq.shape[:-1], pair_count, 2)
+        q_first, q_second = q_pairs[..., 0], q_pairs[..., 1]
+        q_rot = torch.stack(
+            (q_first * cosine - q_second * sine, q_first * sine + q_second * cosine),
+            dim=-1,
+        ).reshape_as(q_seq)
+        k_pairs = k_zero.reshape(*k_zero.shape[:-1], pair_count, 2)
+        k_first, k_second = k_pairs[..., 0], k_pairs[..., 1]
+        k_rot = torch.stack(
+            (
+                k_first * cosine[0] - k_second * sine[0],
+                k_first * sine[0] + k_second * cosine[0],
+            ),
+            dim=-1,
+        ).reshape_as(k_zero)
+
+        do_seq = grad_out[batch_idx, start:stop].float()
+        if z is not None:
+            z_seq = z[batch_idx, start:stop].float()
+            do_seq = do_seq * z_seq * torch.sigmoid(z_seq)
+        input_k = input_k_state[seq_idx].float()
+        input_v = input_v_state[seq_idx].float()
+        decay = torch.exp(
+            torch.cumsum(adt[batch_idx, :, start:stop].float(), dim=-1)
+        ).transpose(0, 1)
+        do_dot_v = torch.sum(do_seq * input_v.unsqueeze(0), dim=-1)
+        q_dot_k = torch.sum(q_rot * input_k.unsqueeze(0), dim=-1)
+        state_scalar = torch.sum(do_dot_v * q_dot_k * decay, dim=0)
+        v_zero = v[batch_idx, start].float()
+        scale_decay = torch.exp(
+            torch.cumsum(adt[batch_idx, :, start:stop].float(), dim=-1)
+            - adt[batch_idx, :, start : start + 1].float()
+        ).transpose(0, 1)
+        scale_gradient = torch.sum(
+            torch.sum(do_seq * v_zero.unsqueeze(0), dim=-1)
+            * torch.sum(q_rot * k_rot.unsqueeze(0), dim=-1)
+            * scale_decay,
+            dim=0,
+        )
+        if grad_final_ssm_state is not None:
+            state_final_scalar = torch.sum(
+                grad_final_ssm_state[seq_idx].float()
+                * input_v.unsqueeze(-1)
+                * input_k.unsqueeze(-2),
+                dim=(-2, -1),
+            )
+            state_scalar = state_scalar + state_final_scalar * torch.exp(
+                torch.sum(adt[batch_idx, :, start:stop].float(), dim=-1)
+            )
+            scale_final_scalar = torch.sum(
+                grad_final_ssm_state[seq_idx].float()
+                * v_zero.unsqueeze(-1)
+                * k_rot.unsqueeze(-2),
+                dim=(-2, -1),
+            )
+            scale_gradient = scale_gradient + scale_final_scalar * torch.exp(
+                torch.sum(adt[batch_idx, :, start + 1 : stop].float(), dim=-1)
+            )
+        state_scalars.append(state_scalar)
+        scale_gradients.append(scale_gradient)
+    return torch.stack(state_scalars), torch.stack(scale_gradients)
+
 
 class _Mamba3Function(torch.autograd.Function):
     """Custom autograd function for Mamba-3 with Triton kernels."""
@@ -127,12 +268,13 @@ class _Mamba3Function(torch.autograd.Function):
             Input_SSM_State_save = Input_SSM_State if Input_SSM_State is not None else torch.empty((), device=Q.device)
             Input_K_State_save = Input_K_State if Input_K_State is not None else torch.empty((), device=Q.device)
             Input_V_State_save = Input_V_State if Input_V_State is not None else torch.empty((), device=Q.device)
+            Input_Angle_State_save = Input_Angle_State if Input_Angle_State is not None else torch.empty((), device=Q.device)
             Final_SSM_State_save = Final_SSM_State if Final_SSM_State is not None else torch.empty((), device=Q.device)
             cu_seqlens_save = cu_seqlens if cu_seqlens is not None else torch.empty((), device=Q.device, dtype=torch.int32)
             
             ctx.save_for_backward(
                 Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, Angles_Cumsum,
-                D_save, Z_save, Input_SSM_State_save, Input_K_State_save, Input_V_State_save,
+                D_save, Z_save, Input_Angle_State_save, Input_SSM_State_save, Input_K_State_save, Input_V_State_save,
                 Out, Out_v, SSM_States, DA_CS, DA_CS_SUM, Q_rot, K_scaled, QK_dot, Scale, Gamma,
                 Final_SSM_State_save, cu_seqlens_save
             )
@@ -165,7 +307,12 @@ class _Mamba3Function(torch.autograd.Function):
         except Exception:
             pass
         
-        if len(ctx.saved_tensors) == 0:
+        # Access ctx.saved_tensors exactly once: each access re-runs the
+        # saved-tensor unpack hooks, and non-reentrant gradient checkpointing
+        # only permits a single unpack per tensor -- a second access raises
+        # CheckpointError.
+        saved = ctx.saved_tensors
+        if len(saved) == 0:
             raise RuntimeError(
                 "Backward called but forward ran without gradient tracking. "
                 "Ensure inputs require grad or run under torch.enable_grad()."
@@ -174,15 +321,16 @@ class _Mamba3Function(torch.autograd.Function):
             raise RuntimeError("No gradients provided for backward pass.")
 
         (Q, K, V, ADT, DT, Trap, Q_bias, K_bias, Angles, Angles_Cumsum,
-        D_save, Z_save, Input_SSM_State_save, Input_K_State_save, Input_V_State_save,
+        D_save, Z_save, Input_Angle_State_save, Input_SSM_State_save, Input_K_State_save, Input_V_State_save,
         Out, Out_v, SSM_States, DA_CS, DA_CS_SUM, Q_rot, K_scaled, QK_dot, Scale, Gamma,
-        Final_SSM_State_save, cu_seqlens_save) = ctx.saved_tensors
+        Final_SSM_State_save, cu_seqlens_save) = saved
         
         D = D_save if ctx.has_D else None
         Z = Z_save if ctx.has_Z else None
         Input_SSM_State = Input_SSM_State_save if ctx.has_input_state else None
         Input_K_State = Input_K_State_save if ctx.has_input_state else None
         Input_V_State = Input_V_State_save if ctx.has_input_state else None
+        Input_Angle_State = Input_Angle_State_save if ctx.has_input_state else None
         cu_seqlens = cu_seqlens_save if ctx.has_varlen else None
         
         if grad_out is None:
@@ -233,6 +381,14 @@ class _Mamba3Function(torch.autograd.Function):
         )
         
         # Step 4: Compute dDT, dTrap, and input state gradients
+        initial_state_scalar = None
+        initial_scale_gradient = None
+        if ctx.has_input_state and V.shape[-1] > 128:
+            initial_state_scalar, initial_scale_gradient = _initial_state_start_terms_fp32(
+                Q, K, V, ADT, DT, Angles, Q_bias, K_bias, grad_out,
+                Input_Angle_State, Input_K_State, Input_V_State, Z,
+                grad_final_ssm_state, cu_seqlens,
+            )
         dDT, dTrap, dInput_SSM_State_final, dInput_K_State, dInput_V_State = compute_ddt_dtrap_dinput_states(
             dscale=dScale,
             dgamma=dGamma,
@@ -242,6 +398,8 @@ class _Mamba3Function(torch.autograd.Function):
             input_k_state=Input_K_State,
             input_v_state=Input_V_State,
             Cu_Seqlens=cu_seqlens,
+            initial_state_scalar=initial_state_scalar,
+            initial_scale_gradient=initial_scale_gradient,
         )
         
         # Step 5: Compute gradients through angle_dt cumsum


### PR DESCRIPTION
Tile the capacity-bound SISO backward paths over independent value/state rows, accumulate shared gradients in fixed-order fp32, and preserve checkpoint compatibility by reading saved tensors once.