### PR TITLE
fix: honor list/tensor eos_token_id in decode stop

### DIFF
--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -205,8 +205,20 @@ def decode(
     def should_stop(current_token, inference_params):
         if inference_params.seqlen_offset == 0:
             return False
-        if eos_token_id is not None and (current_token == eos_token_id).all():
-            return True
+        if eos_token_id is not None:
+            # Support int, list/tuple, or 1-D tensor of EOS ids (HF-style).
+            if isinstance(eos_token_id, (list, tuple)):
+                eos_ids = torch.as_tensor(
+                    eos_token_id, device=current_token.device, dtype=current_token.dtype
+                )
+            elif torch.is_tensor(eos_token_id):
+                eos_ids = eos_token_id.to(device=current_token.device, dtype=current_token.dtype)
+            else:
+                eos_ids = torch.as_tensor(
+                    [eos_token_id], device=current_token.device, dtype=current_token.dtype
+                )
+            if torch.isin(current_token, eos_ids).all():
+                return True
         if inference_params.seqlen_offset >= max_length - 1:
             return True
         return False

--- a/tests/utils/test_decode_eos.py
+++ b/tests/utils/test_decode_eos.py
@@ -1,0 +1,48 @@
+"""EOS stop conditions for decode() without requiring a real Mamba model."""
+from types import SimpleNamespace
+
+import torch
+
+from mamba_ssm.utils.generation import decode
+
+
+class _TinyLM(torch.nn.Module):
+    """Deterministic stand-in: always emits the next id from a fixed sequence."""
+
+    def __init__(self, next_ids):
+        super().__init__()
+        self.next_ids = list(next_ids)
+        self._i = 0
+
+    def forward(self, input_ids, position_ids=None, inference_params=None, num_last_tokens=1):
+        vocab = 32
+        logits = torch.full((input_ids.shape[0], vocab), -1e9)
+        tok = self.next_ids[min(self._i, len(self.next_ids) - 1)]
+        logits[:, tok] = 0.0
+        self._i += 1
+        return SimpleNamespace(logits=logits.unsqueeze(1))
+
+
+def test_decode_stops_on_list_eos():
+    model = _TinyLM([5, 7, 9, 11])
+    out = decode(
+        torch.tensor([[1, 2]]),
+        model,
+        max_length=10,
+        top_k=1,
+        eos_token_id=[7, 99],
+    )
+    # prompt [1,2] + sampled 5 + sampled 7 (EOS) -> stop before 9
+    assert out.sequences.tolist() == [[1, 2, 5, 7]]
+
+
+def test_decode_stops_on_int_eos():
+    model = _TinyLM([3, 4, 5])
+    out = decode(
+        torch.tensor([[0]]),
+        model,
+        max_length=10,
+        top_k=1,
+        eos_token_id=4,
+    )
+    assert out.sequences.tolist() == [[0, 3, 4]]

--- a/tests/utils/test_decode_eos.py
+++ b/tests/utils/test_decode_eos.py
@@ -1,9 +1,11 @@
-"""EOS stop conditions for decode() without requiring a real Mamba model."""
+"""EOS stop conditions for decode() without requiring a GPU."""
 from types import SimpleNamespace
+from unittest.mock import MagicMock
 
+import pytest
 import torch
 
-from mamba_ssm.utils.generation import decode
+from mamba_ssm.utils import generation as gen
 
 
 class _TinyLM(torch.nn.Module):
@@ -23,22 +25,28 @@ class _TinyLM(torch.nn.Module):
         return SimpleNamespace(logits=logits.unsqueeze(1))
 
 
+@pytest.fixture(autouse=True)
+def _stub_cuda_events(monkeypatch):
+    """decode() always constructs cuda.Event today; stub so CPU hosts can test stop logic."""
+    monkeypatch.setattr(torch.cuda, "Event", lambda *a, **k: MagicMock())
+    monkeypatch.setattr(torch.cuda, "synchronize", lambda *a, **k: None)
+
+
 def test_decode_stops_on_list_eos():
     model = _TinyLM([5, 7, 9, 11])
-    out = decode(
+    out = gen.decode(
         torch.tensor([[1, 2]]),
         model,
         max_length=10,
         top_k=1,
         eos_token_id=[7, 99],
     )
-    # prompt [1,2] + sampled 5 + sampled 7 (EOS) -> stop before 9
     assert out.sequences.tolist() == [[1, 2, 5, 7]]
 
 
 def test_decode_stops_on_int_eos():
     model = _TinyLM([3, 4, 5])
-    out = decode(
+    out = gen.decode(
         torch.tensor([[0]]),
         model,
         max_length=10,


### PR DESCRIPTION
## Summary
- `decode()` stopped only when `(current_token == eos_token_id).all()`, which breaks for HF-style multi-EOS lists/tensors (broadcast / type errors, or wrong stop).
- Normalize to a 1-D id tensor and use `torch.isin` so any configured EOS id ends the batch.

## Test plan
- [x] `tests/utils/test_decode_eos.py` (CPU; stubs `torch.cuda.Event`) for int and list EOS ids