### PR TITLE
fix(triton): pass False not None for delta_softplus after manual softplus

### DIFF
--- a/mamba_ssm/ops/triton/ssd_combined.py
+++ b/mamba_ssm/ops/triton/ssd_combined.py
@@ -771,7 +771,7 @@ def ssd_selective_scan(x, dt, A, B, C, D=None, z=None, dt_bias=None, dt_softplus
             dt = F.softplus(dt)
         dt = dt.clamp(min=dt_limit[0], max=dt_limit[1]).to(x.dtype)
         dt_bias = None
-        dt_softplus = None
+        dt_softplus = False
     out = selective_scan_fn(x, dt, A, B, C, D=D, z=z, delta_bias=dt_bias, delta_softplus=dt_softplus)
     return rearrange(out, "b (h p) l -> b l h p", p=headdim)
 


### PR DESCRIPTION
## Summary
- After applying softplus in Python, the kernel was still called with `dt_softplus=None`, which is inconsistent with the bool flag the kernel expects.
- Pass `False` once softplus has already been applied.

## Test plan
- [ ] SSD path that pre-applies softplus
- [ ] Path that still requests kernel softplus
