### PR TITLE
fix(triton): handle None dt_bias/D in selective_state_update

### DIFF
--- a/mamba_ssm/ops/triton/selective_state_update.py
+++ b/mamba_ssm/ops/triton/selective_state_update.py
@@ -196,7 +196,10 @@ def selective_state_update(state, x, dt, A, B, C, D=None, z=None, dt_bias=None, 
                                      ((8, 4) if dstate <= 64 else
                                       ((4, 4) if dstate <= 128 else
                                        ((4, 8))))))
-    tie_hdim = A.stride(-1) == 0 and A.stride(-2) == 0 and dt.stride(-1) == 0 and dt_bias.stride(-1) == 0
+    tie_hdim = (
+        A.stride(-1) == 0 and A.stride(-2) == 0 and dt.stride(-1) == 0
+        and dt_bias is not None and dt_bias.stride(-1) == 0
+    )
     with torch.cuda.device(x.device.index):
         _selective_scan_update_kernel[grid](
             state, x, dt, dt_bias, A, B, C, D, z, out, state_batch_indices,
@@ -204,11 +207,11 @@ def selective_state_update(state, x, dt, A, B, C, D=None, z=None, dt_bias=None, 
             state.stride(0), state.stride(1), state.stride(2), state.stride(3),
             x.stride(0), x.stride(1), x.stride(2),
             dt.stride(0), dt.stride(1), dt.stride(2),
-            *(dt_bias.stride(0), dt_bias.stride(1)) if dt_bias is not None else 0,
+            *(dt_bias.stride(0), dt_bias.stride(1)) if dt_bias is not None else (0, 0),
             A.stride(0), A.stride(1), A.stride(2),
             B.stride(0), B.stride(1), B.stride(2),
             C.stride(0), C.stride(1), C.stride(2),
-            *(D.stride(0), D.stride(1)) if D is not None else 0,
+            *(D.stride(0), D.stride(1)) if D is not None else (0, 0),
             z_strides[0], z_strides[1], z_strides[2],
             out.stride(0), out.stride(1), out.stride(2),
             dt_softplus,


### PR DESCRIPTION
## Summary
- Kernel prep unconditionally read `.stride()` on `dt_bias`/`D`, crashing when those tensors were optional `None`.
- Guard strides and pass zeros when the tensors are absent.

## Test plan
- [ ] selective_state_update with dt_bias=None and D=None
- [ ] Path with both tensors set still matches prior numerics
