### PR TITLE
fix: only create CUDA timing events when enable_timing is set

### DIFF
--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -211,10 +211,10 @@ def decode(
             return True
         return False
 
-    start = torch.cuda.Event(enable_timing=enable_timing)
-    end = torch.cuda.Event(enable_timing=enable_timing)
-
+    start = end = None
     if enable_timing:
+        start = torch.cuda.Event(enable_timing=True)
+        end = torch.cuda.Event(enable_timing=True)
         start.record()
     scores, sequences = [], [input_ids]
     sequences_cat = input_ids


### PR DESCRIPTION
## Summary
- Decode path always constructed CUDA Events even when `enable_timing` was false.
- Create start/end events only when timing is requested.

## Test plan
- [ ] Decode with enable_timing=False (no event alloc)
- [ ] Decode with enable_timing=True still reports elapsed time
