### PR TITLE
fix: treat non-positive sample temperature as greedy

### DIFF
--- a/mamba_ssm/utils/generation.py
+++ b/mamba_ssm/utils/generation.py
@@ -85,6 +85,9 @@ def sample(logits, top_k=1, top_p=0.0, min_p=0.0, temperature=1.0):
     Arguments:
         logits: Tensor of shape (batch_size, vocab_size)
     """
+    # Non-positive temperature is undefined for softmax sampling; treat as greedy.
+    if temperature is not None and temperature <= 0:
+        return logits.argmax(dim=-1)
     if top_k == 1:  # Short-circuit for greedy decoding
         return logits.argmax(dim=-1)
     else:

--- a/tests/utils/test_sample_temperature.py
+++ b/tests/utils/test_sample_temperature.py
@@ -1,0 +1,9 @@
+import torch
+
+from mamba_ssm.utils.generation import sample
+
+
+def test_nonpositive_temperature_is_greedy():
+    logits = torch.tensor([[0.0, 3.0, 1.0], [2.0, 0.0, 0.5]])
+    assert sample(logits, top_k=0, temperature=0.0).tolist() == [1, 0]
+    assert sample(logits, top_k=5, temperature=-1.0).tolist() == [1, 0]


### PR DESCRIPTION
## Summary
- `sample()` divided logits by `temperature` whenever it differed from 1.0, including `0` / negative values, which produces Inf/NaN and unstable multinomial draws.
- Treat non-positive temperature as greedy `argmax`, matching common HF-style behavior.

## Test plan
- [x] `tests/utils/test_sample_temperature.py` for temperature `0` and `-1`