### PR TITLE
fix: accept (B, 1, D) in Mamba3.step like Mamba2

### DIFF
--- a/mamba_ssm/modules/mamba3.py
+++ b/mamba_ssm/modules/mamba3.py
@@ -320,20 +320,26 @@ class Mamba3(nn.Module):
         will be made available in the future.
 
         Args:
-            u: (batch, d_model)
+            u: (batch, d_model) or (batch, 1, d_model) — same decode contract as Mamba2.step
             angle_state: (batch, nheads, num_rope_angles)
             ssm_state: (batch, nheads, headdim, d_state)
             k_state: (batch, R, nheads, d_state), where R = mimo_rank (R=1 if not MIMO)
             v_state: (batch, nheads, headdim)
             **kwargs: ignored
         Returns:
-            out: (batch, d_model)
+            out: same rank as u — (batch, d_model) or (batch, 1, d_model)
             nxt_angle_state: (batch, nheads, num_rope_angles)
             state_out: (batch, nheads, headdim, d_state)
             nxt_k_state: (batch, R, nheads, d_state), where R = mimo_rank (R=1 if not MIMO)
             nxt_v_state: (batch, nheads, headdim)
         """
         assert mamba3_step_fn is not None, "Cute Mamba-3 step function is not available. Please ensure you installed the necessary dependencies, such as nvidia-cutlass-dsl and quack-kernels."
+
+        # Match Mamba2.step: generation / forward decode pass (B, 1, D).
+        keep_seqlen_dim = u.dim() == 3
+        if keep_seqlen_dim:
+            assert u.shape[1] == 1, "Only support decoding with 1 token at a time for now"
+            u = u.squeeze(1)
 
         # in_proj
         zxBCdt = self.in_proj(u)
@@ -437,6 +443,8 @@ class Mamba3(nn.Module):
         k_state.copy_(nxt_k_state)
         v_state.copy_(nxt_v_state)
 
+        if keep_seqlen_dim:
+            out = out.unsqueeze(1)
         return out, nxt_angle_state, ssm_state, nxt_k_state, nxt_v_state
     
     def allocate_inference_cache(self, batch_size, max_seqlen, device=None, dtype=None, inplace_state=None, **kwargs):

--- a/tests/modules/test_mamba3_step_shape.py
+++ b/tests/modules/test_mamba3_step_shape.py
@@ -1,0 +1,63 @@
+"""Shape contract for Mamba3.step — matches Mamba2 decode (B, 1, D)."""
+import types
+
+import pytest
+import torch
+
+from mamba_ssm.modules import mamba3 as mamba3_mod
+
+
+class _DummyNorm:
+    def __init__(self):
+        self.weight = torch.ones(1)
+        self.eps = 1e-5
+
+    def __call__(self, y, z=None):
+        return y
+
+
+def _stub_step_fn(*args, **kwargs):
+    # Fill `out` if provided; otherwise no-op for the fused path.
+    out = kwargs.get("out")
+    if out is not None:
+        out.zero_()
+    return None
+
+
+@pytest.mark.parametrize("keep_seq", [False, True])
+def test_mamba3_step_accepts_batched_token(monkeypatch, keep_seq):
+    monkeypatch.setattr(mamba3_mod, "mamba3_step_fn", _stub_step_fn)
+    monkeypatch.setattr(
+        mamba3_mod,
+        "apply_rotary_qk_inference_fwd",
+        lambda q, k, angle_state, angle_proj, dt, bias_q, bias_k, **kw: (
+            q,
+            k,
+            angle_state.clone(),
+        ),
+    )
+
+    batch, d_model = 2, 64
+    m = mamba3_mod.Mamba3(
+        d_model=d_model,
+        d_state=16,
+        headdim=16,
+        expand=2,
+        is_mimo=False,
+        is_outproj_norm=False,
+        device="cpu",
+        dtype=torch.float32,
+    )
+    # Avoid needing the real CuteDSL path beyond the stub.
+    m.norm = _DummyNorm()
+
+    angle, ssm, k_state, v_state = m.allocate_inference_cache(
+        batch_size=batch, max_seqlen=8, device="cpu", dtype=torch.float32
+    )
+    if keep_seq:
+        u = torch.randn(batch, 1, d_model)
+    else:
+        u = torch.randn(batch, d_model)
+
+    out, *_ = m.step(u, angle, ssm, k_state, v_state)
+    assert out.shape == u.shape


### PR DESCRIPTION
## Summary
- `Mamba3.forward()` routes `inference_params.seqlen_offset > 0` into `step()` with `u` still shaped `(B, L, D)`.
- `step()` only handled `(B, D)`, so decode / `.generate()` raised `EinopsError` in `_preprocess` (issues #1014 / #1022).
- Mirror `Mamba2.step`: accept `(B, 1, D)`, squeeze for the kernel path, unsqueeze the returned token so callers keep their input rank.

## Test plan
- [x] Added `tests/modules/test_mamba3_step_shape.py` (stubs CuteDSL kernel; checks `(B, D)` and `(B, 1, D)` round-trip shapes)
- [ ] On CUDA with CuteDSL deps: `model.generate(...)` for an official Mamba-3 checkpoint past the first token